### PR TITLE
StringUtils class not handling byte arrays correctly

### DIFF
--- a/src-test/org/etools/j1939_84/utils/StringUtilsTest.java
+++ b/src-test/org/etools/j1939_84/utils/StringUtilsTest.java
@@ -5,6 +5,8 @@
 package org.etools.j1939_84.utils;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -35,6 +37,36 @@ public class StringUtilsTest {
         input = "\u0000\u0000\u0000";
         actual = StringUtils.stripLeadingAndTrailingNulls(input);
         assertEquals("", actual);
+
+        input = null;
+        actual = StringUtils.stripLeadingAndTrailingNulls(input);
+        assertEquals("", actual);
+    }
+
+    @Test
+    public void testContainsNonPrintableAsciiCharacter() {
+        String input = "\u0000Fmes\u0000Csage\u0000A\u0000\u0000";
+        assertTrue(StringUtils.containsNonPrintableAsciiCharacter(input));
+
+        String inputWithoutNonPrintable = "message";
+        assertFalse(StringUtils.containsNonPrintableAsciiCharacter(inputWithoutNonPrintable));
+
+        byte[] inputBytes = { (byte) 0x00, (byte) 0x01 };
+        assertTrue(StringUtils.containsNonPrintableAsciiCharacter(inputBytes));
+
+    }
+
+    @Test
+    public void testContainsOnlyNumericAsciiCharacters() {
+
+        String input = "\u0000mes\u0000sage\u0000A\u0000\u0000";
+        assertFalse(StringUtils.containsOnlyNumericAsciiCharacters(input));
+
+        String inputOnlyNumbers = "012938457583957";
+        assertTrue(StringUtils.containsOnlyNumericAsciiCharacters(inputOnlyNumbers));
+
+        String inputStringAndNumbers = "01V#3845S58A957";
+        assertFalse(StringUtils.containsOnlyNumericAsciiCharacters(inputStringAndNumbers));
 
     }
 }

--- a/src-test/org/etools/j1939_84/utils/StringUtilsTest.java
+++ b/src-test/org/etools/j1939_84/utils/StringUtilsTest.java
@@ -54,6 +54,50 @@ public class StringUtilsTest {
         byte[] inputBytes = { (byte) 0x00, (byte) 0x01 };
         assertTrue(StringUtils.containsNonPrintableAsciiCharacter(inputBytes));
 
+        // Legit Hex values between 0x20 and 0x7F
+        byte[] inputBytesWithoutNonPrintableChar = { 0x5D,
+                0x3F,
+                0x6F,
+                0x60,
+                0x50,
+                0x42,
+                0x54,
+                0x75,
+                0x4D,
+                0x50,
+                0x52,
+                0x5F,
+                0x4B,
+                0x6A,
+                0x67,
+                0x69,
+                0x59,
+                0x76,
+                0x45,
+                0x7A };
+        assertFalse(StringUtils.containsNonPrintableAsciiCharacter(inputBytesWithoutNonPrintableChar));
+
+        byte[] inputBytesWithNonPrintableChar = { 0x5D,
+                0x3F,
+                0x6F,
+                0x60,
+                0x50,
+                0x42,
+                0x54,
+                0x75,
+                0x4D,
+                0x50,
+                0x52,
+                0x5F,
+                0x4B,
+                0x6A,
+                0x1B,  // unprintable character
+                0x69,
+                0x59,
+                0x76,
+                0x45,
+                0x7A };
+        assertTrue(StringUtils.containsNonPrintableAsciiCharacter(inputBytesWithNonPrintableChar));
     }
 
     @Test
@@ -67,6 +111,5 @@ public class StringUtilsTest {
 
         String inputStringAndNumbers = "01V#3845S58A957";
         assertFalse(StringUtils.containsOnlyNumericAsciiCharacters(inputStringAndNumbers));
-
     }
 }

--- a/src/org/etools/j1939_84/utils/StringUtils.java
+++ b/src/org/etools/j1939_84/utils/StringUtils.java
@@ -29,14 +29,12 @@ public class StringUtils {
      * @param string String to be checked for non-printable ASCII characters
      */
     public static boolean containsNonPrintableAsciiCharacter(byte[] bytes) {
-        boolean containsNonPrintableChar = false;
-
         for (int i = 0; i < bytes.length; i++) {
             if ((bytes[i] > 32) || (bytes[i] < 127)) {
-                containsNonPrintableChar = true;
+                return true;
             }
         }
-        return containsNonPrintableChar;
+        return false;
     }
 
     /*

--- a/src/org/etools/j1939_84/utils/StringUtils.java
+++ b/src/org/etools/j1939_84/utils/StringUtils.java
@@ -26,6 +26,20 @@ public class StringUtils {
     }
 
     /*
+     * @param string String to be checked for non-printable ASCII characters
+     */
+    public static boolean containsNonPrintableAsciiCharacter(byte[] bytes) {
+        boolean containsNonPrintableChar = false;
+
+        for (int i = 0; i < bytes.length; i++) {
+            if ((bytes[i] > 32) || (bytes[i] < 127)) {
+                containsNonPrintableChar = true;
+            }
+        }
+        return containsNonPrintableChar;
+    }
+
+    /*
      * @param string String to be checked for non-numeric ASCII characters
      */
     public static boolean containsOnlyNumericAsciiCharacters(String string) {

--- a/src/org/etools/j1939_84/utils/StringUtils.java
+++ b/src/org/etools/j1939_84/utils/StringUtils.java
@@ -30,7 +30,7 @@ public class StringUtils {
      */
     public static boolean containsNonPrintableAsciiCharacter(byte[] bytes) {
         for (int i = 0; i < bytes.length; i++) {
-            if ((bytes[i] > 32) || (bytes[i] < 127)) {
+            if ((Byte.toUnsignedInt(bytes[i]) < 32) || (Byte.toUnsignedInt(bytes[i]) > 127)) {
                 return true;
             }
         }


### PR DESCRIPTION
#8 - Update the StringUtils() to take a byte array for checking when verifying the presence of a non-numeric number.  Unit tests added and old ones updated as well.