### PR TITLE
DM11 requests need to be configurable

### DIFF
--- a/src-test/org/etools/j1939_84/modules/DiagnosticMessageModuleTest.java
+++ b/src-test/org/etools/j1939_84/modules/DiagnosticMessageModuleTest.java
@@ -4,6 +4,7 @@
 package org.etools.j1939_84.modules;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.etools.j1939_84.J1939_84.NL;
 import static org.etools.j1939_84.bus.j1939.J1939.GLOBAL_ADDR;
 import static org.etools.j1939_84.controllers.ResultsListener.NOOP;
@@ -248,7 +249,8 @@ public class DiagnosticMessageModuleTest {
                 + NL;
 
         TestResultsListener listener = new TestResultsListener();
-        assertEquals(List.of(packet1), instance.requestDM11(listener));
+
+        assertEquals(List.of(packet1), instance.requestDM11(listener, 600, MILLISECONDS));
         assertEquals(expected, listener.getResults());
 
         verify(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
@@ -1669,6 +1671,7 @@ public class DiagnosticMessageModuleTest {
         verify(j1939).read(anyLong(), any());
     }
 
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
     @Test
     public void testRequestDM2DestinationSpecificWithEngine1Response() throws BusException {
         final int pgn = DM2PreviouslyActiveDTC.PGN;

--- a/src/org/etools/j1939_84/bus/j1939/J1939.java
+++ b/src/org/etools/j1939_84/bus/j1939/J1939.java
@@ -556,16 +556,16 @@ public class J1939 {
         }
     }
 
+    /**
+     * Make a single Global request with standard wait bus read time specified @ 600ms.
+     */
     public List<AcknowledgmentPacket> requestForAcks(ResultsListener listener, String title, int pgn) {
-        listener.onResult("");
-        listener.onResult(getDateTimeModule().getTime() + " " + title);
-        Packet requestPacket = createRequestPacket(pgn, GLOBAL_ADDR);
-        return requestGlobalOnce(pgn, requestPacket, listener)
-                                                              .stream()
-                                                              .flatMap(e -> e.right.stream())
-                                                              .collect(Collectors.toList());
+        return requestForAcks(listener, title, pgn, GLOBAL_TIMEOUT, MILLISECONDS);
     }
 
+    /**
+     * Make a single Global request with wait bus read time specified.
+     */
     public List<AcknowledgmentPacket>
            requestForAcks(ResultsListener listener, String title, int pgn, long timeOut, TimeUnit timeUnit) {
         listener.onResult("");
@@ -577,6 +577,9 @@ public class J1939 {
                                                                                  .collect(Collectors.toList());
     }
 
+    /**
+     * Make a single DS request with no retries.
+     */
     public List<AcknowledgmentPacket> requestForAcks(ResultsListener listener, String title, int pgn, int address) {
         listener.onResult("");
         listener.onResult(getDateTimeModule().getTime() + " " + title);

--- a/src/org/etools/j1939_84/bus/j1939/J1939.java
+++ b/src/org/etools/j1939_84/bus/j1939/J1939.java
@@ -566,6 +566,17 @@ public class J1939 {
                                                               .collect(Collectors.toList());
     }
 
+    public List<AcknowledgmentPacket>
+           requestForAcks(ResultsListener listener, String title, int pgn, long timeOut, TimeUnit timeUnit) {
+        listener.onResult("");
+        listener.onResult(getDateTimeModule().getTime() + " " + title);
+        Packet requestPacket = createRequestPacket(pgn, GLOBAL_ADDR);
+        return requestGlobalOnce(pgn, requestPacket, listener, timeOut, timeUnit)
+                                                                                 .stream()
+                                                                                 .flatMap(e -> e.right.stream())
+                                                                                 .collect(Collectors.toList());
+    }
+
     public List<AcknowledgmentPacket> requestForAcks(ResultsListener listener, String title, int pgn, int address) {
         listener.onResult("");
         listener.onResult(getDateTimeModule().getTime() + " " + title);
@@ -664,6 +675,76 @@ public class J1939 {
         List<Either<T, AcknowledgmentPacket>> result;
         try {
             Stream<Packet> stream = read(GLOBAL_TIMEOUT, MILLISECONDS);
+            Packet sent = bus.send(request);
+            LocalDateTime lateTime;
+            if (sent != null) {
+                listener.onResult(sent.toTimeString());
+                lateTime = sent.getTimestamp().plus(GLOBAL_WARN_TIMEOUT, ChronoUnit.MILLIS);
+            } else {
+                logWarning(listener, FAILED_TO_SEND + request);
+                lateTime = null;
+            }
+            List<Packet> lateBam = new ArrayList<>();
+            result = stream
+                           .filter(globalFilter(pgn))
+                           .peek(p -> {
+                               /*
+                                * If the first fragment arrived after lateBam, then it
+                                * is late.
+                                */
+                               if (lateTime != null && p.getFragments().size() > 0
+                                       && p.getFragments().get(0).getTimestamp().isAfter(lateTime)) {
+                                   lateBam.add(p);
+                               }
+                           })
+                           // Collect all of the packet, even though they are not
+                           // complete. They were all announced in time.
+                           .collect(Collectors.toList())
+                           .stream()
+                           .map(rawPacket -> {
+                               try {
+                                   listener.onResult(rawPacket.toTimeString());
+                                   Either<T, AcknowledgmentPacket> pp = process(rawPacket);
+                                   listener.onResult(pp.resolve().toString());
+                                   return pp;
+                               } catch (PacketException e) {
+                                   // This is not a complete packet. Should be logged
+                                   // as a failure elsewhere.
+                                   return null;
+                               }
+                           })
+                           .filter(Objects::nonNull)
+                           .collect(Collectors.toList());
+            /* Log late fragments as raw packets. */
+            lateBam.forEach(p -> {
+                logTiming(listener, LATE_RESPONSE + " " + p.getFragments().get(0).toTimeString());
+            });
+
+            if (result.isEmpty()) {
+                listener.onResult(getDateTimeModule().getTime() + " " + TIMEOUT_MESSAGE);
+            }
+        } catch (BusException e) {
+            severe("Error requesting packet", e);
+            result = Collections.emptyList();
+        }
+        return result;
+    }
+
+    /**
+     * Request from global only once.
+     */
+    private <T extends GenericPacket> List<Either<T, AcknowledgmentPacket>> requestGlobalOnce(int pgn,
+                                                                                              Packet request,
+                                                                                              ResultsListener listener,
+                                                                                              long timeOut,
+                                                                                              TimeUnit timeUnit) {
+        if (request.getDestination() != GLOBAL_ADDR) {
+            throw new IllegalArgumentException("Request not to global.");
+        }
+
+        List<Either<T, AcknowledgmentPacket>> result;
+        try {
+            Stream<Packet> stream = read(timeOut, timeUnit);
             Packet sent = bus.send(request);
             LocalDateTime lateTime;
             if (sent != null) {

--- a/src/org/etools/j1939_84/bus/simulated/Engine.java
+++ b/src/org/etools/j1939_84/bus/simulated/Engine.java
@@ -5,6 +5,8 @@ package org.etools.j1939_84.bus.simulated;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.create;
+import static org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response.ACK;
 import static org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response.NACK;
 import static org.etools.j1939_84.bus.j1939.packets.CompositeSystem.AC_SYSTEM_REFRIGERANT;
 import static org.etools.j1939_84.bus.j1939.packets.CompositeSystem.BOOST_PRESSURE_CONTROL_SYS;
@@ -44,12 +46,13 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
 
 import org.etools.j1939_84.bus.Bus;
 import org.etools.j1939_84.bus.BusException;
 import org.etools.j1939_84.bus.Packet;
-import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
 import org.etools.j1939_84.bus.j1939.packets.CompositeSystem;
 import org.etools.j1939_84.bus.j1939.packets.DM11ClearActiveDTCsPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM12MILOnEmissionDTCPacket;
@@ -96,6 +99,7 @@ import org.etools.j1939_84.model.SpnFmi;
 public class Engine implements AutoCloseable {
     private static final Charset A_UTF8 = StandardCharsets.UTF_8;
     private final static int ADDR = 0x00;
+    private static final int BUS_ADDR = 0xA5;
     private static final byte[] COMPONENT_ID = "INT*570261221315646M13*570HM2U3545277**".getBytes(A_UTF8);
     private static final byte[] DISTANCE = to4Bytes(256345L * 8); // km
 
@@ -261,7 +265,7 @@ public class Engine implements AutoCloseable {
 
         // DM3
         sim.response(p -> isRequestFor(DM3DiagnosticDataClearPacket.PGN, p),
-                     p -> AcknowledgmentPacket.create(ADDR,
+                     p -> create(ADDR,
                                                       NACK,
                                                       0,
                                                       p.getSource(),
@@ -288,6 +292,27 @@ public class Engine implements AutoCloseable {
                                                              pendingDTCs.toArray(new DiagnosticTroubleCode[0]))
                                                      .getPacket());
 
+        // DM11
+        sim.response(p -> isRequestFor(DM11ClearActiveDTCsPacket.PGN, p),
+                     p -> {
+                         new Timer().schedule(new TimerTask() {
+                             @Override
+                             public void run() {
+                                 sim.sendNow(create(ADDR,
+                                                    NACK,
+                                                    0,
+                                                    p.getSource(),
+                                                    DM11ClearActiveDTCsPacket.PGN).getPacket());
+                             }
+                         }, 4800);
+
+                         return create(0x85,
+                                       ACK,
+                                       0,
+                                       p.getSource(),
+                                       DM11ClearActiveDTCsPacket.PGN).getPacket();
+                     });
+
         // DM11 Global Request
         sim.response(p -> (p.getId(0xFFFF) == 0xEAFF) && p.get24(0) == DM11ClearActiveDTCsPacket.PGN,
                      p -> {
@@ -302,7 +327,7 @@ public class Engine implements AutoCloseable {
 
         // DM11 DS Request
         sim.response(p -> p.getId(0xFFFF) == (0xEA00 | Engine.ADDR) && p.get24(0) == DM11ClearActiveDTCsPacket.PGN,
-                     p -> AcknowledgmentPacket.create(ADDR, NACK, 0, p.getSource(), DM11ClearActiveDTCsPacket.PGN)
+                     p -> create(ADDR, NACK, 0, p.getSource(), DM11ClearActiveDTCsPacket.PGN)
                                               .getPacket());
 
         // DM12

--- a/src/org/etools/j1939_84/bus/simulated/Engine.java
+++ b/src/org/etools/j1939_84/bus/simulated/Engine.java
@@ -5,7 +5,6 @@ package org.etools.j1939_84.bus.simulated;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.create;
 import static org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response.ACK;
 import static org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response.NACK;
 import static org.etools.j1939_84.bus.j1939.packets.CompositeSystem.AC_SYSTEM_REFRIGERANT;
@@ -53,6 +52,7 @@ import java.util.concurrent.TimeUnit;
 import org.etools.j1939_84.bus.Bus;
 import org.etools.j1939_84.bus.BusException;
 import org.etools.j1939_84.bus.Packet;
+import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
 import org.etools.j1939_84.bus.j1939.packets.CompositeSystem;
 import org.etools.j1939_84.bus.j1939.packets.DM11ClearActiveDTCsPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM12MILOnEmissionDTCPacket;
@@ -265,7 +265,7 @@ public class Engine implements AutoCloseable {
 
         // DM3
         sim.response(p -> isRequestFor(DM3DiagnosticDataClearPacket.PGN, p),
-                     p -> create(ADDR,
+                     p -> AcknowledgmentPacket.create(ADDR,
                                                       NACK,
                                                       0,
                                                       p.getSource(),
@@ -298,7 +298,7 @@ public class Engine implements AutoCloseable {
                          new Timer().schedule(new TimerTask() {
                              @Override
                              public void run() {
-                                 sim.sendNow(create(ADDR,
+                                 sim.sendNow(AcknowledgmentPacket.create(ADDR,
                                                     NACK,
                                                     0,
                                                     p.getSource(),
@@ -306,7 +306,7 @@ public class Engine implements AutoCloseable {
                              }
                          }, 4800);
 
-                         return create(0x85,
+                         return AcknowledgmentPacket.create(0x85,
                                        ACK,
                                        0,
                                        p.getSource(),
@@ -327,7 +327,7 @@ public class Engine implements AutoCloseable {
 
         // DM11 DS Request
         sim.response(p -> p.getId(0xFFFF) == (0xEA00 | Engine.ADDR) && p.get24(0) == DM11ClearActiveDTCsPacket.PGN,
-                     p -> create(ADDR, NACK, 0, p.getSource(), DM11ClearActiveDTCsPacket.PGN)
+                     p -> AcknowledgmentPacket.create(ADDR, NACK, 0, p.getSource(), DM11ClearActiveDTCsPacket.PGN)
                                               .getPacket());
 
         // DM12

--- a/src/org/etools/j1939_84/modules/DiagnosticMessageModule.java
+++ b/src/org/etools/j1939_84/modules/DiagnosticMessageModule.java
@@ -148,6 +148,14 @@ public class DiagnosticMessageModule extends FunctionalModule {
         return getJ1939().requestForAcks(listener, title, DM11ClearActiveDTCsPacket.PGN, address);
     }
 
+    public List<AcknowledgmentPacket> requestDM11(ResultsListener listener, long timeOut, TimeUnit timeUnit) {
+        return getJ1939().requestForAcks(listener,
+                                         "Global DM11 Request",
+                                         DM11ClearActiveDTCsPacket.PGN,
+                                         timeOut,
+                                         timeUnit);
+    }
+
     public RequestResult<DM12MILOnEmissionDTCPacket> requestDM12(ResultsListener listener) {
         return requestDMPackets("DM12", DM12MILOnEmissionDTCPacket.class, GLOBAL_ADDR, listener);
     }

--- a/src/org/etools/j1939_84/modules/DiagnosticMessageModule.java
+++ b/src/org/etools/j1939_84/modules/DiagnosticMessageModule.java
@@ -145,8 +145,7 @@ public class DiagnosticMessageModule extends FunctionalModule {
      */
     @Deprecated
     public List<AcknowledgmentPacket> requestDM11(ResultsListener listener) {
-        final long GLOBAL_TIMEOUT = 600;
-        return requestDM11(listener, GLOBAL_TIMEOUT, MILLISECONDS);
+        return requestDM11(listener, 600, MILLISECONDS);
     }
 
     public List<AcknowledgmentPacket> requestDM11(ResultsListener listener, int address) {

--- a/src/org/etools/j1939_84/modules/DiagnosticMessageModule.java
+++ b/src/org/etools/j1939_84/modules/DiagnosticMessageModule.java
@@ -3,6 +3,7 @@
  */
 package org.etools.j1939_84.modules;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.etools.j1939_84.J1939_84.NL;
 import static org.etools.j1939_84.bus.j1939.J1939.GLOBAL_ADDR;
 
@@ -139,8 +140,13 @@ public class DiagnosticMessageModule extends FunctionalModule {
         return requestDMPackets("DM6", DM6PendingEmissionDTCPacket.class, address, listener);
     }
 
+    /*
+     * TODO: Remove when Step 9.8 & 12.9 are updated to match new requirements.
+     */
+    @Deprecated
     public List<AcknowledgmentPacket> requestDM11(ResultsListener listener) {
-        return getJ1939().requestForAcks(listener, "Global DM11 Request", DM11ClearActiveDTCsPacket.PGN);
+        final long GLOBAL_TIMEOUT = 600;
+        return requestDM11(listener, GLOBAL_TIMEOUT, MILLISECONDS);
     }
 
     public List<AcknowledgmentPacket> requestDM11(ResultsListener listener, int address) {


### PR DESCRIPTION
Fix #18 - Update DiagnosticMessageModule.java to overload requestDM11() method to allow the passing of two more parameters specifying the number and unit of time to delay and wait for messages to be returned on the bus.