### PR TITLE
Update DM19 to correctly parse and preserve data

### DIFF
--- a/src-test/org/etools/j1939_84/bus/j1939/packets/DM19CalibrationInformationPacketTest.java
+++ b/src-test/org/etools/j1939_84/bus/j1939/packets/DM19CalibrationInformationPacketTest.java
@@ -53,13 +53,13 @@ public class DM19CalibrationInformationPacketTest {
         assertNotNull(calInfos);
         assertEquals(1, calInfos.size());
         CalibrationInformation calInfo = calInfos.get(0);
-        assertEquals("ANT5ASR1      ", calInfo.getCalibrationIdentification());
-        assertEquals("0xB", calInfo.getCalibrationVerificationNumber());
+        assertEquals("ANT5ASR1        ", calInfo.getCalibrationIdentification());
+        assertEquals("0xBDFEBA51", calInfo.getCalibrationVerificationNumber());
         assertArrayEquals(new byte[] { 65, 78, 84, 53, 65, 83, 82, 49, 32, 32, 0, 0, 0, 0, 0, 0 },
                           calInfo.getRawCalId());
         assertArrayEquals(new byte[] { 81, -70, -2 }, calInfo.getRawCvn());
 
-        String expected = "DM19 from Engine #1 (0): CAL ID of ANT5ASR1 and CVN of 0xB";
+        String expected = "DM19 from Engine #1 (0): CAL ID of ANT5ASR1 and CVN of 0xBDFEBA51";
         assertEquals(expected, instance.toString());
     }
 
@@ -92,14 +92,75 @@ public class DM19CalibrationInformationPacketTest {
         assertNotNull(calInfos);
         assertEquals(1, calInfos.size());
         CalibrationInformation calInfo = calInfos.get(0);
-        assertEquals("01234567890123", calInfo.getCalibrationIdentification());
-        assertEquals("0xB", calInfo.getCalibrationVerificationNumber());
+        assertEquals("0123456789012345", calInfo.getCalibrationIdentification());
+        assertEquals("0xBDFEBA51", calInfo.getCalibrationVerificationNumber());
         assertArrayEquals(new byte[] { 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53 },
                           calInfo.getRawCalId());
         assertArrayEquals(new byte[] { 81, -70, -2 }, calInfo.getRawCvn());
 
-        String expected = "DM19 from Engine #1 (0): CAL ID of 01234567890123 and CVN of 0xB";
+        String expected = "DM19 from Engine #1 (0): CAL ID of 0123456789012345 and CVN of 0xBDFEBA51";
         assertEquals(expected, instance.toString());
+    }
+
+    @Test
+    public void testCalIdLengthLessThanFifteen() {
+        CalibrationInformation calInfo = new CalibrationInformation("LessThan15Char", "1234");
+        DM19CalibrationInformationPacket instance = DM19CalibrationInformationPacket.create(0, 0, calInfo);
+        assertNotNull(instance.getCalibrationInformation());
+        System.out.println("Hey " + instance.getCalibrationInformation());
+        CalibrationInformation instanceCalInfo = instance.getCalibrationInformation().get(0);
+        assertEquals("LessThan15Char  ", instanceCalInfo.getCalibrationIdentification());
+        assertEquals("0x34333231", instanceCalInfo.getCalibrationVerificationNumber());
+        assertArrayEquals(new byte[] { 0x4C, 0x65, 0x73, 0x73, 0x54, 0x68, 0x61, 0x6E, 0x31, 0x35, 0x43, 0x68, 0x61,
+                0x72, 0x00, 0x00 },
+                          calInfo.getRawCalId());
+        assertArrayEquals(new byte[] { 49, 50, 51, 52 }, calInfo.getRawCvn());
+    }
+
+    @Test
+    public void testCvnLengthLessThanFour() {
+        CalibrationInformation calInfo = new CalibrationInformation("Equals15Characts", "123");
+        DM19CalibrationInformationPacket instance = DM19CalibrationInformationPacket.create(0, 0, calInfo);
+        CalibrationInformation instanceCalInfo = instance.getCalibrationInformation().get(0);
+        assertNotNull(instanceCalInfo);
+        assertEquals("Equals15Characts", instanceCalInfo.getCalibrationIdentification());
+        assertEquals("0x00333231", instanceCalInfo.getCalibrationVerificationNumber());
+
+        assertArrayEquals(new byte[] { 0x45, 0x71, 0x75, 0x61, 0x6C, 0x73, 0x31, 0x35, 0x43, 0x68, 0x61, 0x72, 0x61,
+                0x63, 0x74, 0x73 },
+                          calInfo.getRawCalId());
+        assertArrayEquals(new byte[] { 49, 50, 51, 0 }, calInfo.getRawCvn());
+    }
+
+    @Test
+    public void testCvnLengthGreaterThanFour() {
+        CalibrationInformation calInfo = new CalibrationInformation("Equals15Characs", "12345");
+        DM19CalibrationInformationPacket instance = DM19CalibrationInformationPacket.create(0,
+                                                                                            0xF9,
+                                                                                            calInfo);
+        assertNotNull(instance.getCalibrationInformation());
+        CalibrationInformation instanceCalInfo = instance.getCalibrationInformation().get(0);
+        assertEquals("Equals15Characs ", instanceCalInfo.getCalibrationIdentification());
+        assertEquals("0x34333231", instanceCalInfo.getCalibrationVerificationNumber());
+
+        assertArrayEquals(new byte[] { 0x45, 0x71, 0x75, 0x61, 0x6C, 0x73, 0x31, 0x35, 0x43, 0x68, 0x61, 0x72, 0x61,
+                0x63, 0x73, 0x00 },
+                          calInfo.getRawCalId());
+        assertArrayEquals(new byte[] { 49, 50, 51, 52 }, calInfo.getRawCvn());
+    }
+
+    @Test
+    public void testCalIdLengthGreaterThanSixteen() {
+        CalibrationInformation calInfo = new CalibrationInformation("GreaterThan16Chars", "1234");
+        DM19CalibrationInformationPacket instance = DM19CalibrationInformationPacket.create(0, 0, calInfo);
+        assertNotNull(calInfo);
+        assertEquals("GreaterThan16Cha", calInfo.getCalibrationIdentification());
+        assertEquals("1234", calInfo.getCalibrationVerificationNumber());
+
+        assertArrayEquals(new byte[] { 0x47, 0x72, 0x65, 0x61, 0x74, 0x65, 0x72, 0x54, 0x68, 0x61, 0x6E, 0x31, 0x36,
+                0x43, 0x68, 0x61 },
+                          calInfo.getRawCalId());
+        assertArrayEquals(new byte[] { 49, 50, 51, 52 }, calInfo.getRawCvn());
     }
 
     @Test
@@ -177,28 +238,28 @@ public class DM19CalibrationInformationPacketTest {
         assertNotNull(calInfos);
         assertEquals(3, calInfos.size());
         CalibrationInformation calInfo1 = calInfos.get(0);
-        assertEquals("ANT5ASR1      ", calInfo1.getCalibrationIdentification());
-        // assertEquals("0xBDFEBA51", calInfo1.getCalibrationVerificationNumber());
+        assertEquals("ANT5ASR1        ", calInfo1.getCalibrationIdentification());
+        assertEquals("0xBDFEBA51", calInfo1.getCalibrationVerificationNumber());
         assertArrayEquals(new byte[] { 65, 78, 84, 53, 65, 83, 82, 49, 32, 32, 0, 0, 0, 0, 0, 0 },
                           calInfo1.getRawCalId());
         assertArrayEquals(new byte[] { 81, -70, -2 }, calInfo1.getRawCvn());
 
         CalibrationInformation calInfo2 = calInfos.get(1);
-        assertEquals("PBT5MPR3      ", calInfo2.getCalibrationIdentification());
-        assertEquals("0x4", calInfo2.getCalibrationVerificationNumber());
+        assertEquals("PBT5MPR3        ", calInfo2.getCalibrationIdentification());
+        assertEquals("0x40DCBF96", calInfo2.getCalibrationVerificationNumber());
         assertArrayEquals(new byte[] { 80, 66, 84, 53, 77, 80, 82, 51, 0, 0, 0, 0, 0, 0, 0, 0 },
                           calInfo2.getRawCalId());
         assertArrayEquals(new byte[] { -106, -65, -36 }, calInfo2.getRawCvn());
 
         CalibrationInformation calInfo3 = calInfos.get(2);
-        assertEquals("RPRBBA10      ", calInfo3.getCalibrationIdentification());
-        assertEquals("0x3", calInfo3.getCalibrationVerificationNumber());
+        assertEquals("RPRBBA10        ", calInfo3.getCalibrationIdentification());
+        assertEquals("0x3EB99140", calInfo3.getCalibrationVerificationNumber());
         assertArrayEquals(new byte[] { 82, 80, 82, 66, 66, 65, 49, 48, 0, 0, 0, 0, 0, 0, 0, 0 },
                           calInfo3.getRawCalId());
         assertArrayEquals(new byte[] { 64, -111, -71 }, calInfo3.getRawCvn());
 
-        String expected = "DM19 from Engine #1 (0): [" + NL + "  CAL ID of ANT5ASR1 and CVN of 0xB" + NL
-                + "  CAL ID of PBT5MPR3 and CVN of 0x4" + NL + "  CAL ID of RPRBBA10 and CVN of 0x3" + NL
+        String expected = "DM19 from Engine #1 (0): [" + NL + "  CAL ID of ANT5ASR1 and CVN of 0xBDFEBA51" + NL
+                + "  CAL ID of PBT5MPR3 and CVN of 0x40DCBF96" + NL + "  CAL ID of RPRBBA10 and CVN of 0x3EB99140" + NL
                 + "]";
         assertEquals(expected, instance.toString());
     }
@@ -232,13 +293,13 @@ public class DM19CalibrationInformationPacketTest {
         assertNotNull(calInfos);
         assertEquals(1, calInfos.size());
         CalibrationInformation calInfo = calInfos.get(0);
-        assertEquals("ANT5ASR1      ", calInfo.getCalibrationIdentification());
-        assertEquals("0x3", calInfo.getCalibrationVerificationNumber());
+        assertEquals("ANT5ASR1        ", calInfo.getCalibrationIdentification());
+        assertEquals("0x33FFAC00", calInfo.getCalibrationVerificationNumber());
         assertArrayEquals(new byte[] { 65, 78, 84, 53, 65, 83, 82, 49, 32, 32, 0, 0, 0, 0, 0, 0 },
                           calInfo.getRawCalId());
         assertArrayEquals(new byte[] { 0, -84, -1 }, calInfo.getRawCvn());
 
-        String expected = "DM19 from Engine #1 (0): CAL ID of ANT5ASR1 and CVN of 0x3";
+        String expected = "DM19 from Engine #1 (0): CAL ID of ANT5ASR1 and CVN of 0x33FFAC00";
         assertEquals(expected, instance.toString());
     }
 
@@ -271,13 +332,13 @@ public class DM19CalibrationInformationPacketTest {
         assertNotNull(calInfos);
         assertEquals(1, calInfos.size());
         CalibrationInformation calInfo = calInfos.get(0);
-        assertEquals("12DBB20002    ", calInfo.getCalibrationIdentification());
-        assertEquals("0x0", calInfo.getCalibrationVerificationNumber());
+        assertEquals("12DBB20002      ", calInfo.getCalibrationIdentification());
+        assertEquals("0x0000E5DE", calInfo.getCalibrationVerificationNumber());
         assertArrayEquals(new byte[] { 49, 50, 68, 66, 66, 50, 48, 48, 48, 50, 0, 0, 0, 0, 0, 0 },
                           calInfo.getRawCalId());
         assertArrayEquals(new byte[] { -34, -27, 0 }, calInfo.getRawCvn());
 
-        String expected = "DM19 from Engine #1 (0): CAL ID of 12DBB20002 and CVN of 0x0";
+        String expected = "DM19 from Engine #1 (0): CAL ID of 12DBB20002 and CVN of 0x0000E5DE";
         assertEquals(expected, instance.toString());
     }
 
@@ -310,13 +371,13 @@ public class DM19CalibrationInformationPacketTest {
         assertNotNull(calInfos);
         assertEquals(1, calInfos.size());
         CalibrationInformation calInfo = calInfos.get(0);
-        assertEquals("ANT5ASR1      ", calInfo.getCalibrationIdentification());
-        assertEquals("0x0", calInfo.getCalibrationVerificationNumber());
+        assertEquals("ANT5ASR1        ", calInfo.getCalibrationIdentification());
+        assertEquals("0x00000000", calInfo.getCalibrationVerificationNumber());
         assertArrayEquals(new byte[] { 65, 78, 84, 53, 65, 83, 82, 49, 32, 32, 0, 0, 0, 0, 0, 0 },
                           calInfo.getRawCalId());
         assertArrayEquals(new byte[] { 0, 0, 0 }, calInfo.getRawCvn());
 
-        String expected = "DM19 from Engine #1 (0): CAL ID of ANT5ASR1 and CVN of 0x0";
+        String expected = "DM19 from Engine #1 (0): CAL ID of ANT5ASR1 and CVN of 0x00000000";
         assertEquals(expected, instance.toString());
     }
 

--- a/src-test/org/etools/j1939_84/bus/j1939/packets/DM19CalibrationInformationPacketTest.java
+++ b/src-test/org/etools/j1939_84/bus/j1939/packets/DM19CalibrationInformationPacketTest.java
@@ -53,13 +53,13 @@ public class DM19CalibrationInformationPacketTest {
         assertNotNull(calInfos);
         assertEquals(1, calInfos.size());
         CalibrationInformation calInfo = calInfos.get(0);
-        assertEquals("ANT5ASR1        ", calInfo.getCalibrationIdentification());
-        assertEquals("0xBDFEBA51", calInfo.getCalibrationVerificationNumber());
-        assertArrayEquals(new byte[] { 65, 78, 84, 53, 65, 83, 82, 49, 32, 32, 32, 32, 32, 32, 32, 32 },
+        assertEquals("ANT5ASR1      ", calInfo.getCalibrationIdentification());
+        assertEquals("0xB", calInfo.getCalibrationVerificationNumber());
+        assertArrayEquals(new byte[] { 65, 78, 84, 53, 65, 83, 82, 49, 32, 32, 0, 0, 0, 0, 0, 0 },
                           calInfo.getRawCalId());
         assertArrayEquals(new byte[] { 81, -70, -2 }, calInfo.getRawCvn());
 
-        String expected = "DM19 from Engine #1 (0): CAL ID of ANT5ASR1 and CVN of 0xBDFEBA51";
+        String expected = "DM19 from Engine #1 (0): CAL ID of ANT5ASR1 and CVN of 0xB";
         assertEquals(expected, instance.toString());
     }
 
@@ -92,13 +92,13 @@ public class DM19CalibrationInformationPacketTest {
         assertNotNull(calInfos);
         assertEquals(1, calInfos.size());
         CalibrationInformation calInfo = calInfos.get(0);
-        assertEquals("0123456789012345", calInfo.getCalibrationIdentification());
-        assertEquals("0xBDFEBA51", calInfo.getCalibrationVerificationNumber());
+        assertEquals("01234567890123", calInfo.getCalibrationIdentification());
+        assertEquals("0xB", calInfo.getCalibrationVerificationNumber());
         assertArrayEquals(new byte[] { 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49, 50, 51, 52, 53 },
                           calInfo.getRawCalId());
         assertArrayEquals(new byte[] { 81, -70, -2 }, calInfo.getRawCvn());
 
-        String expected = "DM19 from Engine #1 (0): CAL ID of 0123456789012345 and CVN of 0xBDFEBA51";
+        String expected = "DM19 from Engine #1 (0): CAL ID of 01234567890123 and CVN of 0xB";
         assertEquals(expected, instance.toString());
     }
 
@@ -177,28 +177,28 @@ public class DM19CalibrationInformationPacketTest {
         assertNotNull(calInfos);
         assertEquals(3, calInfos.size());
         CalibrationInformation calInfo1 = calInfos.get(0);
-        assertEquals("ANT5ASR1        ", calInfo1.getCalibrationIdentification());
-        assertEquals("0xBDFEBA51", calInfo1.getCalibrationVerificationNumber());
-        assertArrayEquals(new byte[] { 65, 78, 84, 53, 65, 83, 82, 49, 32, 32, 32, 32, 32, 32, 32, 32 },
+        assertEquals("ANT5ASR1      ", calInfo1.getCalibrationIdentification());
+        // assertEquals("0xBDFEBA51", calInfo1.getCalibrationVerificationNumber());
+        assertArrayEquals(new byte[] { 65, 78, 84, 53, 65, 83, 82, 49, 32, 32, 0, 0, 0, 0, 0, 0 },
                           calInfo1.getRawCalId());
         assertArrayEquals(new byte[] { 81, -70, -2 }, calInfo1.getRawCvn());
 
         CalibrationInformation calInfo2 = calInfos.get(1);
-        assertEquals("PBT5MPR3        ", calInfo2.getCalibrationIdentification());
-        assertEquals("0x40DCBF96", calInfo2.getCalibrationVerificationNumber());
-        assertArrayEquals(new byte[] { 80, 66, 84, 53, 77, 80, 82, 51, 32, 32, 32, 32, 32, 32, 32, 32 },
+        assertEquals("PBT5MPR3      ", calInfo2.getCalibrationIdentification());
+        assertEquals("0x4", calInfo2.getCalibrationVerificationNumber());
+        assertArrayEquals(new byte[] { 80, 66, 84, 53, 77, 80, 82, 51, 0, 0, 0, 0, 0, 0, 0, 0 },
                           calInfo2.getRawCalId());
         assertArrayEquals(new byte[] { -106, -65, -36 }, calInfo2.getRawCvn());
 
         CalibrationInformation calInfo3 = calInfos.get(2);
-        assertEquals("RPRBBA10        ", calInfo3.getCalibrationIdentification());
-        assertEquals("0x3EB99140", calInfo3.getCalibrationVerificationNumber());
-        assertArrayEquals(new byte[] { 82, 80, 82, 66, 66, 65, 49, 48, 32, 32, 32, 32, 32, 32, 32, 32 },
+        assertEquals("RPRBBA10      ", calInfo3.getCalibrationIdentification());
+        assertEquals("0x3", calInfo3.getCalibrationVerificationNumber());
+        assertArrayEquals(new byte[] { 82, 80, 82, 66, 66, 65, 49, 48, 0, 0, 0, 0, 0, 0, 0, 0 },
                           calInfo3.getRawCalId());
         assertArrayEquals(new byte[] { 64, -111, -71 }, calInfo3.getRawCvn());
 
-        String expected = "DM19 from Engine #1 (0): [" + NL + "  CAL ID of ANT5ASR1 and CVN of 0xBDFEBA51" + NL
-                + "  CAL ID of PBT5MPR3 and CVN of 0x40DCBF96" + NL + "  CAL ID of RPRBBA10 and CVN of 0x3EB99140" + NL
+        String expected = "DM19 from Engine #1 (0): [" + NL + "  CAL ID of ANT5ASR1 and CVN of 0xB" + NL
+                + "  CAL ID of PBT5MPR3 and CVN of 0x4" + NL + "  CAL ID of RPRBBA10 and CVN of 0x3" + NL
                 + "]";
         assertEquals(expected, instance.toString());
     }
@@ -232,13 +232,13 @@ public class DM19CalibrationInformationPacketTest {
         assertNotNull(calInfos);
         assertEquals(1, calInfos.size());
         CalibrationInformation calInfo = calInfos.get(0);
-        assertEquals("ANT5ASR1        ", calInfo.getCalibrationIdentification());
-        assertEquals("0x33FFAC00", calInfo.getCalibrationVerificationNumber());
-        assertArrayEquals(new byte[] { 65, 78, 84, 53, 65, 83, 82, 49, 32, 32, 32, 32, 32, 32, 32, 32 },
+        assertEquals("ANT5ASR1      ", calInfo.getCalibrationIdentification());
+        assertEquals("0x3", calInfo.getCalibrationVerificationNumber());
+        assertArrayEquals(new byte[] { 65, 78, 84, 53, 65, 83, 82, 49, 32, 32, 0, 0, 0, 0, 0, 0 },
                           calInfo.getRawCalId());
         assertArrayEquals(new byte[] { 0, -84, -1 }, calInfo.getRawCvn());
 
-        String expected = "DM19 from Engine #1 (0): CAL ID of ANT5ASR1 and CVN of 0x33FFAC00";
+        String expected = "DM19 from Engine #1 (0): CAL ID of ANT5ASR1 and CVN of 0x3";
         assertEquals(expected, instance.toString());
     }
 
@@ -271,13 +271,13 @@ public class DM19CalibrationInformationPacketTest {
         assertNotNull(calInfos);
         assertEquals(1, calInfos.size());
         CalibrationInformation calInfo = calInfos.get(0);
-        assertEquals("12DBB20002      ", calInfo.getCalibrationIdentification());
-        assertEquals("0x0000E5DE", calInfo.getCalibrationVerificationNumber());
-        assertArrayEquals(new byte[] { 49, 50, 68, 66, 66, 50, 48, 48, 48, 50, 32, 32, 32, 32, 32, 32 },
+        assertEquals("12DBB20002    ", calInfo.getCalibrationIdentification());
+        assertEquals("0x0", calInfo.getCalibrationVerificationNumber());
+        assertArrayEquals(new byte[] { 49, 50, 68, 66, 66, 50, 48, 48, 48, 50, 0, 0, 0, 0, 0, 0 },
                           calInfo.getRawCalId());
         assertArrayEquals(new byte[] { -34, -27, 0 }, calInfo.getRawCvn());
 
-        String expected = "DM19 from Engine #1 (0): CAL ID of 12DBB20002 and CVN of 0x0000E5DE";
+        String expected = "DM19 from Engine #1 (0): CAL ID of 12DBB20002 and CVN of 0x0";
         assertEquals(expected, instance.toString());
     }
 
@@ -310,13 +310,13 @@ public class DM19CalibrationInformationPacketTest {
         assertNotNull(calInfos);
         assertEquals(1, calInfos.size());
         CalibrationInformation calInfo = calInfos.get(0);
-        assertEquals("ANT5ASR1        ", calInfo.getCalibrationIdentification());
-        assertEquals("0x00000000", calInfo.getCalibrationVerificationNumber());
-        assertArrayEquals(new byte[] { 65, 78, 84, 53, 65, 83, 82, 49, 32, 32, 32, 32, 32, 32, 32, 32 },
+        assertEquals("ANT5ASR1      ", calInfo.getCalibrationIdentification());
+        assertEquals("0x0", calInfo.getCalibrationVerificationNumber());
+        assertArrayEquals(new byte[] { 65, 78, 84, 53, 65, 83, 82, 49, 32, 32, 0, 0, 0, 0, 0, 0 },
                           calInfo.getRawCalId());
         assertArrayEquals(new byte[] { 0, 0, 0 }, calInfo.getRawCvn());
 
-        String expected = "DM19 from Engine #1 (0): CAL ID of ANT5ASR1 and CVN of 0x00000000";
+        String expected = "DM19 from Engine #1 (0): CAL ID of ANT5ASR1 and CVN of 0x0";
         assertEquals(expected, instance.toString());
     }
 

--- a/src/org/etools/j1939_84/bus/j1939/packets/DM19CalibrationInformationPacket.java
+++ b/src/org/etools/j1939_84/bus/j1939/packets/DM19CalibrationInformationPacket.java
@@ -5,7 +5,6 @@ package org.etools.j1939_84.bus.j1939.packets;
 
 import static org.etools.j1939_84.J1939_84.NL;
 
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -138,7 +137,7 @@ public class DM19CalibrationInformationPacket extends GenericPacket {
         private final byte[] rawCalId;
         private final byte[] rawCvn;
 
-        public CalibrationInformation(String calId, String cvn) {
+        public CalibrationInformation(String calId, String cvn, byte[] rawCalId, byte[] rawCvn) {
             if (calId.length() > 15) {
                 calibrationIdentification = calId.substring(0, 14);
             } else if (calId.length() < 15) {
@@ -155,13 +154,6 @@ public class DM19CalibrationInformationPacket extends GenericPacket {
                 calibrationVerificationNumber = cvn;
             }
 
-            rawCalId = calibrationIdentification.getBytes(StandardCharsets.UTF_8);
-            rawCvn = calibrationVerificationNumber.getBytes(StandardCharsets.UTF_8);
-        }
-
-        public CalibrationInformation(String id, String cvn, byte[] rawCalId, byte[] rawCvn) {
-            calibrationIdentification = id;
-            calibrationVerificationNumber = cvn;
             this.rawCalId = Arrays.copyOf(rawCalId, rawCalId.length);
             this.rawCvn = Arrays.copyOf(rawCvn, rawCvn.length);
         }

--- a/src/org/etools/j1939_84/bus/j1939/packets/DM19CalibrationInformationPacket.java
+++ b/src/org/etools/j1939_84/bus/j1939/packets/DM19CalibrationInformationPacket.java
@@ -6,6 +6,7 @@ package org.etools.j1939_84.bus.j1939.packets;
 import static java.util.Arrays.fill;
 import static org.etools.j1939_84.J1939_84.NL;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -163,8 +164,8 @@ public class DM19CalibrationInformationPacket extends GenericPacket {
                 calibrationVerificationNumber = String.format("%0$-4s", cvn).replace(' ', (char) 0x00);
             }
 
-            rawCalId = calibrationIdentification.getBytes();
-            rawCvn = calibrationVerificationNumber.getBytes();
+            rawCalId = calibrationIdentification.getBytes(StandardCharsets.UTF_8);
+            rawCvn = calibrationVerificationNumber.getBytes(StandardCharsets.UTF_8);
 
         }
 

--- a/src/org/etools/j1939_84/bus/j1939/packets/ParsedPacket.java
+++ b/src/org/etools/j1939_84/bus/j1939/packets/ParsedPacket.java
@@ -73,13 +73,14 @@ public class ParsedPacket {
      * @return       {@link String}
      */
     protected static String format(byte[] bytes) {
-        for (int i = 0; i < bytes.length; i++) {
-            int chr = bytes[i] & 0xFF;
+        byte[] localBytes = Arrays.copyOf(bytes, bytes.length);
+        for (int i = 0; i < localBytes.length; i++) {
+            int chr = localBytes[i] & 0xFF;
             if ((chr < 0x20) || ((chr > 0x7F) && (chr < 0xA0))) {
-                bytes[i] = ' ';
+                localBytes[i] = ' ';
             }
         }
-        return new String(bytes, StandardCharsets.ISO_8859_1);
+        return new String(localBytes, StandardCharsets.ISO_8859_1);
     }
 
     /**


### PR DESCRIPTION
#8 - Update DM19 to correctly preserve the original data from the message off of the bus and to return a copy of the calInfo for the consumers to use.  Update tests.