### PR TITLE
Rename DiagnosticMessageModule to CommunicationsModule

### DIFF
--- a/src-test/org/etools/j1939_84/controllers/AbstractPartControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/AbstractPartControllerTest.java
@@ -19,7 +19,7 @@ import java.util.concurrent.Executor;
 import org.etools.j1939_84.bus.j1939.J1939;
 import org.etools.j1939_84.bus.j1939.Lookup;
 import org.etools.j1939_84.modules.BannerModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -144,7 +144,7 @@ public class AbstractPartControllerTest {
     protected VehicleInformationModule vehicleInformationModule;
 
     @Mock
-    protected DiagnosticMessageModule diagnosticMessageModule;
+    protected CommunicationsModule communicationsModule;
 
     protected int partNumber;
 

--- a/src-test/org/etools/j1939_84/controllers/SectionA5MessageVerifierTest.java
+++ b/src-test/org/etools/j1939_84/controllers/SectionA5MessageVerifierTest.java
@@ -44,7 +44,7 @@ import org.etools.j1939_84.bus.j1939.packets.SupportedSPN;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 import org.junit.After;
@@ -63,7 +63,7 @@ public class SectionA5MessageVerifierTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     private SectionA5MessageVerifier instance;
 
@@ -86,7 +86,7 @@ public class SectionA5MessageVerifierTest {
         listener = new TestResultsListener(mockListener);
 
         instance = new SectionA5MessageVerifier(dataRepository,
-                                                diagnosticMessageModule,
+                                                communicationsModule,
                                                 vehicleInformationModule,
                                                 PART_NUMBER,
                                                 STEP_NUMBER);
@@ -95,7 +95,7 @@ public class SectionA5MessageVerifierTest {
     @After
     public void tearDown() {
         DateTimeModule.setInstance(null);
-        verifyNoMoreInteractions(diagnosticMessageModule,
+        verifyNoMoreInteractions(communicationsModule,
                                  mockListener,
                                  vehicleInformationModule);
     }
@@ -103,7 +103,7 @@ public class SectionA5MessageVerifierTest {
     @Test
     public void testSetJ1939() {
         instance.setJ1939(j1939);
-        verify(diagnosticMessageModule).setJ1939(j1939);
+        verify(communicationsModule).setJ1939(j1939);
         verify(vehicleInformationModule).setJ1939(j1939);
     }
 
@@ -114,11 +114,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM6PendingEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM6(listener, 0)).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM6(listener, 0)).thenReturn(RequestResult.of(packet));
 
         assertTrue(instance.checkDM6(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM6(listener, 0);
+        verify(communicationsModule).requestDM6(listener, 0);
     }
 
     @Test
@@ -129,11 +129,11 @@ public class SectionA5MessageVerifierTest {
 
         var dtc = DiagnosticTroubleCode.create(123, 1, 1, 1);
         var packet = DM6PendingEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM6(listener, 0)).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM6(listener, 0)).thenReturn(RequestResult.of(packet));
 
         assertFalse(instance.checkDM6(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM6(listener, 0);
+        verify(communicationsModule).requestDM6(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
@@ -147,11 +147,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM6PendingEmissionDTCPacket.create(0, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM6(listener, 0)).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM6(listener, 0)).thenReturn(RequestResult.of(packet));
 
         assertFalse(instance.checkDM6(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM6(listener, 0);
+        verify(communicationsModule).requestDM6(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
@@ -166,11 +166,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM6PendingEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM6(listener, 0)).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM6(listener, 0)).thenReturn(RequestResult.of(packet));
 
         assertTrue(instance.checkDM6(listener, SECTION, 0, false));
 
-        verify(diagnosticMessageModule).requestDM6(listener, 0);
+        verify(communicationsModule).requestDM6(listener, 0);
     }
 
     @Test
@@ -181,11 +181,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM6PendingEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM6(listener, 0)).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM6(listener, 0)).thenReturn(RequestResult.of(packet));
 
         assertFalse(instance.checkDM6(listener, SECTION, 0, false));
 
-        verify(diagnosticMessageModule).requestDM6(listener, 0);
+        verify(communicationsModule).requestDM6(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, "6.2.3.4.a - Engine #1 (0) erased DM6 data");
     }
 
@@ -197,11 +197,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM12MILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM12(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM12(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertTrue(instance.checkDM12(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM12(listener, 0);
+        verify(communicationsModule).requestDM12(listener, 0);
     }
 
     @Test
@@ -212,11 +212,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM12MILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM12(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM12(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertFalse(instance.checkDM12(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM12(listener, 0);
+        verify(communicationsModule).requestDM12(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
@@ -231,11 +231,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM12(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM12(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertFalse(instance.checkDM12(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM12(listener, 0);
+        verify(communicationsModule).requestDM12(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
@@ -250,11 +250,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM12(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM12(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertTrue(instance.checkDM12(listener, SECTION, 0, false));
 
-        verify(diagnosticMessageModule).requestDM12(listener, 0);
+        verify(communicationsModule).requestDM12(listener, 0);
     }
 
     @Test
@@ -265,11 +265,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM12MILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM12(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM12(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertFalse(instance.checkDM12(listener, SECTION, 0, false));
 
-        verify(diagnosticMessageModule).requestDM12(listener, 0);
+        verify(communicationsModule).requestDM12(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, "6.2.3.4.a - Engine #1 (0) erased DM12 data");
     }
 
@@ -281,11 +281,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM23PreviouslyMILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM23(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM23(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertTrue(instance.checkDM23(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM23(listener, 0);
+        verify(communicationsModule).requestDM23(listener, 0);
     }
 
     @Test
@@ -296,11 +296,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM23PreviouslyMILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM23(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM23(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertFalse(instance.checkDM23(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM23(listener, 0);
+        verify(communicationsModule).requestDM23(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
@@ -315,11 +315,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM23PreviouslyMILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM23(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM23(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertFalse(instance.checkDM23(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM23(listener, 0);
+        verify(communicationsModule).requestDM23(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
@@ -334,11 +334,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM23PreviouslyMILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM23(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM23(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertTrue(instance.checkDM23(listener, SECTION, 0, false));
 
-        verify(diagnosticMessageModule).requestDM23(listener, 0);
+        verify(communicationsModule).requestDM23(listener, 0);
     }
 
     @Test
@@ -349,11 +349,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM23PreviouslyMILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM23(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM23(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertFalse(instance.checkDM23(listener, SECTION, 0, false));
 
-        verify(diagnosticMessageModule).requestDM23(listener, 0);
+        verify(communicationsModule).requestDM23(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, "6.2.3.4.a - Engine #1 (0) erased DM23 data");
     }
 
@@ -364,11 +364,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM29DtcCounts.create(0, 0, 0, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM29(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM29(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertTrue(instance.checkDM29(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM29(listener, 0);
+        verify(communicationsModule).requestDM29(listener, 0);
     }
 
     @Test
@@ -378,11 +378,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM29DtcCounts.create(0, 0, 1, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM29(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM29(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertFalse(instance.checkDM29(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM29(listener, 0);
+        verify(communicationsModule).requestDM29(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
@@ -396,11 +396,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM29DtcCounts.create(0, 0, 0, 0, 1, 0, 0);
-        when(diagnosticMessageModule.requestDM29(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM29(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertFalse(instance.checkDM29(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM29(listener, 0);
+        verify(communicationsModule).requestDM29(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
@@ -414,11 +414,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM29DtcCounts.create(0, 0, 0, 0, 0, 1, 0);
-        when(diagnosticMessageModule.requestDM29(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM29(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertFalse(instance.checkDM29(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM29(listener, 0);
+        verify(communicationsModule).requestDM29(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
@@ -432,11 +432,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM29DtcCounts.create(0, 0, 1, 0, 1, 1, 0);
-        when(diagnosticMessageModule.requestDM29(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM29(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertTrue(instance.checkDM29(listener, SECTION, 0, false));
 
-        verify(diagnosticMessageModule).requestDM29(listener, 0);
+        verify(communicationsModule).requestDM29(listener, 0);
     }
 
     @Test
@@ -446,11 +446,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM29DtcCounts.create(0, 0, 0, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM29(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM29(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertFalse(instance.checkDM29(listener, SECTION, 0, false));
 
-        verify(diagnosticMessageModule).requestDM29(listener, 0);
+        verify(communicationsModule).requestDM29(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, "6.2.3.4.a - Engine #1 (0) erased DM29 data");
     }
 
@@ -466,11 +466,11 @@ public class SectionA5MessageVerifierTest {
                                                          0x22,
                                                          List.of(),
                                                          List.of(CompositeSystem.COMPREHENSIVE_COMPONENT));
-        when(diagnosticMessageModule.requestDM5(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM5(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertTrue(instance.checkDM5(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM5(listener, 0);
+        verify(communicationsModule).requestDM5(listener, 0);
     }
 
     @Test
@@ -480,11 +480,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM5DiagnosticReadinessPacket.create(0, 1, 0, 0x22);
-        when(diagnosticMessageModule.requestDM5(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM5(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertFalse(instance.checkDM5(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM5(listener, 0);
+        verify(communicationsModule).requestDM5(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
@@ -498,11 +498,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM5DiagnosticReadinessPacket.create(0, 0, 1, 0x22);
-        when(diagnosticMessageModule.requestDM5(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM5(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertFalse(instance.checkDM5(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM5(listener, 0);
+        verify(communicationsModule).requestDM5(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
@@ -517,11 +517,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM5DiagnosticReadinessPacket.create(0, 1, 0, 0x22, List.of(), List.of(CompositeSystem.CATALYST));
-        when(diagnosticMessageModule.requestDM5(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM5(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertFalse(instance.checkDM5(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM5(listener, 0);
+        verify(communicationsModule).requestDM5(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
@@ -535,11 +535,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM5DiagnosticReadinessPacket.create(0, 1, 1, 0x22);
-        when(diagnosticMessageModule.requestDM5(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM5(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertTrue(instance.checkDM5(listener, SECTION, 0, false));
 
-        verify(diagnosticMessageModule).requestDM5(listener, 0);
+        verify(communicationsModule).requestDM5(listener, 0);
     }
 
     @Test
@@ -549,11 +549,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM5DiagnosticReadinessPacket.create(0, 0xFF, 0xFF, 0x22);
-        when(diagnosticMessageModule.requestDM5(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM5(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertTrue(instance.checkDM5(listener, SECTION, 0, false));
 
-        verify(diagnosticMessageModule).requestDM5(listener, 0);
+        verify(communicationsModule).requestDM5(listener, 0);
     }
 
     @Test
@@ -563,11 +563,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM5DiagnosticReadinessPacket.create(0, 0, 0, 0x22);
-        when(diagnosticMessageModule.requestDM5(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM5(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertFalse(instance.checkDM5(listener, SECTION, 0, false));
 
-        verify(diagnosticMessageModule).requestDM5(listener, 0);
+        verify(communicationsModule).requestDM5(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, "6.2.3.4.a - Engine #1 (0) erased DM5 data");
     }
 
@@ -579,11 +579,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM25ExpandedFreezeFrame.create(0);
-        when(diagnosticMessageModule.requestDM25(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM25(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertTrue(instance.checkDM25(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM25(listener, 0);
+        verify(communicationsModule).requestDM25(listener, 0);
     }
 
     @Test
@@ -594,11 +594,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM25ExpandedFreezeFrame.create(0, freezeFrame);
-        when(diagnosticMessageModule.requestDM25(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM25(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertFalse(instance.checkDM25(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM25(listener, 0);
+        verify(communicationsModule).requestDM25(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
@@ -613,11 +613,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM25ExpandedFreezeFrame.create(0, freezeFrame);
-        when(diagnosticMessageModule.requestDM25(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM25(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertTrue(instance.checkDM25(listener, SECTION, 0, false));
 
-        verify(diagnosticMessageModule).requestDM25(listener, 0);
+        verify(communicationsModule).requestDM25(listener, 0);
     }
 
     @Test
@@ -628,11 +628,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM25ExpandedFreezeFrame.create(0);
-        when(diagnosticMessageModule.requestDM25(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM25(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertFalse(instance.checkDM25(listener, SECTION, 0, false));
 
-        verify(diagnosticMessageModule).requestDM25(listener, 0);
+        verify(communicationsModule).requestDM25(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, "6.2.3.4.a - Engine #1 (0) erased DM25 data");
     }
 
@@ -645,11 +645,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM31DtcToLampAssociation.create(0, 0);
-        when(diagnosticMessageModule.requestDM31(listener, 0)).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM31(listener, 0)).thenReturn(RequestResult.of(packet));
 
         assertTrue(instance.checkDM31(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM31(listener, 0);
+        verify(communicationsModule).requestDM31(listener, 0);
     }
 
     @Test
@@ -661,11 +661,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM31DtcToLampAssociation.create(0, 0, dtcLampStatus);
-        when(diagnosticMessageModule.requestDM31(listener, 0)).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM31(listener, 0)).thenReturn(RequestResult.of(packet));
 
         assertFalse(instance.checkDM31(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM31(listener, 0);
+        verify(communicationsModule).requestDM31(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
@@ -681,11 +681,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM31DtcToLampAssociation.create(0, 0, dtcLampStatus);
-        when(diagnosticMessageModule.requestDM31(listener, 0)).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM31(listener, 0)).thenReturn(RequestResult.of(packet));
 
         assertTrue(instance.checkDM31(listener, SECTION, 0, false));
 
-        verify(diagnosticMessageModule).requestDM31(listener, 0);
+        verify(communicationsModule).requestDM31(listener, 0);
     }
 
     @Test
@@ -697,11 +697,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM31DtcToLampAssociation.create(0, 0);
-        when(diagnosticMessageModule.requestDM31(listener, 0)).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM31(listener, 0)).thenReturn(RequestResult.of(packet));
 
         assertFalse(instance.checkDM31(listener, SECTION, 0, false));
 
-        verify(diagnosticMessageModule).requestDM31(listener, 0);
+        verify(communicationsModule).requestDM31(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, "6.2.3.4.a - Engine #1 (0) erased DM31 data");
     }
 
@@ -712,11 +712,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM21(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM21(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertTrue(instance.checkDM21(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM21(listener, 0);
+        verify(communicationsModule).requestDM21(listener, 0);
     }
 
     @Test
@@ -726,11 +726,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM21DiagnosticReadinessPacket.create(0, 0, 1, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM21(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM21(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertFalse(instance.checkDM21(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM21(listener, 0);
+        verify(communicationsModule).requestDM21(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
@@ -744,11 +744,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 1, 0);
-        when(diagnosticMessageModule.requestDM21(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM21(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertFalse(instance.checkDM21(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM21(listener, 0);
+        verify(communicationsModule).requestDM21(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
@@ -762,11 +762,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM21DiagnosticReadinessPacket.create(0, 0, 0, 1, 0, 0);
-        when(diagnosticMessageModule.requestDM21(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM21(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertFalse(instance.checkDM21(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM21(listener, 0);
+        verify(communicationsModule).requestDM21(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
@@ -780,11 +780,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 0, 1);
-        when(diagnosticMessageModule.requestDM21(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM21(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertFalse(instance.checkDM21(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM21(listener, 0);
+        verify(communicationsModule).requestDM21(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
@@ -798,11 +798,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 1, 0);
-        when(diagnosticMessageModule.requestDM21(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM21(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertTrue(instance.checkDM21(listener, SECTION, 0, false));
 
-        verify(diagnosticMessageModule).requestDM21(listener, 0);
+        verify(communicationsModule).requestDM21(listener, 0);
     }
 
     @Test
@@ -812,11 +812,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM21(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM21(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertFalse(instance.checkDM21(listener, SECTION, 0, false));
 
-        verify(diagnosticMessageModule).requestDM21(listener, 0);
+        verify(communicationsModule).requestDM21(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, "6.2.3.4.a - Engine #1 (0) erased DM21 data");
     }
 
@@ -827,11 +827,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM26TripDiagnosticReadinessPacket.create(0, 0, 0);
-        when(diagnosticMessageModule.requestDM26(listener, 0)).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM26(listener, 0)).thenReturn(RequestResult.of(packet));
 
         assertTrue(instance.checkDM26(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM26(listener, 0);
+        verify(communicationsModule).requestDM26(listener, 0);
     }
 
     @Test
@@ -841,11 +841,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM26TripDiagnosticReadinessPacket.create(0, 0, 1);
-        when(diagnosticMessageModule.requestDM26(listener, 0)).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM26(listener, 0)).thenReturn(RequestResult.of(packet));
 
         assertFalse(instance.checkDM26(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestDM26(listener, 0);
+        verify(communicationsModule).requestDM26(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
@@ -859,11 +859,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM26TripDiagnosticReadinessPacket.create(0, 0, 1);
-        when(diagnosticMessageModule.requestDM26(listener, 0)).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM26(listener, 0)).thenReturn(RequestResult.of(packet));
 
         assertTrue(instance.checkDM26(listener, SECTION, 0, false));
 
-        verify(diagnosticMessageModule).requestDM26(listener, 0);
+        verify(communicationsModule).requestDM26(listener, 0);
     }
 
     @Test
@@ -873,11 +873,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM26TripDiagnosticReadinessPacket.create(0, 0, 0);
-        when(diagnosticMessageModule.requestDM26(listener, 0)).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM26(listener, 0)).thenReturn(RequestResult.of(packet));
 
         assertFalse(instance.checkDM26(listener, SECTION, 0, false));
 
-        verify(diagnosticMessageModule).requestDM26(listener, 0);
+        verify(communicationsModule).requestDM26(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, "6.2.3.4.a - Engine #1 (0) erased DM26 data");
     }
 
@@ -890,11 +890,11 @@ public class SectionA5MessageVerifierTest {
 
         var ratio = new PerformanceRatio(123, 1, 2, 0);
         var packet = DM20MonitorPerformanceRatioPacket.create(0, 13, 9, ratio);
-        when(diagnosticMessageModule.requestDM20(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM20(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertTrue(instance.checkDM20(listener, SECTION, 0));
 
-        verify(diagnosticMessageModule).requestDM20(listener, 0);
+        verify(communicationsModule).requestDM20(listener, 0);
     }
 
     @Test
@@ -906,11 +906,11 @@ public class SectionA5MessageVerifierTest {
 
         var ratio = new PerformanceRatio(123, 0, 0, 0);
         var packet = DM20MonitorPerformanceRatioPacket.create(0, 0, 0, ratio);
-        when(diagnosticMessageModule.requestDM20(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM20(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertFalse(instance.checkDM20(listener, SECTION, 0));
 
-        verify(diagnosticMessageModule).requestDM20(listener, 0);
+        verify(communicationsModule).requestDM20(listener, 0);
 
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, "6.2.3.4.a - Engine #1 (0) erased DM20 data");
     }
@@ -937,11 +937,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM28PermanentEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM28(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM28(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertTrue(instance.checkDM28(listener, SECTION, 0));
 
-        verify(diagnosticMessageModule).requestDM28(listener, 0);
+        verify(communicationsModule).requestDM28(listener, 0);
     }
 
     @Test
@@ -952,11 +952,11 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM28PermanentEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM28(listener, 0)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM28(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertFalse(instance.checkDM28(listener, SECTION, 0));
 
-        verify(diagnosticMessageModule).requestDM28(listener, 0);
+        verify(communicationsModule).requestDM28(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, "6.2.3.4.a - Engine #1 (0) erased DM28 data");
     }
 
@@ -985,11 +985,11 @@ public class SectionA5MessageVerifierTest {
 
         var timer = EngineHoursTimer.create(1, 2, 3);
         var packet = DM33EmissionIncreasingAECDActiveTime.create(0, 0, timer);
-        when(diagnosticMessageModule.requestDM33(listener, 0)).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM33(listener, 0)).thenReturn(RequestResult.of(packet));
 
         assertTrue(instance.checkDM33(listener, SECTION, 0));
 
-        verify(diagnosticMessageModule).requestDM33(listener, 0);
+        verify(communicationsModule).requestDM33(listener, 0);
     }
 
     @Test
@@ -1001,12 +1001,12 @@ public class SectionA5MessageVerifierTest {
 
         var timer = EngineHoursTimer.create(1, 0, 0);
         var packet = DM33EmissionIncreasingAECDActiveTime.create(0, 0, timer);
-        when(diagnosticMessageModule.requestDM33(listener, 0)).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM33(listener, 0)).thenReturn(RequestResult.of(packet));
 
         boolean condition = instance.checkDM33(listener, SECTION, 0);
         assertFalse(condition);
 
-        verify(diagnosticMessageModule).requestDM33(listener, 0);
+        verify(communicationsModule).requestDM33(listener, 0);
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
@@ -1029,11 +1029,11 @@ public class SectionA5MessageVerifierTest {
 
         var timer = EngineHoursTimer.create(1, 0, 0);
         var packet = DM33EmissionIncreasingAECDActiveTime.create(0, 0, timer);
-        when(diagnosticMessageModule.requestDM33(listener, 0)).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM33(listener, 0)).thenReturn(RequestResult.of(packet));
 
         assertTrue(instance.checkDM33(listener, SECTION, 0));
 
-        verify(diagnosticMessageModule).requestDM33(listener, 0);
+        verify(communicationsModule).requestDM33(listener, 0);
     }
 
     @Test
@@ -1044,11 +1044,11 @@ public class SectionA5MessageVerifierTest {
 
         var tr = ScaledTestResult.create(247, 123, 12, 1, 0, 0, 0);
         var packet = DM30ScaledTestResultsPacket.create(0, 0, tr);
-        when(diagnosticMessageModule.requestTestResult(listener, 0, 247, 123, 31)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestTestResult(listener, 0, 247, 123, 31)).thenReturn(BusResult.of(packet));
 
         assertTrue(instance.checkTestResults(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestTestResult(listener, 0, 247, 123, 31);
+        verify(communicationsModule).requestTestResult(listener, 0, 247, 123, 31);
     }
 
     @Test
@@ -1059,11 +1059,11 @@ public class SectionA5MessageVerifierTest {
 
         var tr = ScaledTestResult.create(247, 123, 12, 1, 1, 0, 0);
         var packet = DM30ScaledTestResultsPacket.create(0, 0, tr);
-        when(diagnosticMessageModule.requestTestResult(listener, 0, 247, 123, 31)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestTestResult(listener, 0, 247, 123, 31)).thenReturn(BusResult.of(packet));
 
         assertFalse(instance.checkTestResults(listener, SECTION, 0, true));
 
-        verify(diagnosticMessageModule).requestTestResult(listener, 0, 247, 123, 31);
+        verify(communicationsModule).requestTestResult(listener, 0, 247, 123, 31);
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -1079,11 +1079,11 @@ public class SectionA5MessageVerifierTest {
 
         var tr = ScaledTestResult.create(247, 123, 12, 1, 1, 0, 0);
         var packet = DM30ScaledTestResultsPacket.create(0, 0, tr);
-        when(diagnosticMessageModule.requestTestResult(listener, 0, 247, 123, 31)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestTestResult(listener, 0, 247, 123, 31)).thenReturn(BusResult.of(packet));
 
         assertTrue(instance.checkTestResults(listener, SECTION, 0, false));
 
-        verify(diagnosticMessageModule).requestTestResult(listener, 0, 247, 123, 31);
+        verify(communicationsModule).requestTestResult(listener, 0, 247, 123, 31);
     }
 
     @Test
@@ -1094,11 +1094,11 @@ public class SectionA5MessageVerifierTest {
 
         var tr = ScaledTestResult.create(247, 123, 12, 1, 0xFB00, 0xFFFF, 0xFFFF);
         var packet = DM30ScaledTestResultsPacket.create(0, 0, tr);
-        when(diagnosticMessageModule.requestTestResult(listener, 0, 247, 123, 31)).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestTestResult(listener, 0, 247, 123, 31)).thenReturn(BusResult.of(packet));
 
         assertFalse(instance.checkTestResults(listener, SECTION, 0, false));
 
-        verify(diagnosticMessageModule).requestTestResult(listener, 0, 247, 123, 31);
+        verify(communicationsModule).requestTestResult(listener, 0, 247, 123, 31);
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01ControllerTest.java
@@ -24,7 +24,7 @@ public class Part01ControllerTest extends AbstractPartControllerTest {
                                         DataRepository.newInstance(),
                                         engineSpeedModule,
                                         vehicleInformationModule,
-                                        diagnosticMessageModule,
+                                        communicationsModule,
                                         step01Controller,
                                         step02Controller,
                                         step03Controller,

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step01ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step01ControllerTest.java
@@ -38,7 +38,7 @@ import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.model.VehicleInformationListener;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -69,7 +69,7 @@ public class Part01Step01ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -102,7 +102,7 @@ public class Part01Step01ControllerTest extends AbstractControllerTest {
                                               engineSpeedModule,
                                               bannerModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               DataRepository.newInstance(),
                                               DateTimeModule.getInstance());
 
@@ -113,7 +113,7 @@ public class Part01Step01ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -122,7 +122,7 @@ public class Part01Step01ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step02ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step02ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -59,7 +59,7 @@ public class Part01Step02ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -92,7 +92,7 @@ public class Part01Step02ControllerTest extends AbstractControllerTest {
                                               DataRepository.newInstance(),
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -101,7 +101,7 @@ public class Part01Step02ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -111,7 +111,7 @@ public class Part01Step02ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step03ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step03ControllerTest.java
@@ -29,7 +29,7 @@ import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -60,7 +60,7 @@ public class Part01Step03ControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -94,7 +94,7 @@ public class Part01Step03ControllerTest {
                                               engineSpeedModule,
                                               bannerModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               dataRepository,
                                               DateTimeModule.getInstance());
     }
@@ -105,7 +105,7 @@ public class Part01Step03ControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -121,7 +121,7 @@ public class Part01Step03ControllerTest {
         List<DM5DiagnosticReadinessPacket> packets = new ArrayList<>();
         List<AcknowledgmentPacket> acks = new ArrayList<>();
         RequestResult<DM5DiagnosticReadinessPacket> requestResult = new RequestResult<>(true, packets, acks);
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(requestResult);
+        when(communicationsModule.requestDM5(any())).thenReturn(requestResult);
 
         DM5DiagnosticReadinessPacket packet1 = mock(DM5DiagnosticReadinessPacket.class);
         packets.add(packet1);
@@ -160,10 +160,10 @@ public class Part01Step03ControllerTest {
         verify(executor).execute(runnableCaptor.capture());
         runnableCaptor.getValue().run();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
+        verify(communicationsModule).setJ1939(j1939);
         verify(engineSpeedModule).setJ1939(j1939);
         verify(vehicleInformationModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any());
 
         verify(mockListener).addOutcome(1, 3, FAIL, "6.1.3.2.b - The request for DM5 was NACK'ed");
         verify(mockListener).addOutcome(1,
@@ -198,15 +198,15 @@ public class Part01Step03ControllerTest {
         when(packet2.getResponse()).thenReturn(Response.DENIED);
         acks.add(packet2);
 
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(requestResult);
+        when(communicationsModule.requestDM5(any())).thenReturn(requestResult);
 
         instance.execute(listener, j1939, reportFileModule);
         ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
         verify(executor).execute(runnableCaptor.capture());
         runnableCaptor.getValue().run();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM5(any());
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM5(any());
 
         verify(engineSpeedModule).setJ1939(j1939);
 
@@ -243,7 +243,7 @@ public class Part01Step03ControllerTest {
         when(packet4.getSourceAddress()).thenReturn(0);
         when(packet4.getOBDCompliance()).thenReturn((byte) 4);
         packets.add(packet4);
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(requestResult);
+        when(communicationsModule.requestDM5(any())).thenReturn(requestResult);
 
         AddressClaimPacket addressClaimPacket = mock(AddressClaimPacket.class);
         when(addressClaimPacket.getSourceAddress()).thenReturn(0);
@@ -260,8 +260,8 @@ public class Part01Step03ControllerTest {
         verify(executor).execute(runnableCaptor.capture());
         runnableCaptor.getValue().run();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM5(any());
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM5(any());
 
         verify(engineSpeedModule).setJ1939(j1939);
 

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step04ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step04ControllerTest.java
@@ -36,7 +36,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.SupportedSpnModule;
@@ -78,7 +78,7 @@ public class Part01Step04ControllerTest extends AbstractControllerTest {
     @Mock
     private ResultsListener mockListener;
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
     @Mock
     private ReportFileModule reportFileModule;
     @Mock
@@ -107,7 +107,7 @@ public class Part01Step04ControllerTest extends AbstractControllerTest {
                                               engineSpeedModule,
                                               bannerModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               supportedSpnModule,
                                               dataRepository,
                                               DateTimeModule.getInstance());
@@ -119,7 +119,7 @@ public class Part01Step04ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -128,7 +128,7 @@ public class Part01Step04ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener,
                                  supportedSpnModule);
     }
@@ -141,7 +141,7 @@ public class Part01Step04ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
-        when(diagnosticMessageModule.requestDM24(any(), eq(0)))
+        when(communicationsModule.requestDM24(any(), eq(0)))
                                                                .thenReturn(BusResult.of(packet1));
 
         VehicleInformation vehicleInfo = new VehicleInformation();
@@ -150,8 +150,8 @@ public class Part01Step04ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM24(any(), eq(0));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM24(any(), eq(0));
 
         verify(engineSpeedModule).setJ1939(j1939);
 
@@ -197,11 +197,11 @@ public class Part01Step04ControllerTest extends AbstractControllerTest {
         when(packet1.getSourceAddress()).thenReturn(0);
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
-        when(diagnosticMessageModule.requestDM24(any(), eq(0))).thenReturn(BusResult.of(packet1));
+        when(communicationsModule.requestDM24(any(), eq(0))).thenReturn(BusResult.of(packet1));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         AcknowledgmentPacket packet4 = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM24(any(), eq(1)))
+        when(communicationsModule.requestDM24(any(), eq(1)))
                                                                .thenReturn(BusResult.empty())
                                                                .thenReturn(BusResult.of(packet4));
 
@@ -212,9 +212,9 @@ public class Part01Step04ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM24(any(), eq(0));
-        verify(diagnosticMessageModule, times(2)).requestDM24(any(), eq(1));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM24(any(), eq(0));
+        verify(communicationsModule, times(2)).requestDM24(any(), eq(1));
 
         verify(engineSpeedModule).setJ1939(j1939);
 
@@ -283,7 +283,7 @@ public class Part01Step04ControllerTest extends AbstractControllerTest {
                                                                               0x1B,
                                                                               0x01));
 
-        when(diagnosticMessageModule.requestDM24(any(), eq(0))).thenReturn(BusResult.of(packet1));
+        when(communicationsModule.requestDM24(any(), eq(0))).thenReturn(BusResult.of(packet1));
 
         //@formatter:off
         DM24SPNSupportPacket packet4 = new DM24SPNSupportPacket(Packet.create(DM24SPNSupportPacket.PGN,
@@ -322,7 +322,7 @@ public class Part01Step04ControllerTest extends AbstractControllerTest {
                 0x00, 0x1F, 0x00, 0x00, 0x00, 0x1F, 0x00, 0x00, 0x00, 0x1F, 0x00, 0x00, 0x00, 0x1F, 0x00));
         //@formatter:on
 
-        when(diagnosticMessageModule.requestDM24(any(), eq(1))).thenReturn(BusResult.of(packet4));
+        when(communicationsModule.requestDM24(any(), eq(1))).thenReturn(BusResult.of(packet4));
 
         VehicleInformation vehicleInfo = new VehicleInformation();
         vehicleInfo.setFuelType(BI_GAS);
@@ -333,9 +333,9 @@ public class Part01Step04ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM24(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM24(any(), eq(1));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM24(any(), eq(0));
+        verify(communicationsModule).requestDM24(any(), eq(1));
 
         verify(engineSpeedModule).setJ1939(j1939);
 

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step06ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step06ControllerTest.java
@@ -25,7 +25,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -67,7 +67,7 @@ public class Part01Step06ControllerTest extends AbstractControllerTest {
     @Mock
     private VehicleInformationModule vehicleInformationModule;
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     /*
      * All values must be checked prior to mocking so that we are not creating
@@ -111,7 +111,7 @@ public class Part01Step06ControllerTest extends AbstractControllerTest {
                                               vehicleInformationModule,
                                               dataRepository,
                                               DateTimeModule.getInstance(),
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -120,7 +120,7 @@ public class Part01Step06ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
 
     }
 
@@ -131,7 +131,7 @@ public class Part01Step06ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  vehicleInformationModule,
                                  mockListener,
-                                 diagnosticMessageModule);
+                                 communicationsModule);
     }
 
     /**
@@ -145,7 +145,7 @@ public class Part01Step06ControllerTest extends AbstractControllerTest {
         String famName = familyName.replace("A", "*");
 
         List<DM56EngineFamilyPacket> parsedPackets = List.of(createDM56(2006, "2006E-MY", famName));
-        when(diagnosticMessageModule.requestDM56(any())).thenReturn(parsedPackets);
+        when(communicationsModule.requestDM56(any())).thenReturn(parsedPackets);
 
         runTest();
 
@@ -154,7 +154,7 @@ public class Part01Step06ControllerTest extends AbstractControllerTest {
                                         FAIL,
                                         "6.1.6.2.e. - Engine family has <> 12 characters before first asterisk character (ASCII 0x2A)");
 
-        verify(diagnosticMessageModule).requestDM56(any());
+        verify(communicationsModule).requestDM56(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -169,7 +169,7 @@ public class Part01Step06ControllerTest extends AbstractControllerTest {
         String famName = familyName.replace("*", "44*");
 
         List<DM56EngineFamilyPacket> parsedPackets = List.of(createDM56(2006, "2006E-MY", famName));
-        when(diagnosticMessageModule.requestDM56(any())).thenReturn(parsedPackets);
+        when(communicationsModule.requestDM56(any())).thenReturn(parsedPackets);
 
         runTest();
 
@@ -178,7 +178,7 @@ public class Part01Step06ControllerTest extends AbstractControllerTest {
                                         FAIL,
                                         "6.1.6.2.e. - Engine family has <> 12 characters before first asterisk character (ASCII 0x2A)");
 
-        verify(diagnosticMessageModule).requestDM56(any());
+        verify(communicationsModule).requestDM56(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -191,13 +191,13 @@ public class Part01Step06ControllerTest extends AbstractControllerTest {
     @TestDoc(value = @TestItem(verifies = "6.1.6.2.a", description = "Engine model year does not match user input"))
     public void testEngineModelYearDoesNotMatch() {
         List<DM56EngineFamilyPacket> parsedPackets = List.of(createDM56(2010, "2010E-MY", familyName));
-        when(diagnosticMessageModule.requestDM56(any())).thenReturn(parsedPackets);
+        when(communicationsModule.requestDM56(any())).thenReturn(parsedPackets);
 
         runTest();
 
         verify(mockListener).addOutcome(1, 6, FAIL, "6.1.6.2.a - Engine model year does not match user input");
 
-        verify(diagnosticMessageModule).requestDM56(any());
+        verify(communicationsModule).requestDM56(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -212,7 +212,7 @@ public class Part01Step06ControllerTest extends AbstractControllerTest {
         String famName = familyName.replace(" OBD*", "");
 
         List<DM56EngineFamilyPacket> parsedPackets = List.of(createDM56(2006, "2006E-MY", famName));
-        when(diagnosticMessageModule.requestDM56(any())).thenReturn(parsedPackets);
+        when(communicationsModule.requestDM56(any())).thenReturn(parsedPackets);
 
         runTest();
 
@@ -221,7 +221,7 @@ public class Part01Step06ControllerTest extends AbstractControllerTest {
                                         FAIL,
                                         "6.1.6.2.e. - Engine family has <> 12 characters before first 'null' character (ASCII 0x00)");
 
-        verify(diagnosticMessageModule).requestDM56(any());
+        verify(communicationsModule).requestDM56(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -238,11 +238,11 @@ public class Part01Step06ControllerTest extends AbstractControllerTest {
         String famName = familyName.replace('*', Character.MIN_VALUE);
 
         List<DM56EngineFamilyPacket> parsedPackets = List.of(createDM56(2006, "2006E-MY", famName));
-        when(diagnosticMessageModule.requestDM56(any())).thenReturn(parsedPackets);
+        when(communicationsModule.requestDM56(any())).thenReturn(parsedPackets);
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM56(any());
+        verify(communicationsModule).requestDM56(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -259,7 +259,7 @@ public class Part01Step06ControllerTest extends AbstractControllerTest {
         String famName = familyName.replace("*", "4");
 
         List<DM56EngineFamilyPacket> parsedPackets = List.of(createDM56(2006, "2006E-MY", famName));
-        when(diagnosticMessageModule.requestDM56(any())).thenReturn(parsedPackets);
+        when(communicationsModule.requestDM56(any())).thenReturn(parsedPackets);
 
         runTest();
 
@@ -268,7 +268,7 @@ public class Part01Step06ControllerTest extends AbstractControllerTest {
                                         FAIL,
                                         "6.1.6.2.e. - Engine family has <> 12 characters before first 'null' character (ASCII 0x00)");
 
-        verify(diagnosticMessageModule).requestDM56(any());
+        verify(communicationsModule).requestDM56(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -295,14 +295,14 @@ public class Part01Step06ControllerTest extends AbstractControllerTest {
                     + "Not formatted correctly")
     public void testModelYearField() {
         List<DM56EngineFamilyPacket> parsedPackets = List.of(createDM56(2006, "2006V-MY", familyName));
-        when(diagnosticMessageModule.requestDM56(any())).thenReturn(parsedPackets);
+        when(communicationsModule.requestDM56(any())).thenReturn(parsedPackets);
 
         runTest();
 
         verify(mockListener).addOutcome(1, 6, FAIL, "6.1.6.2.b - Indicates 'V' instead of 'E' for cert type");
         verify(mockListener).addOutcome(1, 6, FAIL, "6.1.6.2.c - Not formatted correctly");
 
-        verify(diagnosticMessageModule).requestDM56(any());
+        verify(communicationsModule).requestDM56(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -314,11 +314,11 @@ public class Part01Step06ControllerTest extends AbstractControllerTest {
     @Test
     @TestDoc(value = @TestItem(verifies = "6.1.6", description = "No packets are returned"))
     public void testPacketsEmpty() {
-        when(diagnosticMessageModule.requestDM56(any())).thenReturn(List.of());
+        when(communicationsModule.requestDM56(any())).thenReturn(List.of());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM56(any());
+        verify(communicationsModule).requestDM56(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("6.1.6.1.a - DM56 is not supported" + NL, listener.getResults());
@@ -331,13 +331,13 @@ public class Part01Step06ControllerTest extends AbstractControllerTest {
     @TestDoc(value = @TestItem(verifies = "6.1.6", description = "Happy Path with no errors and one packet"))
     public void testRunHappyPath() {
         DM56EngineFamilyPacket dm56 = DM56EngineFamilyPacket.create(0, 2006, true, familyName);
-        when(diagnosticMessageModule.requestDM56(any())).thenReturn(List.of(dm56));
+        when(communicationsModule.requestDM56(any())).thenReturn(List.of(dm56));
 
         runTest();
 
         assertSame(dm56, dataRepository.getObdModule(0).getLatest(DM56EngineFamilyPacket.class));
 
-        verify(diagnosticMessageModule).requestDM56(any());
+        verify(communicationsModule).requestDM56(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step07ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step07ControllerTest.java
@@ -33,7 +33,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -65,7 +65,7 @@ public class Part01Step07ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
     @Mock
     private EngineSpeedModule engineSpeedModule;
     @Mock
@@ -103,7 +103,7 @@ public class Part01Step07ControllerTest extends AbstractControllerTest {
                                               vehicleInformationModule,
                                               dataRepository,
                                               DateTimeModule.getInstance(),
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -112,7 +112,7 @@ public class Part01Step07ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -121,7 +121,7 @@ public class Part01Step07ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step08ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step08ControllerTest.java
@@ -25,7 +25,7 @@ import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -51,7 +51,7 @@ public class Part01Step08ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
     @Mock
     private EngineSpeedModule engineSpeedModule;
     @Mock
@@ -91,7 +91,7 @@ public class Part01Step08ControllerTest extends AbstractControllerTest {
                                               engineSpeedModule,
                                               bannerModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               dataRepository,
                                               DateTimeModule.getInstance());
 
@@ -102,7 +102,7 @@ public class Part01Step08ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
 
     }
 
@@ -113,7 +113,7 @@ public class Part01Step08ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -127,7 +127,7 @@ public class Part01Step08ControllerTest extends AbstractControllerTest {
 
         DM20MonitorPerformanceRatioPacket dm20 = createDM20(0, SPs);
 
-        when(diagnosticMessageModule.requestDM20(any())).thenReturn(RequestResult.of(dm20));
+        when(communicationsModule.requestDM20(any())).thenReturn(RequestResult.of(dm20));
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
@@ -137,7 +137,7 @@ public class Part01Step08ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any());
+        verify(communicationsModule).requestDM20(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -154,7 +154,7 @@ public class Part01Step08ControllerTest extends AbstractControllerTest {
         List<Integer> SPs = List.of(3058, 3064, 5321, 3055);
         DM20MonitorPerformanceRatioPacket dm20 = createDM20(0, SPs);
 
-        when(diagnosticMessageModule.requestDM20(any())).thenReturn(RequestResult.of(dm20));
+        when(communicationsModule.requestDM20(any())).thenReturn(RequestResult.of(dm20));
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
@@ -164,7 +164,7 @@ public class Part01Step08ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any());
+        verify(communicationsModule).requestDM20(any());
 
         verify(mockListener).addOutcome(1,
                                         8,
@@ -186,7 +186,7 @@ public class Part01Step08ControllerTest extends AbstractControllerTest {
         List<Integer> SPs = List.of(3058, 3306, 3053, 3050, 3051, 3055, 3056, 3057);
         DM20MonitorPerformanceRatioPacket dm20 = createDM20(0, SPs);
 
-        when(diagnosticMessageModule.requestDM20(any())).thenReturn(RequestResult.of(dm20));
+        when(communicationsModule.requestDM20(any())).thenReturn(RequestResult.of(dm20));
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
@@ -196,8 +196,8 @@ public class Part01Step08ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM20(any());
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM20(any());
 
         verify(mockListener).addOutcome(1,
                                         8,
@@ -219,7 +219,7 @@ public class Part01Step08ControllerTest extends AbstractControllerTest {
 
         DM20MonitorPerformanceRatioPacket dm20 = createDM20(0, SPs);
 
-        when(diagnosticMessageModule.requestDM20(any())).thenReturn(RequestResult.of(dm20));
+        when(communicationsModule.requestDM20(any())).thenReturn(RequestResult.of(dm20));
 
         VehicleInformation vehicleInformation = new VehicleInformation();
         vehicleInformation.setFuelType(FuelType.DSL);
@@ -227,7 +227,7 @@ public class Part01Step08ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any());
+        verify(communicationsModule).requestDM20(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -245,7 +245,7 @@ public class Part01Step08ControllerTest extends AbstractControllerTest {
 
         DM20MonitorPerformanceRatioPacket dm20 = createDM20(0, SPs);
 
-        when(diagnosticMessageModule.requestDM20(any())).thenReturn(RequestResult.of(dm20));
+        when(communicationsModule.requestDM20(any())).thenReturn(RequestResult.of(dm20));
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
@@ -255,7 +255,7 @@ public class Part01Step08ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any());
+        verify(communicationsModule).requestDM20(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -268,7 +268,7 @@ public class Part01Step08ControllerTest extends AbstractControllerTest {
     @Test
     @TestDoc(value = @TestItem(verifies = "6.1.8.2.a", description = "A.4 - Compression Ignition Engine Minimum SPs Verified: none - empty packet returned"))
     public void testEmptyPacketsCompressionIgnition() {
-        when(diagnosticMessageModule.requestDM20(any())).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM20(any())).thenReturn(RequestResult.empty());
 
         VehicleInformation vehicleInformation = new VehicleInformation();
         vehicleInformation.setFuelType(FuelType.DSL);
@@ -276,7 +276,7 @@ public class Part01Step08ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any());
+        verify(communicationsModule).requestDM20(any());
 
         verify(mockListener).addOutcome(1,
                                         8,
@@ -294,7 +294,7 @@ public class Part01Step08ControllerTest extends AbstractControllerTest {
     @Test
     @TestDoc(value = @TestItem(verifies = "6.1.8.2.a", description = "A.4 - Spark Ignition Engine Minimum SPs Verified: none - empty packet returned"))
     public void testEmptyPacketsSparkIgnition() {
-        when(diagnosticMessageModule.requestDM20(any())).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM20(any())).thenReturn(RequestResult.empty());
 
         VehicleInformation vehicleInformation = new VehicleInformation();
         vehicleInformation.setFuelType(FuelType.BI_CNG);
@@ -302,7 +302,7 @@ public class Part01Step08ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any());
+        verify(communicationsModule).requestDM20(any());
 
         verify(mockListener).addOutcome(1,
                                         8,
@@ -333,7 +333,7 @@ public class Part01Step08ControllerTest extends AbstractControllerTest {
         List<Integer> sps = List.of(5322, 5318, 3058, 3064, 5321, 3055);
         DM20MonitorPerformanceRatioPacket dm20 = createDM20(0, sps);
 
-        when(diagnosticMessageModule.requestDM20(any())).thenReturn(RequestResult.of(dm20));
+        when(communicationsModule.requestDM20(any())).thenReturn(RequestResult.of(dm20));
 
         VehicleInformation vehicleInformation = new VehicleInformation();
         vehicleInformation.setFuelType(FuelType.BI_DSL);
@@ -341,7 +341,7 @@ public class Part01Step08ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any());
+        verify(communicationsModule).requestDM20(any());
 
         verify(mockListener).addOutcome(1,
                                         8,
@@ -364,7 +364,7 @@ public class Part01Step08ControllerTest extends AbstractControllerTest {
 
         DM20MonitorPerformanceRatioPacket dm20 = createDM20(0x00, SPs);
 
-        when(diagnosticMessageModule.requestDM20(any())).thenReturn(RequestResult.of(dm20));
+        when(communicationsModule.requestDM20(any())).thenReturn(RequestResult.of(dm20));
 
         dataRepository.putObdModule(new OBDModuleInformation(0x00));
 
@@ -375,7 +375,7 @@ public class Part01Step08ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(ResultsListener.class));
+        verify(communicationsModule).requestDM20(any(ResultsListener.class));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -433,7 +433,7 @@ public class Part01Step08ControllerTest extends AbstractControllerTest {
                                                                                                                1,
                                                                                                                0x00));
 
-        when(diagnosticMessageModule.requestDM20(any())).thenReturn(RequestResult.of(dm20));
+        when(communicationsModule.requestDM20(any())).thenReturn(RequestResult.of(dm20));
 
         dataRepository.putObdModule(new OBDModuleInformation(0x00));
 
@@ -443,7 +443,7 @@ public class Part01Step08ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any());
+        verify(communicationsModule).requestDM20(any());
 
         verify(mockListener).addOutcome(1,
                                         8,

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step09ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step09ControllerTest.java
@@ -29,7 +29,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -87,7 +87,7 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -135,7 +135,7 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
                                               vehicleInformationModule,
                                               dataRepository,
                                               DateTimeModule.getInstance(),
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -144,7 +144,7 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step10ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step10ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -55,7 +55,7 @@ public class Part01Step10ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -91,7 +91,7 @@ public class Part01Step10ControllerTest extends AbstractControllerTest {
                                               engineSpeedModule,
                                               bannerModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               dateTimeModule,
                                               dataRepository);
         setup(instance,
@@ -101,7 +101,7 @@ public class Part01Step10ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -110,7 +110,7 @@ public class Part01Step10ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -135,14 +135,14 @@ public class Part01Step10ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
         dataRepository.putObdModule(new OBDModuleInformation(2));
 
-        when(diagnosticMessageModule.requestDM11(any(ResultsListener.class),
-                                                 eq(5L),
-                                                 eq(SECONDS))).thenReturn(acknowledgmentPackets);
+        when(communicationsModule.requestDM11(any(ResultsListener.class),
+                                              eq(5L),
+                                              eq(SECONDS))).thenReturn(acknowledgmentPackets);
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM11(any(), eq(5L), eq(SECONDS));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM11(any(), eq(5L), eq(SECONDS));
 
         verify(mockListener).addOutcome(1, 10, FAIL, "6.1.10.2.a - The request for DM11 was NACK'ed by Engine #2 (1)");
 
@@ -168,12 +168,12 @@ public class Part01Step10ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
-        when(diagnosticMessageModule.requestDM11(any(), eq(5L), eq(SECONDS))).thenReturn(acknowledgmentPackets);
+        when(communicationsModule.requestDM11(any(), eq(5L), eq(SECONDS))).thenReturn(acknowledgmentPackets);
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM11(any(ResultsListener.class), eq(5L), eq(SECONDS));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM11(any(ResultsListener.class), eq(5L), eq(SECONDS));
 
         verify(mockListener).addOutcome(1, 10, WARN, "6.1.10.3.a - The request for DM11 was ACK'ed by Engine #1 (0)");
 
@@ -215,15 +215,15 @@ public class Part01Step10ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
-        when(diagnosticMessageModule.requestDM11(any(ResultsListener.class),
-                                                 eq(5L),
-                                                 eq(SECONDS))).thenReturn(List.of(acknowledgmentPacket));
+        when(communicationsModule.requestDM11(any(ResultsListener.class),
+                                              eq(5L),
+                                              eq(SECONDS))).thenReturn(List.of(acknowledgmentPacket));
 
         runTest();
 
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM11(any(ResultsListener.class), eq(5L), eq(SECONDS));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM11(any(ResultsListener.class), eq(5L), eq(SECONDS));
 
         String expectedMessages = "";
         assertEquals(expectedMessages, listener.getMessages());
@@ -238,14 +238,14 @@ public class Part01Step10ControllerTest extends AbstractControllerTest {
             @TestItem(verifies = "6.1.10.1.c", description = "Pass if no response to the global DM11 query has been received in 5 s") })
     public void testNoResponseInFiveSeconds() {
 
-        when(diagnosticMessageModule.requestDM11(any(ResultsListener.class),
-                                                 eq(5L),
-                                                 eq(SECONDS))).thenReturn(List.of());
+        when(communicationsModule.requestDM11(any(ResultsListener.class),
+                                              eq(5L),
+                                              eq(SECONDS))).thenReturn(List.of());
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM11(any(ResultsListener.class), eq(5L), eq(SECONDS));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM11(any(ResultsListener.class), eq(5L), eq(SECONDS));
 
         String expectedMessages = "";
         assertEquals(expectedMessages, listener.getMessages());
@@ -262,14 +262,14 @@ public class Part01Step10ControllerTest extends AbstractControllerTest {
     public void testNackReturnedToDm11Request() {
         AcknowledgmentPacket ackPacket = AcknowledgmentPacket.create(0, NACK);
         dataRepository.putObdModule(new OBDModuleInformation(0));
-        when(diagnosticMessageModule.requestDM11(any(ResultsListener.class),
-                                                 eq(5L),
-                                                 eq(SECONDS))).thenReturn(List.of(ackPacket));
+        when(communicationsModule.requestDM11(any(ResultsListener.class),
+                                              eq(5L),
+                                              eq(SECONDS))).thenReturn(List.of(ackPacket));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM11(any(ResultsListener.class), eq(5L), eq(SECONDS));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM11(any(ResultsListener.class), eq(5L), eq(SECONDS));
 
         verify(mockListener).addOutcome(1,
                                         10,

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step11ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step11ControllerTest.java
@@ -29,7 +29,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -57,7 +57,7 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -90,7 +90,7 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
         instance = new Part01Step11Controller(executor,
                                               engineSpeedModule,
                                               bannerModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               vehicleInformationModule,
                                               dataRepository,
                                               DateTimeModule.getInstance());
@@ -101,7 +101,7 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -109,7 +109,7 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
         verifyNoMoreInteractions(executor,
                                  engineSpeedModule,
                                  bannerModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  vehicleInformationModule,
                                  mockListener);
     }
@@ -171,15 +171,15 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0x21));
 
         // return empty list
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class)))
                                                         .thenReturn(new RequestResult<>(false, List.of(), List.of()));
 
         DM21DiagnosticReadinessPacket packet4 = create(0x00, 0, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0x00)))
+        when(communicationsModule.requestDM21(any(), eq(0x00)))
                                                                .thenReturn(new BusResult<>(false, packet4));
 
         DM21DiagnosticReadinessPacket packet5 = create(0x17, 0, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class), eq(0x17)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class), eq(0x17)))
                                                                 .thenReturn(new BusResult<>(false, packet5));
 
         AcknowledgmentPacket ackPacket = AcknowledgmentPacket.create(0x21,
@@ -187,17 +187,17 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
                                                                      0,
                                                                      0x21,
                                                                      DM21DiagnosticReadinessPacket.PGN);
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class), eq(0x21)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class), eq(0x21)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    ackPacket));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM21(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM21(any(ResultsListener.class), eq(0x00));
-        verify(diagnosticMessageModule).requestDM21(any(ResultsListener.class), eq(0x17));
-        verify(diagnosticMessageModule).requestDM21(any(ResultsListener.class), eq(0x21));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM21(any(ResultsListener.class));
+        verify(communicationsModule).requestDM21(any(ResultsListener.class), eq(0x00));
+        verify(communicationsModule).requestDM21(any(ResultsListener.class), eq(0x17));
+        verify(communicationsModule).requestDM21(any(ResultsListener.class), eq(0x21));
 
         verify(mockListener).addOutcome(1,
                                         11,
@@ -291,21 +291,21 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
         List<DM21DiagnosticReadinessPacket> globalPackets = new ArrayList<>();
 
         DM21DiagnosticReadinessPacket packet0x00 = create(0x00, 0, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class), eq(0x00)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class), eq(0x00)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    packet0x00));
         globalPackets.add(packet0x00);
 
         DM21DiagnosticReadinessPacket packet0x17 = create(0x17, 0, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class), eq(0x17)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class), eq(0x17)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    packet0x17));
         globalPackets.add(packet0x17);
 
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class), eq(0x21)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class), eq(0x21)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    Optional.empty()));
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class)))
                                                                              .thenReturn(new RequestResult<>(false,
                                                                                                              globalPackets,
                                                                                                              List.of()));
@@ -313,11 +313,11 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM21(any());
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0x17));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0x21));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM21(any());
+        verify(communicationsModule).requestDM21(any(), eq(0x00));
+        verify(communicationsModule).requestDM21(any(), eq(0x17));
+        verify(communicationsModule).requestDM21(any(), eq(0x21));
 
         verify(mockListener).addOutcome(1,
                                         11,
@@ -387,7 +387,7 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
         List<DM21DiagnosticReadinessPacket> globalPackets = new ArrayList<>();
 
         DM21DiagnosticReadinessPacket packet0x00 = create(0x00, 0, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class), eq(0x00)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class), eq(0x00)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    packet0x00));
         globalPackets.add(packet0x00);
@@ -396,28 +396,28 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
         globalPackets.add(packet0x17);
 
         DM21DiagnosticReadinessPacket dsPacket0x17 = create(0x17, 0, 0, 0, 2, 0);
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class), eq(0x17)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class), eq(0x17)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    dsPacket0x17));
 
         DM21DiagnosticReadinessPacket packet0x21 = create(0x21, 0, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class), eq(0x21)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class), eq(0x21)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    packet0x21));
         globalPackets.add(packet0x21);
 
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class)))
                                                                              .thenReturn(new RequestResult<>(false,
                                                                                                              globalPackets,
                                                                                                              List.of()));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM21(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM21(any(ResultsListener.class), eq(0x00));
-        verify(diagnosticMessageModule).requestDM21(any(ResultsListener.class), eq(0x17));
-        verify(diagnosticMessageModule).requestDM21(any(ResultsListener.class), eq(0x21));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM21(any(ResultsListener.class));
+        verify(communicationsModule).requestDM21(any(ResultsListener.class), eq(0x00));
+        verify(communicationsModule).requestDM21(any(ResultsListener.class), eq(0x17));
+        verify(communicationsModule).requestDM21(any(ResultsListener.class), eq(0x21));
 
         verify(mockListener).addOutcome(1,
                                         11,
@@ -500,7 +500,7 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
         List<DM21DiagnosticReadinessPacket> globalPackets = new ArrayList<>();
 
         DM21DiagnosticReadinessPacket packet0x00 = create(0x00, 0, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class), eq(0x00)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class), eq(0x00)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    packet0x00));
         globalPackets.add(packet0x00);
@@ -510,31 +510,31 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
                                                                          0,
                                                                          0x09,
                                                                          DM21DiagnosticReadinessPacket.PGN);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0x09)))
+        when(communicationsModule.requestDM21(any(), eq(0x09)))
                                                                   .thenReturn(new BusResult<>(false, ackPacket0x09));
 
         DM21DiagnosticReadinessPacket packet0x17 = create(0x17, 0, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0x17)))
+        when(communicationsModule.requestDM21(any(), eq(0x17)))
                                                                   .thenReturn(new BusResult<>(false, packet0x17));
         globalPackets.add(packet0x17);
 
         DM21DiagnosticReadinessPacket packet0x21 = create(0x21, 0, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class), eq(0x21)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class), eq(0x21)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    packet0x21));
 
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class))).thenReturn(new RequestResult<>(false,
-                                                                                        globalPackets,
-                                                                                        List.of()));
+        when(communicationsModule.requestDM21(any(ResultsListener.class))).thenReturn(new RequestResult<>(false,
+                                                                                                          globalPackets,
+                                                                                                          List.of()));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM21(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM21(any(ResultsListener.class), eq(0x00));
-        verify(diagnosticMessageModule).requestDM21(any(ResultsListener.class), eq(0x09));
-        verify(diagnosticMessageModule).requestDM21(any(ResultsListener.class), eq(0x17));
-        verify(diagnosticMessageModule).requestDM21(any(ResultsListener.class), eq(0x21));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM21(any(ResultsListener.class));
+        verify(communicationsModule).requestDM21(any(ResultsListener.class), eq(0x00));
+        verify(communicationsModule).requestDM21(any(ResultsListener.class), eq(0x09));
+        verify(communicationsModule).requestDM21(any(ResultsListener.class), eq(0x17));
+        verify(communicationsModule).requestDM21(any(ResultsListener.class), eq(0x21));
 
         verify(mockListener).addOutcome(1,
                                         11,
@@ -614,21 +614,21 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
         DM21DiagnosticReadinessPacket packet0x00 = create(0x00, 0, 0, 0, 0, 0);
         packets.add(packet0x00);
         // Destination Specific response
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class), eq(0x00)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class), eq(0x00)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    packet0x00));
         // Global response
         DM21DiagnosticReadinessPacket packet0x09 = create(0x09, 0, 0, 0, 0, 0);
         packets.add(packet0x09);
         // Destination Specific response
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class), eq(0x09)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class), eq(0x09)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    Optional.empty()));
         // Global response
         DM21DiagnosticReadinessPacket packet0x17 = create(0x17, 0, 0, 0, 0, 0);
         packets.add(packet0x17);
         // Destination Specific response
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class), eq(0x17)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class), eq(0x17)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    packet0x17));
 
@@ -636,21 +636,21 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
         DM21DiagnosticReadinessPacket packet0x21 = create(0x21, 0, 0, 0, 0, 0);
         packets.add(packet0x21);
         // Destination Specific response
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class),
-                                                 eq(0x21))).thenReturn(new BusResult<>(false,
+        when(communicationsModule.requestDM21(any(ResultsListener.class),
+                                              eq(0x21))).thenReturn(new BusResult<>(false,
                                                                                        packet0x21));
         // returned RequestResult
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class))).thenReturn(new RequestResult<>(false,
-                                                                                                             packets,
-                                                                                                             List.of()));
+        when(communicationsModule.requestDM21(any(ResultsListener.class))).thenReturn(new RequestResult<>(false,
+                                                                                                          packets,
+                                                                                                          List.of()));
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM21(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM21(any(ResultsListener.class), eq(0x00));
-        verify(diagnosticMessageModule).requestDM21(any(ResultsListener.class), eq(0x09));
-        verify(diagnosticMessageModule).requestDM21(any(ResultsListener.class), eq(0x17));
-        verify(diagnosticMessageModule).requestDM21(any(ResultsListener.class), eq(0x21));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM21(any(ResultsListener.class));
+        verify(communicationsModule).requestDM21(any(ResultsListener.class), eq(0x00));
+        verify(communicationsModule).requestDM21(any(ResultsListener.class), eq(0x09));
+        verify(communicationsModule).requestDM21(any(ResultsListener.class), eq(0x17));
+        verify(communicationsModule).requestDM21(any(ResultsListener.class), eq(0x21));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -723,29 +723,29 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
         packets.add(packet17);
         packets.add(packet21);
         // Global DM21 request response - return packets
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class)))
                                                                              .thenReturn(new RequestResult<>(false,
                                                                                                              packets,
                                                                                                              List.of()));
         // DS to 0x00 response - return packet0
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class), eq(0x00)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class), eq(0x00)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    packet0));
         // DS to 0x17 response - return packet17
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class), eq(0x17)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class), eq(0x17)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    packet17));
 
-        when(diagnosticMessageModule.requestDM21(any(), eq(0x21)))
+        when(communicationsModule.requestDM21(any(), eq(0x21)))
                                                                   .thenReturn(new BusResult<>(false, packet21));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM21(any());
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0x17));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0x21));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM21(any());
+        verify(communicationsModule).requestDM21(any(), eq(0x00));
+        verify(communicationsModule).requestDM21(any(), eq(0x17));
+        verify(communicationsModule).requestDM21(any(), eq(0x21));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -818,30 +818,30 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
         packets.add(globalPacket0x00);
         packets.add(globalPacket0x17);
         packets.add(globalPacket0x21);
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class)))
                                                                              .thenReturn(new RequestResult<>(false,
                                                                                                              packets,
                                                                                                              List.of()));
 
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class), eq(0x00)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class), eq(0x00)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    globalPacket0x00));
 
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class), eq(0x17)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class), eq(0x17)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    globalPacket0x17));
 
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class), eq(0x21)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class), eq(0x21)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    globalPacket0x21));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0x17));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0x21));
-        verify(diagnosticMessageModule).requestDM21(any());
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM21(any(), eq(0x00));
+        verify(communicationsModule).requestDM21(any(), eq(0x17));
+        verify(communicationsModule).requestDM21(any(), eq(0x21));
+        verify(communicationsModule).requestDM21(any());
 
         verify(mockListener).addOutcome(1,
                                         11,
@@ -918,13 +918,13 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
         List<DM21DiagnosticReadinessPacket> packets = new ArrayList<>();
 
         DM21DiagnosticReadinessPacket packet0x00 = create(0x00, 0, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class), eq(0x00)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class), eq(0x00)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    packet0x00));
         packets.add(packet0x00);
 
         DM21DiagnosticReadinessPacket packet0x17 = create(0x17, 0, 10, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class), eq(0x17)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class), eq(0x17)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    packet0x17));
         packets.add(packet0x17);
@@ -935,22 +935,22 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
                                                                                         0,
                                                                                         0,
                                                                                         0);
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class), eq(0x21)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class), eq(0x21)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    packet0x21));
         packets.add(packet0x21);
-        when(diagnosticMessageModule.requestDM21(any(ResultsListener.class)))
+        when(communicationsModule.requestDM21(any(ResultsListener.class)))
                                                                              .thenReturn(new RequestResult<>(false,
                                                                                                              packets,
                                                                                                              List.of()));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM21(any());
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0x17));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0x21));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM21(any());
+        verify(communicationsModule).requestDM21(any(), eq(0x00));
+        verify(communicationsModule).requestDM21(any(), eq(0x17));
+        verify(communicationsModule).requestDM21(any(), eq(0x21));
 
         verify(mockListener).addOutcome(1,
                                         11,
@@ -1028,28 +1028,28 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
 
         DM21DiagnosticReadinessPacket packet0x00 = create(0x00, 0, 0, 0, 0, 0);
         packets.add(packet0x00);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0x00)))
+        when(communicationsModule.requestDM21(any(), eq(0x00)))
                                                                   .thenReturn(new BusResult<>(false, packet0x00));
 
         DM21DiagnosticReadinessPacket packet0x17 = create(0x17, 0, 0, 0, 20, 0);
         packets.add(packet0x17);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0x17)))
+        when(communicationsModule.requestDM21(any(), eq(0x17)))
                                                                   .thenReturn(new BusResult<>(false, packet0x17));
 
         DM21DiagnosticReadinessPacket packet0x21 = create(0x21, 0, 0, 0, 0, 0);
         packets.add(packet0x21);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0x21)))
+        when(communicationsModule.requestDM21(any(), eq(0x21)))
                                                                   .thenReturn(new BusResult<>(false, packet0x21));
-        when(diagnosticMessageModule.requestDM21(any()))
+        when(communicationsModule.requestDM21(any()))
                                                         .thenReturn(new RequestResult<>(false, packets, List.of()));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM21(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM21(any(ResultsListener.class), eq(0x00));
-        verify(diagnosticMessageModule).requestDM21(any(ResultsListener.class), eq(0x17));
-        verify(diagnosticMessageModule).requestDM21(any(ResultsListener.class), eq(0x21));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM21(any(ResultsListener.class));
+        verify(communicationsModule).requestDM21(any(ResultsListener.class), eq(0x00));
+        verify(communicationsModule).requestDM21(any(ResultsListener.class), eq(0x17));
+        verify(communicationsModule).requestDM21(any(ResultsListener.class), eq(0x21));
 
         verify(mockListener).addOutcome(1,
                                         11,
@@ -1127,31 +1127,31 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
         List<DM21DiagnosticReadinessPacket> packets = new ArrayList<>();
 
         DM21DiagnosticReadinessPacket packet0x00 = create(0x00, 0, 0, 0, 0, 25);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0x00)))
+        when(communicationsModule.requestDM21(any(), eq(0x00)))
                                                                   .thenReturn(new BusResult<>(false, packet0x00));
         packets.add(packet0x00);
 
         DM21DiagnosticReadinessPacket packet0x17 = create(0x17, 0, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0x17)))
+        when(communicationsModule.requestDM21(any(), eq(0x17)))
                                                                   .thenReturn(new BusResult<>(false, packet0x17));
         packets.add(packet0x17);
 
         DM21DiagnosticReadinessPacket packet0x21 = create(0x21, 0, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0x21)))
+        when(communicationsModule.requestDM21(any(), eq(0x21)))
                                                                   .thenReturn(new BusResult<>(false, packet0x21));
         packets.add(packet0x21);
 
-        when(diagnosticMessageModule.requestDM21(any()))
+        when(communicationsModule.requestDM21(any()))
                                                         .thenReturn(new RequestResult<>(false, packets, List.of()));
 
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0x17));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0x21));
-        verify(diagnosticMessageModule).requestDM21(any());
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM21(any(), eq(0x00));
+        verify(communicationsModule).requestDM21(any(), eq(0x17));
+        verify(communicationsModule).requestDM21(any(), eq(0x21));
+        verify(communicationsModule).requestDM21(any());
 
         verify(mockListener).addOutcome(1,
                                         11,

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step12ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step12ControllerTest.java
@@ -34,7 +34,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -81,7 +81,7 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
     private ResultsListener mockListener;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private ReportFileModule reportFileModule;
@@ -109,7 +109,7 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
                                               bannerModule,
                                               dataRepository,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               tableA7Validator,
                                               DateTimeModule.getInstance());
 
@@ -120,7 +120,7 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -131,7 +131,7 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
                                  vehicleInformationModule,
                                  mockListener,
                                  tableA7Validator,
-                                 diagnosticMessageModule);
+                                 communicationsModule);
     }
 
     /**
@@ -185,18 +185,18 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
                                                                                     scaledTestResult,
                                                                                     scaledTestResult2);
 
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0x00),
-                                                        eq(247),
-                                                        eq(supportedSPN.getSpn()),
-                                                        eq(31))).thenReturn(List.of(dm30Packet));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0x00),
+                                                     eq(247),
+                                                     eq(supportedSPN.getSpn()),
+                                                     eq(31))).thenReturn(List.of(dm30Packet));
 
         when(tableA7Validator.findDuplicates(any())).thenReturn(List.of());
         when(tableA7Validator.validateForCompressionIgnition(any(), any())).thenReturn(true);
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0x00), eq(247), eq(supportedSPN.getSpn()), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(0x00), eq(247), eq(supportedSPN.getSpn()), eq(31));
 
         verify(tableA7Validator, times(2)).findDuplicates(any());
         verify(tableA7Validator).validateForCompressionIgnition(any(), any());
@@ -261,18 +261,18 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
                                                                                     scaledTestResult,
                                                                                     scaledTestResult2);
 
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0x00),
-                                                        eq(247),
-                                                        eq(supportedSPN.getSpn()),
-                                                        eq(31))).thenReturn(List.of(dm30Packet));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0x00),
+                                                     eq(247),
+                                                     eq(supportedSPN.getSpn()),
+                                                     eq(31))).thenReturn(List.of(dm30Packet));
 
         when(tableA7Validator.findDuplicates(any())).thenReturn(List.of());
         when(tableA7Validator.validateForCompressionIgnition(any(), any())).thenReturn(false);
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0x00), eq(247), eq(supportedSPN.getSpn()), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(0x00), eq(247), eq(supportedSPN.getSpn()), eq(31));
 
         verify(tableA7Validator, times(2)).findDuplicates(any());
         verify(tableA7Validator).validateForCompressionIgnition(any(), any());
@@ -330,11 +330,11 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         SupportedSPN supportedSPN = SupportedSPN.create(99, true, true, true, 1);
         dataRepository.putObdModule(createOBDModuleInformation(0x00, supportedSPN));
 
-        when(diagnosticMessageModule.requestTestResults(any(ResultsListener.class),
-                                                        eq(0x00),
-                                                        eq(247),
-                                                        eq(99),
-                                                        eq(31))).thenReturn(List.of());
+        when(communicationsModule.requestTestResults(any(ResultsListener.class),
+                                                     eq(0x00),
+                                                     eq(247),
+                                                     eq(99),
+                                                     eq(31))).thenReturn(List.of());
 
         when(tableA7Validator.validateForSparkIgnition(any(), any(ResultsListener.class))).thenReturn(true);
 
@@ -345,7 +345,7 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
                                         FAIL,
                                         "6.1.12.2.a (A.7.2.a) - No test result for Supported SP 99 from Engine #1 (0)");
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(247), eq(99), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(247), eq(99), eq(31));
 
         verify(tableA7Validator).findDuplicates(any());
         verify(tableA7Validator).validateForSparkIgnition(any(), any(ResultsListener.class));
@@ -432,15 +432,15 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         ScaledTestResult scaledTestResult = ScaledTestResult.create(247, 157, 0, 242, 0, 0, 0);
         DM30ScaledTestResultsPacket dm30Packet = DM30ScaledTestResultsPacket.create(0, 0, scaledTestResult);
 
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0),
-                                                        eq(247),
-                                                        eq(supportedSPN.getSpn()),
-                                                        eq(31))).thenReturn(List.of(dm30Packet));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0),
+                                                     eq(247),
+                                                     eq(supportedSPN.getSpn()),
+                                                     eq(31))).thenReturn(List.of(dm30Packet));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0x00), eq(247), eq(supportedSPN.getSpn()), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(0x00), eq(247), eq(supportedSPN.getSpn()), eq(31));
 
         verify(tableA7Validator, times(2)).findDuplicates(any());
 
@@ -499,11 +499,11 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         ScaledTestResult scaledTestResult = ScaledTestResult.create(247, 157, 0, 242, 0, 0x88, 0);
         DM30ScaledTestResultsPacket dm30Packet = DM30ScaledTestResultsPacket.create(0, 0, scaledTestResult);
 
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0),
-                                                        eq(247),
-                                                        eq(supportedSPN.getSpn()),
-                                                        eq(31))).thenReturn(List.of(dm30Packet));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0),
+                                                     eq(247),
+                                                     eq(supportedSPN.getSpn()),
+                                                     eq(31))).thenReturn(List.of(dm30Packet));
 
         when(tableA7Validator.findDuplicates(any())).thenReturn(List.of());
         when(tableA7Validator.validateForSparkIgnition(any(), any())).thenReturn(true);
@@ -515,7 +515,7 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
                                         FAIL,
                                         "6.1.12.2.a (A.7.1.b) - Test result for SP 157 FMI 0 from Engine #1 (0) does not report the test result/min test limit/max test limit initialized properly");
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0x00), eq(247), eq(supportedSPN.getSpn()), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(0x00), eq(247), eq(supportedSPN.getSpn()), eq(31));
 
         verify(tableA7Validator, times(2)).findDuplicates(any());
         verify(tableA7Validator).validateForSparkIgnition(any(), any());
@@ -575,11 +575,11 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         ScaledTestResult scaledTestResult = ScaledTestResult.create(247, 157, 0, 242, 0xFB00, 0, 0x88);
         DM30ScaledTestResultsPacket dm30Packet = DM30ScaledTestResultsPacket.create(0, 0, scaledTestResult);
 
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0),
-                                                        eq(247),
-                                                        eq(supportedSPN.getSpn()),
-                                                        eq(31))).thenReturn(List.of(dm30Packet));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0),
+                                                     eq(247),
+                                                     eq(supportedSPN.getSpn()),
+                                                     eq(31))).thenReturn(List.of(dm30Packet));
 
         when(tableA7Validator.validateForSparkIgnition(any(), any())).thenReturn(true);
 
@@ -590,7 +590,7 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
                                         FAIL,
                                         "6.1.12.2.a (A.7.1.b) - Test result for SP 157 FMI 0 from Engine #1 (0) does not report the test result/min test limit/max test limit initialized properly");
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0x00), eq(247), eq(supportedSPN.getSpn()), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(0x00), eq(247), eq(supportedSPN.getSpn()), eq(31));
 
         verify(tableA7Validator, times(2)).findDuplicates(any());
         verify(tableA7Validator).validateForSparkIgnition(any(), any());
@@ -650,11 +650,11 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         ScaledTestResult scaledTestResult = ScaledTestResult.create(247, 157, 0, 242, 0x25, 0, 0);
         DM30ScaledTestResultsPacket dm30Packet = DM30ScaledTestResultsPacket.create(0, 0, scaledTestResult);
 
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0),
-                                                        eq(247),
-                                                        eq(157),
-                                                        eq(31))).thenReturn(List.of(dm30Packet));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0),
+                                                     eq(247),
+                                                     eq(157),
+                                                     eq(31))).thenReturn(List.of(dm30Packet));
 
         when(tableA7Validator.findDuplicates(any())).thenReturn(Set.of());
         when(tableA7Validator.validateForSparkIgnition(any(), any())).thenReturn(true);
@@ -666,7 +666,7 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
                                         FAIL,
                                         "6.1.12.2.a (A.7.1.b) - Test result for SP 157 FMI 0 from Engine #1 (0) does not report the test result/min test limit/max test limit initialized properly");
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(247), eq(supportedSPN.getSpn()), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(247), eq(supportedSPN.getSpn()), eq(31));
 
         verify(tableA7Validator, times(2)).findDuplicates(any());
         verify(tableA7Validator).validateForSparkIgnition(any(), any());
@@ -727,11 +727,11 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
 
         DM30ScaledTestResultsPacket dm30Packet = DM30ScaledTestResultsPacket.create(0, 0, scaledTestResult);
 
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0),
-                                                        eq(247),
-                                                        eq(157),
-                                                        eq(31))).thenReturn(List.of(dm30Packet));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0),
+                                                     eq(247),
+                                                     eq(157),
+                                                     eq(31))).thenReturn(List.of(dm30Packet));
 
         when(tableA7Validator.findDuplicates(any())).thenReturn(List.of());
         when(tableA7Validator.validateForSparkIgnition(any(), any())).thenReturn(true);
@@ -742,7 +742,7 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
                                         FAIL,
                                         "6.1.12.2.a (A.7.1.c) - #1 SLOT identifier for SP 157 FMI 0 from Engine #1 (0) is invalid");
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0x00), eq(247), eq(supportedSPN.getSpn()), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(0x00), eq(247), eq(supportedSPN.getSpn()), eq(31));
 
         verify(tableA7Validator, times(2)).findDuplicates(any());
         verify(tableA7Validator).validateForSparkIgnition(any(), any());
@@ -855,22 +855,22 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
                                                                                     0,
                                                                                     scaledTestResult);
 
-        when(diagnosticMessageModule.requestTestResults(any(ResultsListener.class),
-                                                        eq(0x00),
-                                                        eq(247),
-                                                        eq(157),
-                                                        eq(31))).thenReturn(List.of(dm30Packet));
+        when(communicationsModule.requestTestResults(any(ResultsListener.class),
+                                                     eq(0x00),
+                                                     eq(247),
+                                                     eq(157),
+                                                     eq(31))).thenReturn(List.of(dm30Packet));
 
         when(tableA7Validator.findDuplicates(any())).thenReturn(List.of());
         when(tableA7Validator.validateForSparkIgnition(any(), any())).thenReturn(true);
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResults(any(ResultsListener.class),
-                                                           eq(0x00),
-                                                           eq(247),
-                                                           eq(157),
-                                                           eq(31));
+        verify(communicationsModule).requestTestResults(any(ResultsListener.class),
+                                                        eq(0x00),
+                                                        eq(247),
+                                                        eq(157),
+                                                        eq(31));
 
         verify(mockListener).addOutcome(1,
                                         12,
@@ -943,11 +943,11 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
                                                                                     scaledTestResult,
                                                                                     scaledTestResult2);
 
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0x00),
-                                                        eq(247),
-                                                        eq(159),
-                                                        eq(31))).thenReturn(List.of(dm30Packet));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0x00),
+                                                     eq(247),
+                                                     eq(159),
+                                                     eq(31))).thenReturn(List.of(dm30Packet));
 
         when(tableA7Validator.findDuplicates(any())).thenReturn(List.of(scaledTestResult), List.of());
 
@@ -960,7 +960,7 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
                                         WARN,
                                         "6.1.12.2.a (A.7.1.d) - Engine #1 (0) returned duplicate test results for SP 159 FMI 18");
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0x00), eq(247), eq(supportedSP.getSpn()), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(0x00), eq(247), eq(supportedSP.getSpn()), eq(31));
 
         verify(tableA7Validator, times(2)).findDuplicates(any());
         verify(tableA7Validator).validateForSparkIgnition(any(), any());
@@ -1038,16 +1038,16 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
                                                                                         0,
                                                                                         scaledTestResult2);
 
-        when(diagnosticMessageModule.requestTestResults(any(ResultsListener.class),
-                                                        eq(0x00),
-                                                        eq(247),
-                                                        eq(159),
-                                                        eq(31))).thenReturn(List.of(dm30Packet0x00));
-        when(diagnosticMessageModule.requestTestResults(any(ResultsListener.class),
-                                                        eq(0x09),
-                                                        eq(247),
-                                                        eq(159),
-                                                        eq(31))).thenReturn(List.of(dm30Packet0x09));
+        when(communicationsModule.requestTestResults(any(ResultsListener.class),
+                                                     eq(0x00),
+                                                     eq(247),
+                                                     eq(159),
+                                                     eq(31))).thenReturn(List.of(dm30Packet0x00));
+        when(communicationsModule.requestTestResults(any(ResultsListener.class),
+                                                     eq(0x09),
+                                                     eq(247),
+                                                     eq(159),
+                                                     eq(31))).thenReturn(List.of(dm30Packet0x09));
 
         when(tableA7Validator.findDuplicates(eq(List.of(scaledTestResult2)))).thenReturn(List.of());
         when(tableA7Validator.findDuplicates(eq(List.of(scaledTestResult,
@@ -1063,16 +1063,16 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
                                         WARN,
                                         "6.1.12.2.a (A.7.2.b) - More than one ECU responded with test results for SP 159 + FMI 18 combination");
 
-        verify(diagnosticMessageModule).requestTestResults(any(),
-                                                           eq(0x00),
-                                                           eq(247),
-                                                           eq(supportedSP0x00.getSpn()),
-                                                           eq(31));
-        verify(diagnosticMessageModule).requestTestResults(any(),
-                                                           eq(0x09),
-                                                           eq(247),
-                                                           eq(supportedSP0x09.getSpn()),
-                                                           eq(31));
+        verify(communicationsModule).requestTestResults(any(),
+                                                        eq(0x00),
+                                                        eq(247),
+                                                        eq(supportedSP0x00.getSpn()),
+                                                        eq(31));
+        verify(communicationsModule).requestTestResults(any(),
+                                                        eq(0x09),
+                                                        eq(247),
+                                                        eq(supportedSP0x09.getSpn()),
+                                                        eq(31));
 
         verify(tableA7Validator, times(3)).findDuplicates(any());
         verify(tableA7Validator).validateForCompressionIgnition(any(), any());
@@ -1133,11 +1133,11 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         ScaledTestResult scaledTestResult2 = ScaledTestResult.create(247, 159, 18, 8, 0, 0, 0);
         DM30ScaledTestResultsPacket dm30Packet2 = DM30ScaledTestResultsPacket.create(0, 0, scaledTestResult2);
 
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0),
-                                                        eq(247),
-                                                        eq(159),
-                                                        eq(31))).thenReturn(List.of(dm30Packet2));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0),
+                                                     eq(247),
+                                                     eq(159),
+                                                     eq(31))).thenReturn(List.of(dm30Packet2));
 
         when(tableA7Validator.findDuplicates(any())).thenReturn(List.of());
         when(tableA7Validator.validateForSparkIgnition(any(), any())).thenReturn(false);
@@ -1146,7 +1146,7 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
 
         assertEquals(List.of(), listener.getOutcomes());
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0x00), eq(247), eq(supportedSP.getSpn()), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(0x00), eq(247), eq(supportedSP.getSpn()), eq(31));
 
         verify(tableA7Validator, times(2)).findDuplicates(any());
         verify(tableA7Validator).validateForSparkIgnition(any(), any());

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step13ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step13ControllerTest.java
@@ -31,7 +31,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -60,7 +60,7 @@ public class Part01Step13ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -98,7 +98,7 @@ public class Part01Step13ControllerTest extends AbstractControllerTest {
                                               engineSpeedModule,
                                               bannerModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               dataRepository,
                                               sectionA6Validator,
                                               DateTimeModule.getInstance());
@@ -111,7 +111,7 @@ public class Part01Step13ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
 
     }
 
@@ -124,7 +124,7 @@ public class Part01Step13ControllerTest extends AbstractControllerTest {
                                  vehicleInformationModule,
                                  mockListener,
                                  sectionA6Validator,
-                                 diagnosticMessageModule);
+                                 communicationsModule);
     }
 
     /**
@@ -248,11 +248,11 @@ public class Part01Step13ControllerTest extends AbstractControllerTest {
                                                                                                 packet0,
                                                                                                 packet17,
                                                                                                 packet21);
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(globalRequestResponse);
+        when(communicationsModule.requestDM5(any())).thenReturn(globalRequestResponse);
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any());
 
         verify(sectionA6Validator).verify(any(), eq("6.1.13.2.a"), eq(globalRequestResponse));
 
@@ -329,18 +329,18 @@ public class Part01Step13ControllerTest extends AbstractControllerTest {
         RequestResult<DM5DiagnosticReadinessPacket> globalRequestResponse = new RequestResult<>(false,
                                                                                                 List.of(),
                                                                                                 List.of(ackPacket0x44));
-        when(diagnosticMessageModule.requestDM5(any(ResultsListener.class))).thenReturn(globalRequestResponse);
+        when(communicationsModule.requestDM5(any(ResultsListener.class))).thenReturn(globalRequestResponse);
 
         BusResult<DM5DiagnosticReadinessPacket> busResult0x44 = new BusResult<>(false,
                                                                                 ackPacket0x44);
-        when(diagnosticMessageModule.requestDM5(any(), eq(0x44))).thenReturn(busResult0x44);
+        when(communicationsModule.requestDM5(any(), eq(0x44))).thenReturn(busResult0x44);
 
         dataRepository.putObdModule(new OBDModuleInformation(0x44));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM5(any(ResultsListener.class), eq(0x44));
+        verify(communicationsModule).requestDM5(any(ResultsListener.class));
+        verify(communicationsModule).requestDM5(any(ResultsListener.class), eq(0x44));
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -438,7 +438,7 @@ public class Part01Step13ControllerTest extends AbstractControllerTest {
                                                                                                  0x1E));
         BusResult<DM5DiagnosticReadinessPacket> busResult0x00 = new BusResult<>(false,
                                                                                 packet0x00);
-        when(diagnosticMessageModule.requestDM5(any(ResultsListener.class), eq(0x00))).thenReturn(busResult0x00);
+        when(communicationsModule.requestDM5(any(ResultsListener.class), eq(0x00))).thenReturn(busResult0x00);
 
         DM5DiagnosticReadinessPacket packet0x17 = new DM5DiagnosticReadinessPacket(Packet.create(PGN,
                                                                                                  0x17,
@@ -452,16 +452,16 @@ public class Part01Step13ControllerTest extends AbstractControllerTest {
                                                                                                  0x1E));
         BusResult<DM5DiagnosticReadinessPacket> busResult0x17 = new BusResult<>(false,
                                                                                 packet0x17);
-        when(diagnosticMessageModule.requestDM5(any(), eq(0x17))).thenReturn(busResult0x17);
+        when(communicationsModule.requestDM5(any(), eq(0x17))).thenReturn(busResult0x17);
 
         AcknowledgmentPacket ackPacket0x21 = AcknowledgmentPacket.create(0x21, NACK);
         BusResult<DM5DiagnosticReadinessPacket> busResult0x21 = new BusResult<>(false,
                                                                                 ackPacket0x21);
-        when(diagnosticMessageModule.requestDM5(any(), eq(0x21))).thenReturn(busResult0x21);
+        when(communicationsModule.requestDM5(any(), eq(0x21))).thenReturn(busResult0x21);
         RequestResult<DM5DiagnosticReadinessPacket> globalRequestResponse = new RequestResult<>(false,
                                                                                                 List.of(packet0x00),
                                                                                                 List.of(ackPacket0x44));
-        when(diagnosticMessageModule.requestDM5(any(ResultsListener.class))).thenReturn(globalRequestResponse);
+        when(communicationsModule.requestDM5(any(ResultsListener.class))).thenReturn(globalRequestResponse);
 
         dataRepository.putObdModule(new OBDModuleInformation(0x00));
         dataRepository.putObdModule(new OBDModuleInformation(0x17));
@@ -469,10 +469,10 @@ public class Part01Step13ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any());
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0x17));
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0x21));
+        verify(communicationsModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any(), eq(0x00));
+        verify(communicationsModule).requestDM5(any(), eq(0x17));
+        verify(communicationsModule).requestDM5(any(), eq(0x21));
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -591,15 +591,15 @@ public class Part01Step13ControllerTest extends AbstractControllerTest {
                                                                                          false,
                                                                                          List.of(packet0, packet21),
                                                                                          List.of(packet23));
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(globalResponse);
+        when(communicationsModule.requestDM5(any())).thenReturn(globalResponse);
 
-        when(diagnosticMessageModule.requestDM5(any(), eq(0x00)))
+        when(communicationsModule.requestDM5(any(), eq(0x00)))
                                                                  .thenReturn(new BusResult<>(false, Optional.empty()));
-        when(diagnosticMessageModule.requestDM5(any(), eq(0x17)))
+        when(communicationsModule.requestDM5(any(), eq(0x17)))
                                                                  .thenReturn(new BusResult<>(false, Optional.empty()));
-        when(diagnosticMessageModule.requestDM5(any(), eq(0x21)))
+        when(communicationsModule.requestDM5(any(), eq(0x21)))
                                                                  .thenReturn(new BusResult<>(false, packet21V2));
-        when(diagnosticMessageModule.requestDM5(any(), eq(0x23)))
+        when(communicationsModule.requestDM5(any(), eq(0x23)))
                                                                  .thenReturn(new BusResult<>(false, packet23));
 
         dataRepository.putObdModule(new OBDModuleInformation(0x00));
@@ -609,11 +609,11 @@ public class Part01Step13ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any());
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0x17));
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0x21));
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0x23));
+        verify(communicationsModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any(), eq(0x00));
+        verify(communicationsModule).requestDM5(any(), eq(0x17));
+        verify(communicationsModule).requestDM5(any(), eq(0x21));
+        verify(communicationsModule).requestDM5(any(), eq(0x23));
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -787,8 +787,8 @@ public class Part01Step13ControllerTest extends AbstractControllerTest {
                                                                                                    0x00,
                                                                                                    0x00,
                                                                                                    0x00));
-        when(diagnosticMessageModule.requestDM5(any(ResultsListener.class),
-                                                eq(0x17))).thenReturn(new BusResult<>(false, dsPacket0x17));
+        when(communicationsModule.requestDM5(any(ResultsListener.class),
+                                             eq(0x17))).thenReturn(new BusResult<>(false, dsPacket0x17));
 
         dataRepository.putObdModule(new OBDModuleInformation(0x23));
         AcknowledgmentPacket nackPacket0x23 = AcknowledgmentPacket.create(0x23,
@@ -796,20 +796,20 @@ public class Part01Step13ControllerTest extends AbstractControllerTest {
                                                                           1,
                                                                           0xF9,
                                                                           PGN);
-        when(diagnosticMessageModule.requestDM5(any(ResultsListener.class),
-                                                eq(0x23))).thenReturn(new BusResult<>(false, nackPacket0x23));
+        when(communicationsModule.requestDM5(any(ResultsListener.class),
+                                             eq(0x23))).thenReturn(new BusResult<>(false, nackPacket0x23));
 
         RequestResult<DM5DiagnosticReadinessPacket> globalRequestResponse = new RequestResult<>(
                                                                                                 false,
                                                                                                 List.of(packet0x17),
                                                                                                 List.of());
-        when(diagnosticMessageModule.requestDM5(any(ResultsListener.class))).thenReturn(globalRequestResponse);
+        when(communicationsModule.requestDM5(any(ResultsListener.class))).thenReturn(globalRequestResponse);
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM5(any(ResultsListener.class), eq(0x17));
-        verify(diagnosticMessageModule).requestDM5(any(ResultsListener.class), eq(0x23));
+        verify(communicationsModule).requestDM5(any(ResultsListener.class));
+        verify(communicationsModule).requestDM5(any(ResultsListener.class), eq(0x17));
+        verify(communicationsModule).requestDM5(any(ResultsListener.class), eq(0x23));
 
         verify(mockListener).addOutcome(
                                         1,

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step14ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step14ControllerTest.java
@@ -29,7 +29,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -57,7 +57,7 @@ public class Part01Step14ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -93,7 +93,7 @@ public class Part01Step14ControllerTest extends AbstractControllerTest {
                                               engineSpeedModule,
                                               bannerModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               dataRepository,
                                               DateTimeModule.getInstance());
 
@@ -104,7 +104,7 @@ public class Part01Step14ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -113,7 +113,7 @@ public class Part01Step14ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -157,20 +157,20 @@ public class Part01Step14ControllerTest extends AbstractControllerTest {
         OBDModuleInformation obdModule = new OBDModuleInformation(0);
         obdModule.set(DM5DiagnosticReadinessPacket.create(0, 0, 0, 0x22, enabledSystems, completeSystems), 1);
         dataRepository.putObdModule(obdModule);
-        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
+        when(communicationsModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM26(any(), eq(1))).thenReturn(new RequestResult<>(false, nack));
+        when(communicationsModule.requestDM26(any(), eq(1))).thenReturn(new RequestResult<>(false, nack));
 
-        when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
+        when(communicationsModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM26(any());
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM26(any(), eq(1));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM26(any());
+        verify(communicationsModule).requestDM26(any(), eq(0));
+        verify(communicationsModule).requestDM26(any(), eq(1));
 
         String expectedResults = NL + "Vehicle Composite of DM26:" + NL;
         expectedResults += "    A/C system refrigerant         enabled, not complete" + NL;
@@ -196,12 +196,12 @@ public class Part01Step14ControllerTest extends AbstractControllerTest {
 
     @Test
     public void testFailureForNoDm26() {
-        when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM26(any())).thenReturn(RequestResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM26(any());
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM26(any());
 
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, "6.1.14.2.f - No OBD ECU provided DM26");
 
@@ -236,14 +236,14 @@ public class Part01Step14ControllerTest extends AbstractControllerTest {
         obdModule.set(DM5DiagnosticReadinessPacket.create(0, 0, 0, 0x22, enabledSystems, completeSystems), 1);
         dataRepository.putObdModule(obdModule);
 
-        when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
-        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
+        when(communicationsModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
+        when(communicationsModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM26(any());
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM26(any());
+        verify(communicationsModule).requestDM26(any(), eq(0));
 
         String expectedResults = NL + "Vehicle Composite of DM26:" + NL;
         expectedResults += "    A/C system refrigerant         enabled, not complete" + NL;
@@ -304,14 +304,14 @@ public class Part01Step14ControllerTest extends AbstractControllerTest {
         obdModule.set(DM5DiagnosticReadinessPacket.create(0, 0, 0, 0x22, dm5SupportedSystem, completeSystems), 1);
         dataRepository.putObdModule(obdModule);
 
-        when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
-        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
+        when(communicationsModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
+        when(communicationsModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM26(any());
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM26(any());
+        verify(communicationsModule).requestDM26(any(), eq(0));
 
         String expectedResults = NL + "Vehicle Composite of DM26:" + NL;
         expectedResults += "    A/C system refrigerant         enabled, not complete" + NL;
@@ -363,14 +363,14 @@ public class Part01Step14ControllerTest extends AbstractControllerTest {
         obdModule.set(DM5DiagnosticReadinessPacket.create(0, 0, 0, 0x22, enabledSystems, completeSystems), 1);
         dataRepository.putObdModule(obdModule);
 
-        when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
-        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
+        when(communicationsModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
+        when(communicationsModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM26(any());
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM26(any());
+        verify(communicationsModule).requestDM26(any(), eq(0));
 
         String expectedResults = NL + "Vehicle Composite of DM26:" + NL;
         expectedResults += "    A/C system refrigerant         enabled, not complete" + NL;
@@ -430,14 +430,14 @@ public class Part01Step14ControllerTest extends AbstractControllerTest {
         obdModule.set(DM5DiagnosticReadinessPacket.create(0, 0, 0, 0x22, dm5SupportedSystems, completeSystems), 1);
         dataRepository.putObdModule(obdModule);
 
-        when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
-        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
+        when(communicationsModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
+        when(communicationsModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM26(any());
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM26(any());
+        verify(communicationsModule).requestDM26(any(), eq(0));
 
         String expectedResults = NL + "Vehicle Composite of DM26:" + NL;
         expectedResults += "    A/C system refrigerant         enabled, not complete" + NL;
@@ -491,14 +491,14 @@ public class Part01Step14ControllerTest extends AbstractControllerTest {
         obdModule.set(DM5DiagnosticReadinessPacket.create(0, 0, 0, 0x22, enabledSystems, completeSystems), 1);
         dataRepository.putObdModule(obdModule);
 
-        when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
-        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
+        when(communicationsModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
+        when(communicationsModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM26(any());
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM26(any());
+        verify(communicationsModule).requestDM26(any(), eq(0));
 
         String expectedResults = NL + "Vehicle Composite of DM26:" + NL;
         expectedResults += "    A/C system refrigerant         enabled, not complete" + NL;
@@ -552,14 +552,14 @@ public class Part01Step14ControllerTest extends AbstractControllerTest {
         obdModule.set(DM5DiagnosticReadinessPacket.create(0, 0, 0, 0x22, enabledSystems, completeSystems), 1);
         dataRepository.putObdModule(obdModule);
 
-        when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
-        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
+        when(communicationsModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
+        when(communicationsModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM26(any());
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM26(any());
+        verify(communicationsModule).requestDM26(any(), eq(0));
 
         String expectedResults = NL + "Vehicle Composite of DM26:" + NL;
         expectedResults += "    A/C system refrigerant         enabled, not complete" + NL;
@@ -618,16 +618,16 @@ public class Part01Step14ControllerTest extends AbstractControllerTest {
         obdModule1.set(DM5DiagnosticReadinessPacket.create(1, 0, 0, 0x22, enabledSystems, completeSystems), 1);
         dataRepository.putObdModule(obdModule1);
 
-        when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.of(dm26_0, dm26_1));
-        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26_0));
-        when(diagnosticMessageModule.requestDM26(any(), eq(1))).thenReturn(RequestResult.of(dm26_1));
+        when(communicationsModule.requestDM26(any())).thenReturn(RequestResult.of(dm26_0, dm26_1));
+        when(communicationsModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26_0));
+        when(communicationsModule.requestDM26(any(), eq(1))).thenReturn(RequestResult.of(dm26_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM26(any());
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM26(any(), eq(1));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM26(any());
+        verify(communicationsModule).requestDM26(any(), eq(0));
+        verify(communicationsModule).requestDM26(any(), eq(1));
 
         String expectedResults = NL + "Vehicle Composite of DM26:" + NL;
         expectedResults += "    A/C system refrigerant     not enabled,     complete" + NL;
@@ -681,16 +681,16 @@ public class Part01Step14ControllerTest extends AbstractControllerTest {
         obdModule.set(DM5DiagnosticReadinessPacket.create(0, 0, 0, 0x22, enabledSystems, completeSystems), 1);
         dataRepository.putObdModule(obdModule);
 
-        when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
+        when(communicationsModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
 
         var dm26Ds = DM26TripDiagnosticReadinessPacket.create(0, 1, 0, enabledSystems, completeSystems);
-        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26Ds));
+        when(communicationsModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26Ds));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM26(any());
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM26(any());
+        verify(communicationsModule).requestDM26(any(), eq(0));
 
         String expectedResults = NL + "Vehicle Composite of DM26:" + NL;
         expectedResults += "    A/C system refrigerant         enabled, not complete" + NL;
@@ -743,19 +743,19 @@ public class Part01Step14ControllerTest extends AbstractControllerTest {
         OBDModuleInformation obdModule = new OBDModuleInformation(0);
         obdModule.set(DM5DiagnosticReadinessPacket.create(0, 0, 0, 0x22, enabledSystems, completeSystems), 1);
         dataRepository.putObdModule(obdModule);
-        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
+        when(communicationsModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
-        when(diagnosticMessageModule.requestDM26(any(), eq(1))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM26(any(), eq(1))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
+        when(communicationsModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM26(any());
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM26(any(), eq(1));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM26(any());
+        verify(communicationsModule).requestDM26(any(), eq(0));
+        verify(communicationsModule).requestDM26(any(), eq(1));
 
         String expectedResults = NL + "Vehicle Composite of DM26:" + NL;
         expectedResults += "    A/C system refrigerant         enabled, not complete" + NL;

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step15ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step15ControllerTest.java
@@ -27,7 +27,7 @@ import org.etools.j1939_84.controllers.ResultsListener;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -59,7 +59,7 @@ public class Part01Step15ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -94,7 +94,7 @@ public class Part01Step15ControllerTest extends AbstractControllerTest {
                                               engineSpeedModule,
                                               bannerModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               dataRepository,
                                               new TestDateTimeModule());
 
@@ -105,7 +105,7 @@ public class Part01Step15ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -114,7 +114,7 @@ public class Part01Step15ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -158,12 +158,12 @@ public class Part01Step15ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(0x01));
 
-        when(diagnosticMessageModule.readDM1(any(ResultsListener.class))).thenReturn(List.of());
+        when(communicationsModule.readDM1(any(ResultsListener.class))).thenReturn(List.of());
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).readDM1(any(ResultsListener.class));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).readDM1(any(ResultsListener.class));
 
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, "6.1.15.2.e - No OBD ECU provided a DM1");
 
@@ -214,12 +214,12 @@ public class Part01Step15ControllerTest extends AbstractControllerTest {
                                                                  OFF);
         dataRepository.putObdModule(new OBDModuleInformation(0x01));
 
-        when(diagnosticMessageModule.readDM1(any(ResultsListener.class))).thenReturn(List.of(packet1));
+        when(communicationsModule.readDM1(any(ResultsListener.class))).thenReturn(List.of(packet1));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).readDM1(any(ResultsListener.class));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).readDM1(any(ResultsListener.class));
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -280,12 +280,12 @@ public class Part01Step15ControllerTest extends AbstractControllerTest {
                                                                  dtc3);
         dataRepository.putObdModule(new OBDModuleInformation(0x01));
 
-        when(diagnosticMessageModule.readDM1(any(ResultsListener.class))).thenReturn(List.of(packet1));
+        when(communicationsModule.readDM1(any(ResultsListener.class))).thenReturn(List.of(packet1));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).readDM1(any(ResultsListener.class));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).readDM1(any(ResultsListener.class));
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -362,12 +362,12 @@ public class Part01Step15ControllerTest extends AbstractControllerTest {
         // make the module and OBD
         dataRepository.putObdModule(new OBDModuleInformation(0x03));
 
-        when(diagnosticMessageModule.readDM1(any(ResultsListener.class))).thenReturn(List.of(packet2, packet3));
+        when(communicationsModule.readDM1(any(ResultsListener.class))).thenReturn(List.of(packet2, packet3));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).readDM1(any(ResultsListener.class));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).readDM1(any(ResultsListener.class));
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -443,12 +443,12 @@ public class Part01Step15ControllerTest extends AbstractControllerTest {
         // make the module and OBD
         dataRepository.putObdModule(new OBDModuleInformation(0x03));
 
-        when(diagnosticMessageModule.readDM1(any(ResultsListener.class))).thenReturn(List.of(packet2, packet3));
+        when(communicationsModule.readDM1(any(ResultsListener.class))).thenReturn(List.of(packet2, packet3));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).readDM1(any(ResultsListener.class));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).readDM1(any(ResultsListener.class));
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -506,12 +506,12 @@ public class Part01Step15ControllerTest extends AbstractControllerTest {
         // make the module and OBD
         dataRepository.putObdModule(new OBDModuleInformation(0x03));
         // return the OBD module's packet when requested
-        when(diagnosticMessageModule.readDM1(any(ResultsListener.class))).thenReturn(List.of(packet3));
+        when(communicationsModule.readDM1(any(ResultsListener.class))).thenReturn(List.of(packet3));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).readDM1(any(ResultsListener.class));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).readDM1(any(ResultsListener.class));
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -599,12 +599,12 @@ public class Part01Step15ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(0x17));
 
-        when(diagnosticMessageModule.readDM1(any(ResultsListener.class))).thenReturn(List.of(packet2));
+        when(communicationsModule.readDM1(any(ResultsListener.class))).thenReturn(List.of(packet2));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).readDM1(any(ResultsListener.class));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).readDM1(any(ResultsListener.class));
 
         assertEquals("", listener.getResults());
     }
@@ -654,12 +654,12 @@ public class Part01Step15ControllerTest extends AbstractControllerTest {
         // make it an OBD module
         dataRepository.putObdModule(new OBDModuleInformation(0x01));
         // return the packet with the active dtc and a MIL on for the OBD module
-        when(diagnosticMessageModule.readDM1(any(ResultsListener.class))).thenReturn(List.of(packet1));
+        when(communicationsModule.readDM1(any(ResultsListener.class))).thenReturn(List.of(packet1));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).readDM1(any(ResultsListener.class));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).readDM1(any(ResultsListener.class));
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step16ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step16ControllerTest.java
@@ -30,7 +30,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -56,7 +56,7 @@ public class Part01Step16ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -90,7 +90,7 @@ public class Part01Step16ControllerTest extends AbstractControllerTest {
                                               engineSpeedModule,
                                               bannerModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               dataRepository,
                                               DateTimeModule.getInstance());
 
@@ -101,7 +101,7 @@ public class Part01Step16ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
 
     }
 
@@ -112,7 +112,7 @@ public class Part01Step16ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  vehicleInformationModule,
                                  mockListener,
-                                 diagnosticMessageModule);
+                                 communicationsModule);
     }
 
     /**
@@ -158,14 +158,14 @@ public class Part01Step16ControllerTest extends AbstractControllerTest {
 
         var dtc1 = DiagnosticTroubleCode.create(123, 1, 1, 1);
         var packet1 = DM2PreviouslyActiveDTC.create(0x00, OFF, OFF, OFF, OFF, dtc1);
-        when(diagnosticMessageModule.requestDM2(any(ResultsListener.class))).thenReturn(RequestResult.of(packet1));
-        when(diagnosticMessageModule.requestDM2(any(ResultsListener.class),
-                                                eq(0x00))).thenReturn(BusResult.of(packet1));
+        when(communicationsModule.requestDM2(any(ResultsListener.class))).thenReturn(RequestResult.of(packet1));
+        when(communicationsModule.requestDM2(any(ResultsListener.class),
+                                             eq(0x00))).thenReturn(BusResult.of(packet1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM2(any(ResultsListener.class), eq(0x00));
+        verify(communicationsModule).requestDM2(any(ResultsListener.class));
+        verify(communicationsModule).requestDM2(any(ResultsListener.class), eq(0x00));
 
         verify(mockListener).addOutcome(1,
                                         16,
@@ -245,14 +245,14 @@ public class Part01Step16ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0x00));
 
         var packet1 = DM2PreviouslyActiveDTC.create(0x00, NOT_SUPPORTED, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM2(any(ResultsListener.class))).thenReturn(RequestResult.of(packet1));
-        when(diagnosticMessageModule.requestDM2(any(ResultsListener.class),
-                                                eq(0x00))).thenReturn(BusResult.of(packet1));
+        when(communicationsModule.requestDM2(any(ResultsListener.class))).thenReturn(RequestResult.of(packet1));
+        when(communicationsModule.requestDM2(any(ResultsListener.class),
+                                             eq(0x00))).thenReturn(BusResult.of(packet1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM2(any(ResultsListener.class), eq(0x00));
+        verify(communicationsModule).requestDM2(any(ResultsListener.class));
+        verify(communicationsModule).requestDM2(any(ResultsListener.class), eq(0x00));
 
         verify(mockListener).addOutcome(1,
                                         16,
@@ -306,15 +306,15 @@ public class Part01Step16ControllerTest extends AbstractControllerTest {
     public void testMILOff() {
         var packet1 = DM2PreviouslyActiveDTC.create(0x00, OFF, OFF, OFF, OFF);
         dataRepository.putObdModule(new OBDModuleInformation(0x00));
-        when(diagnosticMessageModule.requestDM2(any(ResultsListener.class))).thenReturn(RequestResult.of(packet1));
-        when(diagnosticMessageModule.requestDM2(any(ResultsListener.class),
-                                                eq(0x00))).thenReturn(new BusResult<>(false, packet1));
+        when(communicationsModule.requestDM2(any(ResultsListener.class))).thenReturn(RequestResult.of(packet1));
+        when(communicationsModule.requestDM2(any(ResultsListener.class),
+                                             eq(0x00))).thenReturn(new BusResult<>(false, packet1));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM2(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM2(any(ResultsListener.class), eq(0x00));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM2(any(ResultsListener.class));
+        verify(communicationsModule).requestDM2(any(ResultsListener.class), eq(0x00));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -364,14 +364,14 @@ public class Part01Step16ControllerTest extends AbstractControllerTest {
 
         var dtc = DiagnosticTroubleCode.create(12, 1, 1, 1);
         var packet1 = DM2PreviouslyActiveDTC.create(0x00, SLOW_FLASH, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM2(any(ResultsListener.class))).thenReturn(RequestResult.of(packet1));
-        when(diagnosticMessageModule.requestDM2(any(ResultsListener.class),
-                                                eq(0x00))).thenReturn(BusResult.of(packet1));
+        when(communicationsModule.requestDM2(any(ResultsListener.class))).thenReturn(RequestResult.of(packet1));
+        when(communicationsModule.requestDM2(any(ResultsListener.class),
+                                             eq(0x00))).thenReturn(BusResult.of(packet1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM2(any(ResultsListener.class), eq(0x00));
+        verify(communicationsModule).requestDM2(any(ResultsListener.class));
+        verify(communicationsModule).requestDM2(any(ResultsListener.class), eq(0x00));
 
         verify(mockListener).addOutcome(1,
                                         16,
@@ -427,11 +427,11 @@ public class Part01Step16ControllerTest extends AbstractControllerTest {
             @TestItem(verifies = "6.1.16.2.c", description = "Fail if any non-OBD ECU does not report MIL off or not supported") })
     public void testNonObdModuleMilOnFailure() {
         var packet1 = DM2PreviouslyActiveDTC.create(0x00, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM2(any(ResultsListener.class))).thenReturn(RequestResult.of(packet1));
+        when(communicationsModule.requestDM2(any(ResultsListener.class))).thenReturn(RequestResult.of(packet1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any(ResultsListener.class));
+        verify(communicationsModule).requestDM2(any(ResultsListener.class));
 
         verify(mockListener).addOutcome(1,
                                         16,
@@ -498,21 +498,21 @@ public class Part01Step16ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(0x00));
         var packet1 = DM2PreviouslyActiveDTC.create(0x00, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM2(any(ResultsListener.class),
-                                                eq(0x00))).thenReturn(BusResult.of(packet1));
+        when(communicationsModule.requestDM2(any(ResultsListener.class),
+                                             eq(0x00))).thenReturn(BusResult.of(packet1));
 
         dataRepository.putObdModule(new OBDModuleInformation(0x03));
         DM2PreviouslyActiveDTC packet4 = DM2PreviouslyActiveDTC.create(0x03, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM2(any(ResultsListener.class),
-                                                eq(0x03))).thenReturn(BusResult.of(packet4));
+        when(communicationsModule.requestDM2(any(ResultsListener.class),
+                                             eq(0x03))).thenReturn(BusResult.of(packet4));
 
-        when(diagnosticMessageModule.requestDM2(any(ResultsListener.class))).thenReturn(RequestResult.of(packet1));
+        when(communicationsModule.requestDM2(any(ResultsListener.class))).thenReturn(RequestResult.of(packet1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
-        verify(diagnosticMessageModule).requestDM2(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM2(any(), eq(0x03));
+        verify(communicationsModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any(), eq(0x00));
+        verify(communicationsModule).requestDM2(any(), eq(0x03));
 
         verify(mockListener).addOutcome(1,
                                         16,
@@ -578,25 +578,25 @@ public class Part01Step16ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(0x00));
         DM2PreviouslyActiveDTC packet2 = DM2PreviouslyActiveDTC.create(0x00, OFF, ON, OFF, OFF);
-        when(diagnosticMessageModule.requestDM2(any(ResultsListener.class),
-                                                eq(0x00))).thenReturn(BusResult.of(packet2));
+        when(communicationsModule.requestDM2(any(ResultsListener.class),
+                                             eq(0x00))).thenReturn(BusResult.of(packet2));
 
         DM2PreviouslyActiveDTC packet1 = DM2PreviouslyActiveDTC.create(0x00, OFF, OFF, OFF, OFF);
 
         dataRepository.putObdModule(new OBDModuleInformation(0x03));
         AcknowledgmentPacket packet4 = AcknowledgmentPacket.create(0x03, NACK);
-        when(diagnosticMessageModule.requestDM2(any(), eq(0x03))).thenReturn(BusResult.of(packet4));
+        when(communicationsModule.requestDM2(any(), eq(0x03))).thenReturn(BusResult.of(packet4));
 
         DM2PreviouslyActiveDTC packet3 = DM2PreviouslyActiveDTC.create(0x03, OFF, OFF, OFF, OFF);
 
-        when(diagnosticMessageModule.requestDM2(any(ResultsListener.class))).thenReturn(RequestResult.of(packet1,
-                                                                                                         packet3));
+        when(communicationsModule.requestDM2(any(ResultsListener.class))).thenReturn(RequestResult.of(packet1,
+                                                                                                      packet3));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM2(any(ResultsListener.class), eq(0x00));
-        verify(diagnosticMessageModule).requestDM2(any(ResultsListener.class), eq(0x03));
+        verify(communicationsModule).requestDM2(any(ResultsListener.class));
+        verify(communicationsModule).requestDM2(any(ResultsListener.class), eq(0x00));
+        verify(communicationsModule).requestDM2(any(ResultsListener.class), eq(0x03));
 
         verify(mockListener).addOutcome(1,
                                         16,
@@ -664,20 +664,20 @@ public class Part01Step16ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(0x00));
         DM2PreviouslyActiveDTC packet1 = DM2PreviouslyActiveDTC.create(0x00, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM2(any(), eq(0x00))).thenReturn(BusResult.of(packet1));
+        when(communicationsModule.requestDM2(any(), eq(0x00))).thenReturn(BusResult.of(packet1));
 
         dataRepository.putObdModule(new OBDModuleInformation(0x03));
         AcknowledgmentPacket packet4 = AcknowledgmentPacket.create(0x03, NACK);
-        when(diagnosticMessageModule.requestDM2(any(ResultsListener.class),
-                                                eq(0x03))).thenReturn(BusResult.of(packet4));
+        when(communicationsModule.requestDM2(any(ResultsListener.class),
+                                             eq(0x03))).thenReturn(BusResult.of(packet4));
 
-        when(diagnosticMessageModule.requestDM2(any(ResultsListener.class))).thenReturn(RequestResult.of(packet1));
+        when(communicationsModule.requestDM2(any(ResultsListener.class))).thenReturn(RequestResult.of(packet1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM2(any(ResultsListener.class), eq(0x00));
-        verify(diagnosticMessageModule).requestDM2(any(ResultsListener.class), eq(0x03));
+        verify(communicationsModule).requestDM2(any(ResultsListener.class));
+        verify(communicationsModule).requestDM2(any(ResultsListener.class), eq(0x00));
+        verify(communicationsModule).requestDM2(any(ResultsListener.class), eq(0x03));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step17ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step17ControllerTest.java
@@ -30,7 +30,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -60,7 +60,7 @@ public class Part01Step17ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -96,7 +96,7 @@ public class Part01Step17ControllerTest extends AbstractControllerTest {
                                               engineSpeedModule,
                                               bannerModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               dataRepository,
                                               DateTimeModule.getInstance());
 
@@ -107,7 +107,7 @@ public class Part01Step17ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -116,7 +116,7 @@ public class Part01Step17ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -181,26 +181,26 @@ public class Part01Step17ControllerTest extends AbstractControllerTest {
                                                                                 OFF,
                                                                                 OFF);
 
-        when(diagnosticMessageModule.requestDM6(any(ResultsListener.class), eq(0x00)))
+        when(communicationsModule.requestDM6(any(ResultsListener.class), eq(0x00)))
                                                                                       .thenReturn(new RequestResult<>(false,
                                                                                                                       List.of(packet),
                                                                                                                       List.of()));
 
-        when(diagnosticMessageModule.requestDM6(any(ResultsListener.class)))
+        when(communicationsModule.requestDM6(any(ResultsListener.class)))
                                                                             .thenReturn(new RequestResult<>(false,
                                                                                                             List.of(packet),
                                                                                                             List.of()));
-        when(diagnosticMessageModule.requestDM6(any(ResultsListener.class), eq(0x01)))
+        when(communicationsModule.requestDM6(any(ResultsListener.class), eq(0x01)))
                                                                                       .thenReturn(new RequestResult<>(false,
                                                                                                                       List.of(),
                                                                                                                       List.of()));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM6(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM6(any(ResultsListener.class), eq(0x00));
-        verify(diagnosticMessageModule).requestDM6(any(ResultsListener.class), eq(0x01));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM6(any(ResultsListener.class));
+        verify(communicationsModule).requestDM6(any(ResultsListener.class), eq(0x00));
+        verify(communicationsModule).requestDM6(any(ResultsListener.class), eq(0x01));
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -280,25 +280,25 @@ public class Part01Step17ControllerTest extends AbstractControllerTest {
 
         DM6PendingEmissionDTCPacket obdPacket3 = DM6PendingEmissionDTCPacket.create(0x03, OFF, OFF, OFF, OFF);
 
-        when(diagnosticMessageModule.requestDM6(any()))
+        when(communicationsModule.requestDM6(any()))
                                                        .thenReturn(new RequestResult<>(false,
                                                                                        List.of(packet1, packet3),
                                                                                        List.of()));
-        when(diagnosticMessageModule.requestDM6(any(), eq(0x01)))
+        when(communicationsModule.requestDM6(any(), eq(0x01)))
                                                                  .thenReturn(new RequestResult<>(false,
                                                                                                  List.of(packet1),
                                                                                                  List.of()));
-        when(diagnosticMessageModule.requestDM6(any(), eq(0x03)))
+        when(communicationsModule.requestDM6(any(), eq(0x03)))
                                                                  .thenReturn(new RequestResult<>(false,
                                                                                                  List.of(obdPacket3),
                                                                                                  List.of()));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM6(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM6(any(ResultsListener.class), eq(0x01));
-        verify(diagnosticMessageModule).requestDM6(any(), eq(0x03));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM6(any(ResultsListener.class));
+        verify(communicationsModule).requestDM6(any(ResultsListener.class), eq(0x01));
+        verify(communicationsModule).requestDM6(any(), eq(0x03));
 
         assertEquals("", listener.getResults());
 
@@ -368,26 +368,26 @@ public class Part01Step17ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0x00));
         dataRepository.putObdModule(new OBDModuleInformation(0x03));
 
-        when(diagnosticMessageModule.requestDM6(any(ResultsListener.class)))
+        when(communicationsModule.requestDM6(any(ResultsListener.class)))
                                                                             .thenReturn(new RequestResult<>(false,
                                                                                                             List.of(packet0,
                                                                                                                     packet3),
                                                                                                             List.of()));
-        when(diagnosticMessageModule.requestDM6(any(ResultsListener.class), eq(0x00)))
+        when(communicationsModule.requestDM6(any(ResultsListener.class), eq(0x00)))
                                                                                       .thenReturn(new RequestResult<>(false,
                                                                                                                       List.of(packet0),
                                                                                                                       List.of()));
-        when(diagnosticMessageModule.requestDM6(any(ResultsListener.class), eq(0x03)))
+        when(communicationsModule.requestDM6(any(ResultsListener.class), eq(0x03)))
                                                                                       .thenReturn(new RequestResult<>(false,
                                                                                                                       List.of(packet3),
                                                                                                                       List.of()));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM6(any());
-        verify(diagnosticMessageModule).requestDM6(any(ResultsListener.class), eq(0x00));
-        verify(diagnosticMessageModule).requestDM6(any(ResultsListener.class), eq(0x03));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM6(any());
+        verify(communicationsModule).requestDM6(any(ResultsListener.class), eq(0x00));
+        verify(communicationsModule).requestDM6(any(ResultsListener.class), eq(0x03));
 
         assertEquals("", listener.getResults());
 
@@ -456,26 +456,26 @@ public class Part01Step17ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0x01));
         dataRepository.putObdModule(new OBDModuleInformation(0x03));
 
-        when(diagnosticMessageModule.requestDM6(any(ResultsListener.class)))
+        when(communicationsModule.requestDM6(any(ResultsListener.class)))
                                                                             .thenReturn(new RequestResult<>(false,
                                                                                                             List.of(packet1,
                                                                                                                     packet3),
                                                                                                             List.of()));
-        when(diagnosticMessageModule.requestDM6(any(ResultsListener.class), eq(0x01)))
+        when(communicationsModule.requestDM6(any(ResultsListener.class), eq(0x01)))
                                                                                       .thenReturn(new RequestResult<>(false,
                                                                                                                       List.of(packet1),
                                                                                                                       List.of()));
-        when(diagnosticMessageModule.requestDM6(any(ResultsListener.class), eq(0x03)))
+        when(communicationsModule.requestDM6(any(ResultsListener.class), eq(0x03)))
                                                                                       .thenReturn(new RequestResult<>(false,
                                                                                                                       List.of(packet3),
                                                                                                                       List.of()));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM6(any());
-        verify(diagnosticMessageModule).requestDM6(any(), eq(0x01));
-        verify(diagnosticMessageModule).requestDM6(any(), eq(0x03));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM6(any());
+        verify(communicationsModule).requestDM6(any(), eq(0x01));
+        verify(communicationsModule).requestDM6(any(), eq(0x03));
 
         assertEquals("", listener.getResults());
 
@@ -531,20 +531,20 @@ public class Part01Step17ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(0x01));
 
-        when(diagnosticMessageModule.requestDM6(any(ResultsListener.class)))
+        when(communicationsModule.requestDM6(any(ResultsListener.class)))
                                                                             .thenReturn(new RequestResult<>(false,
                                                                                                             List.of(),
                                                                                                             List.of()));
-        when(diagnosticMessageModule.requestDM6(any(ResultsListener.class), eq(0x01)))
+        when(communicationsModule.requestDM6(any(ResultsListener.class), eq(0x01)))
                                                                                       .thenReturn(new RequestResult<>(false,
                                                                                                                       List.of(),
                                                                                                                       List.of(ackPacket1)));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM6(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM6(any(ResultsListener.class), eq(0x01));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM6(any(ResultsListener.class));
+        verify(communicationsModule).requestDM6(any(ResultsListener.class), eq(0x01));
 
         assertEquals("", listener.getResults());
 
@@ -637,20 +637,20 @@ public class Part01Step17ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(0x01));
 
-        when(diagnosticMessageModule.requestDM6(any(ResultsListener.class)))
+        when(communicationsModule.requestDM6(any(ResultsListener.class)))
                                                        .thenReturn(new RequestResult<>(false,
                                                                                        List.of(packet1),
                                                                                        List.of()));
-        when(diagnosticMessageModule.requestDM6(any(ResultsListener.class), eq(0x01)))
+        when(communicationsModule.requestDM6(any(ResultsListener.class), eq(0x01)))
                                                                  .thenReturn(new RequestResult<>(false,
                                                                                                  List.of(packet1),
                                                                                                  List.of()));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM6(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM6(any(ResultsListener.class), eq(0x01));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM6(any(ResultsListener.class));
+        verify(communicationsModule).requestDM6(any(ResultsListener.class), eq(0x01));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step18ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step18ControllerTest.java
@@ -31,7 +31,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -62,7 +62,7 @@ public class Part01Step18ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -98,7 +98,7 @@ public class Part01Step18ControllerTest extends AbstractControllerTest {
                                               engineSpeedModule,
                                               bannerModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               dataRepository,
                                               DateTimeModule.getInstance());
 
@@ -109,7 +109,7 @@ public class Part01Step18ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -118,7 +118,7 @@ public class Part01Step18ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -211,22 +211,22 @@ public class Part01Step18ControllerTest extends AbstractControllerTest {
                                                                                     OFF,
                                                                                     OFF);
 
-        when(diagnosticMessageModule.requestDM12(any(ResultsListener.class)))
+        when(communicationsModule.requestDM12(any(ResultsListener.class)))
                                                                              .thenReturn(new RequestResult<>(false,
                                                                                                              List.of(dm12Packet33),
                                                                                                              List.of()));
-        when(diagnosticMessageModule.requestDM12(any(ResultsListener.class), eq(0x01)))
+        when(communicationsModule.requestDM12(any(ResultsListener.class), eq(0x01)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    Optional.empty()));
-        when(diagnosticMessageModule.requestDM12(any(ResultsListener.class), eq(0x33)))
+        when(communicationsModule.requestDM12(any(ResultsListener.class), eq(0x33)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    dm12Packet33));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any());
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0x01));
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0x33));
+        verify(communicationsModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any(), eq(0x01));
+        verify(communicationsModule).requestDM12(any(), eq(0x33));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -311,24 +311,24 @@ public class Part01Step18ControllerTest extends AbstractControllerTest {
 
         DM12MILOnEmissionDTCPacket obdPacket3 = DM12MILOnEmissionDTCPacket.create(0x03, OFF, OFF, OFF, OFF);
 
-        when(diagnosticMessageModule.requestDM12(any(ResultsListener.class)))
+        when(communicationsModule.requestDM12(any(ResultsListener.class)))
                                                                              .thenReturn(new RequestResult<>(false,
                                                                                                              List.of(packet1,
                                                                                                                      packet3),
                                                                                                              List.of()));
 
-        when(diagnosticMessageModule.requestDM12(any(ResultsListener.class), eq(0x01)))
+        when(communicationsModule.requestDM12(any(ResultsListener.class), eq(0x01)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    packet1));
-        when(diagnosticMessageModule.requestDM12(any(ResultsListener.class), eq(0x03)))
+        when(communicationsModule.requestDM12(any(ResultsListener.class), eq(0x03)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    obdPacket3));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM12(any(ResultsListener.class), eq(0x01));
-        verify(diagnosticMessageModule).requestDM12(any(ResultsListener.class), eq(0x03));
+        verify(communicationsModule).requestDM12(any(ResultsListener.class));
+        verify(communicationsModule).requestDM12(any(ResultsListener.class), eq(0x01));
+        verify(communicationsModule).requestDM12(any(ResultsListener.class), eq(0x03));
 
         assertEquals("", listener.getResults());
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -396,7 +396,7 @@ public class Part01Step18ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0x01));
         DiagnosticTroubleCode dtc = DiagnosticTroubleCode.create(609, 19, 0, 0);
         DM12MILOnEmissionDTCPacket packet1 = DM12MILOnEmissionDTCPacket.create(0x01, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM12(any(ResultsListener.class), eq(0x01)))
+        when(communicationsModule.requestDM12(any(ResultsListener.class), eq(0x01)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    packet1));
         dataRepository.putObdModule(new OBDModuleInformation(0x03));
@@ -411,11 +411,11 @@ public class Part01Step18ControllerTest extends AbstractControllerTest {
                                                                                           0x00,
                                                                                           0x00,
                                                                                           0x00));
-        when(diagnosticMessageModule.requestDM12(any(ResultsListener.class), eq(0x03)))
+        when(communicationsModule.requestDM12(any(ResultsListener.class), eq(0x03)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    packet3));
 
-        when(diagnosticMessageModule.requestDM12(any(ResultsListener.class)))
+        when(communicationsModule.requestDM12(any(ResultsListener.class)))
                                                                              .thenReturn(new RequestResult<>(false,
                                                                                                              List.of(packet1,
                                                                                                                      packet3),
@@ -423,9 +423,9 @@ public class Part01Step18ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM12(any(ResultsListener.class), eq(0x01));
-        verify(diagnosticMessageModule).requestDM12(any(ResultsListener.class), eq(0x03));
+        verify(communicationsModule).requestDM12(any(ResultsListener.class));
+        verify(communicationsModule).requestDM12(any(ResultsListener.class), eq(0x01));
+        verify(communicationsModule).requestDM12(any(ResultsListener.class), eq(0x03));
 
         assertEquals("", listener.getResults());
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -492,17 +492,17 @@ public class Part01Step18ControllerTest extends AbstractControllerTest {
     public void testMilNotOffFailure() {
         dataRepository.putObdModule(new OBDModuleInformation(0x01));
         DM12MILOnEmissionDTCPacket packet1 = DM12MILOnEmissionDTCPacket.create(0x01, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM12(any(ResultsListener.class), eq(0x01)))
+        when(communicationsModule.requestDM12(any(ResultsListener.class), eq(0x01)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    packet1));
 
         dataRepository.putObdModule(new OBDModuleInformation(0x03));
         DM12MILOnEmissionDTCPacket packet3 = DM12MILOnEmissionDTCPacket.create(0x03, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM12(any(ResultsListener.class), eq(0x03)))
+        when(communicationsModule.requestDM12(any(ResultsListener.class), eq(0x03)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    packet3));
 
-        when(diagnosticMessageModule.requestDM12(any(ResultsListener.class)))
+        when(communicationsModule.requestDM12(any(ResultsListener.class)))
                                                                              .thenReturn(new RequestResult<>(false,
                                                                                                              List.of(packet1,
                                                                                                                      packet3),
@@ -510,9 +510,9 @@ public class Part01Step18ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any());
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0x01));
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0x03));
+        verify(communicationsModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any(), eq(0x01));
+        verify(communicationsModule).requestDM12(any(), eq(0x03));
 
         assertEquals("", listener.getResults());
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -567,19 +567,19 @@ public class Part01Step18ControllerTest extends AbstractControllerTest {
     public void testNoObdProvidesDm12Failure() {
         dataRepository.putObdModule(new OBDModuleInformation(0x01));
         AcknowledgmentPacket ackPacket1 = AcknowledgmentPacket.create(0x01, NACK);
-        when(diagnosticMessageModule.requestDM12(any(ResultsListener.class), eq(0x01)))
+        when(communicationsModule.requestDM12(any(ResultsListener.class), eq(0x01)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    ackPacket1));
 
-        when(diagnosticMessageModule.requestDM12(any(ResultsListener.class)))
+        when(communicationsModule.requestDM12(any(ResultsListener.class)))
                                                                              .thenReturn(new RequestResult<>(false,
                                                                                                              List.of(),
                                                                                                              List.of()));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM12(any(ResultsListener.class), eq(0x01));
+        verify(communicationsModule).requestDM12(any(ResultsListener.class));
+        verify(communicationsModule).requestDM12(any(ResultsListener.class), eq(0x01));
 
         assertEquals("", listener.getResults());
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -656,23 +656,23 @@ public class Part01Step18ControllerTest extends AbstractControllerTest {
                                                                                           0x00,
                                                                                           0x00,
                                                                                           0x00));
-        when(diagnosticMessageModule.requestDM12(any(ResultsListener.class),
-                                                 eq(0x01))).thenReturn(new BusResult<>(false, packet1));
+        when(communicationsModule.requestDM12(any(ResultsListener.class),
+                                              eq(0x01))).thenReturn(new BusResult<>(false, packet1));
 
         dataRepository.putObdModule(new OBDModuleInformation(0x33));
         AcknowledgmentPacket ackPacket33 = AcknowledgmentPacket.create(0x33, NACK);
-        when(diagnosticMessageModule.requestDM12(any(ResultsListener.class),
-                                                 eq(0x33))).thenReturn(new BusResult<>(false, ackPacket33));
+        when(communicationsModule.requestDM12(any(ResultsListener.class),
+                                              eq(0x33))).thenReturn(new BusResult<>(false, ackPacket33));
 
-        when(diagnosticMessageModule.requestDM12(any(ResultsListener.class))).thenReturn(new RequestResult<>(false,
-                                                                                                             packet1));
+        when(communicationsModule.requestDM12(any(ResultsListener.class))).thenReturn(new RequestResult<>(false,
+                                                                                                          packet1));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM12(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM12(any(ResultsListener.class), eq(0x01));
-        verify(diagnosticMessageModule).requestDM12(any(ResultsListener.class), eq(0x33));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM12(any(ResultsListener.class));
+        verify(communicationsModule).requestDM12(any(ResultsListener.class), eq(0x01));
+        verify(communicationsModule).requestDM12(any(ResultsListener.class), eq(0x33));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step19ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step19ControllerTest.java
@@ -32,7 +32,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -62,7 +62,7 @@ public class Part01Step19ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -97,7 +97,7 @@ public class Part01Step19ControllerTest extends AbstractControllerTest {
                                               engineSpeedModule,
                                               bannerModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               dataRepository,
                                               DateTimeModule.getInstance());
 
@@ -108,7 +108,7 @@ public class Part01Step19ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -117,7 +117,7 @@ public class Part01Step19ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -205,22 +205,22 @@ public class Part01Step19ControllerTest extends AbstractControllerTest {
     public void testNackNotReceivedFailure() {
 
         dataRepository.putObdModule(new OBDModuleInformation(0x01));
-        when(diagnosticMessageModule.requestDM23(any(ResultsListener.class),
-                                                 eq(0x01))).thenReturn(new BusResult<>(false, Optional.empty()));
+        when(communicationsModule.requestDM23(any(ResultsListener.class),
+                                              eq(0x01))).thenReturn(new BusResult<>(false, Optional.empty()));
 
         dataRepository.putObdModule(new OBDModuleInformation(0x58));
         var packet58 = DM23PreviouslyMILOnEmissionDTCPacket.create(0x58, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM23(any(ResultsListener.class),
-                                                 eq(0x58))).thenReturn(new BusResult<>(false, packet58));
+        when(communicationsModule.requestDM23(any(ResultsListener.class),
+                                              eq(0x58))).thenReturn(new BusResult<>(false, packet58));
 
-        when(diagnosticMessageModule.requestDM23(any(ResultsListener.class))).thenReturn(new RequestResult<>(false,
-                                                                                                             packet58));
+        when(communicationsModule.requestDM23(any(ResultsListener.class))).thenReturn(new RequestResult<>(false,
+                                                                                                          packet58));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM23(any(ResultsListener.class), eq(0x01));
-        verify(diagnosticMessageModule).requestDM23(any(ResultsListener.class), eq(0x58));
+        verify(communicationsModule).requestDM23(any(ResultsListener.class));
+        verify(communicationsModule).requestDM23(any(ResultsListener.class), eq(0x01));
+        verify(communicationsModule).requestDM23(any(ResultsListener.class), eq(0x58));
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -299,7 +299,7 @@ public class Part01Step19ControllerTest extends AbstractControllerTest {
                                                                                                               0x00,
                                                                                                               0x00,
                                                                                                               0x00));
-        when(diagnosticMessageModule.requestDM23(any(ResultsListener.class), eq(0x01)))
+        when(communicationsModule.requestDM23(any(ResultsListener.class), eq(0x01)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    packet1));
 
@@ -309,7 +309,7 @@ public class Part01Step19ControllerTest extends AbstractControllerTest {
                                                                                                    ON,
                                                                                                    OFF,
                                                                                                    OFF);
-        when(diagnosticMessageModule.requestDM23(any(ResultsListener.class)))
+        when(communicationsModule.requestDM23(any(ResultsListener.class)))
                                                                              .thenReturn(new RequestResult<>(false,
                                                                                                              packet1,
                                                                                                              packet3));
@@ -319,15 +319,15 @@ public class Part01Step19ControllerTest extends AbstractControllerTest {
                                                                                                       OFF,
                                                                                                       OFF,
                                                                                                       OFF);
-        when(diagnosticMessageModule.requestDM23(any(ResultsListener.class), eq(0x03)))
+        when(communicationsModule.requestDM23(any(ResultsListener.class), eq(0x03)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    obdPacket3));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM23(any(ResultsListener.class), eq(0x01));
-        verify(diagnosticMessageModule).requestDM23(any(ResultsListener.class), eq(0x03));
+        verify(communicationsModule).requestDM23(any(ResultsListener.class));
+        verify(communicationsModule).requestDM23(any(ResultsListener.class), eq(0x01));
+        verify(communicationsModule).requestDM23(any(ResultsListener.class), eq(0x03));
 
         assertEquals("", listener.getResults());
 
@@ -405,7 +405,7 @@ public class Part01Step19ControllerTest extends AbstractControllerTest {
                                                                                                    dtc1,
                                                                                                    dtc2,
                                                                                                    dtc3);
-        when(diagnosticMessageModule.requestDM23(any(ResultsListener.class), eq(0x01)))
+        when(communicationsModule.requestDM23(any(ResultsListener.class), eq(0x01)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    packet1));
 
@@ -420,19 +420,19 @@ public class Part01Step19ControllerTest extends AbstractControllerTest {
                                                                                                               0x00,
                                                                                                               0x00,
                                                                                                               0x00));
-        when(diagnosticMessageModule.requestDM23(any(ResultsListener.class),
-                                                 eq(0x03))).thenReturn(new BusResult<>(false,
+        when(communicationsModule.requestDM23(any(ResultsListener.class),
+                                              eq(0x03))).thenReturn(new BusResult<>(false,
                                                                                        packet3));
 
-        when(diagnosticMessageModule.requestDM23(any(ResultsListener.class))).thenReturn(new RequestResult<>(false,
-                                                                                                             packet1,
-                                                                                                             packet3));
+        when(communicationsModule.requestDM23(any(ResultsListener.class))).thenReturn(new RequestResult<>(false,
+                                                                                                          packet1,
+                                                                                                          packet3));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM23(any(ResultsListener.class), eq(0x01));
-        verify(diagnosticMessageModule).requestDM23(any(ResultsListener.class), eq(0x03));
+        verify(communicationsModule).requestDM23(any(ResultsListener.class));
+        verify(communicationsModule).requestDM23(any(ResultsListener.class), eq(0x01));
+        verify(communicationsModule).requestDM23(any(ResultsListener.class), eq(0x03));
 
         assertEquals("", listener.getResults());
 
@@ -505,7 +505,7 @@ public class Part01Step19ControllerTest extends AbstractControllerTest {
                                                                                                    OFF,
                                                                                                    OFF,
                                                                                                    OFF);
-        when(diagnosticMessageModule.requestDM23(any(ResultsListener.class), eq(0x01)))
+        when(communicationsModule.requestDM23(any(ResultsListener.class), eq(0x01)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    packet1));
 
@@ -521,20 +521,20 @@ public class Part01Step19ControllerTest extends AbstractControllerTest {
                                                                                                               0x00,
                                                                                                               0x00,
                                                                                                               0x00));
-        when(diagnosticMessageModule.requestDM23(any(ResultsListener.class), eq(0x03)))
+        when(communicationsModule.requestDM23(any(ResultsListener.class), eq(0x03)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    packet3));
 
-        when(diagnosticMessageModule.requestDM23(any(ResultsListener.class)))
+        when(communicationsModule.requestDM23(any(ResultsListener.class)))
                                                                              .thenReturn(new RequestResult<>(false,
                                                                                                              packet1,
                                                                                                              packet3));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM23(any(ResultsListener.class), eq(0x01));
-        verify(diagnosticMessageModule).requestDM23(any(ResultsListener.class), eq(0x03));
+        verify(communicationsModule).requestDM23(any(ResultsListener.class));
+        verify(communicationsModule).requestDM23(any(ResultsListener.class), eq(0x01));
+        verify(communicationsModule).requestDM23(any(ResultsListener.class), eq(0x03));
 
         assertEquals("", listener.getResults());
 
@@ -589,18 +589,18 @@ public class Part01Step19ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0x01));
         AcknowledgmentPacket packet1 = AcknowledgmentPacket.create(0x01, NACK);
 
-        when(diagnosticMessageModule.requestDM23(any(ResultsListener.class), eq(0x01)))
+        when(communicationsModule.requestDM23(any(ResultsListener.class), eq(0x01)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    packet1));
 
-        when(diagnosticMessageModule.requestDM23(any(ResultsListener.class)))
+        when(communicationsModule.requestDM23(any(ResultsListener.class)))
                                                                              .thenReturn(new RequestResult<>(false,
                                                                                                              List.of()));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM23(any(ResultsListener.class), eq(0x01));
+        verify(communicationsModule).requestDM23(any(ResultsListener.class));
+        verify(communicationsModule).requestDM23(any(ResultsListener.class), eq(0x01));
 
         assertEquals("", listener.getResults());
 
@@ -669,7 +669,7 @@ public class Part01Step19ControllerTest extends AbstractControllerTest {
     public void testNoErrors() {
         dataRepository.putObdModule(new OBDModuleInformation(0x01));
         AcknowledgmentPacket ackPacket1 = AcknowledgmentPacket.create(0x01, NACK);
-        when(diagnosticMessageModule.requestDM23(any(ResultsListener.class), eq(0x01)))
+        when(communicationsModule.requestDM23(any(ResultsListener.class), eq(0x01)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    ackPacket1));
 
@@ -684,19 +684,19 @@ public class Part01Step19ControllerTest extends AbstractControllerTest {
                                                                                                               0x00,
                                                                                                               0x00,
                                                                                                               0x00));
-        when(diagnosticMessageModule.requestDM23(any(ResultsListener.class), eq(0x33)))
+        when(communicationsModule.requestDM23(any(ResultsListener.class), eq(0x33)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    packet33));
 
-        when(diagnosticMessageModule.requestDM23(any(ResultsListener.class)))
+        when(communicationsModule.requestDM23(any(ResultsListener.class)))
                                                                              .thenReturn(new RequestResult<>(false,
                                                                                                              packet33));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any());
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0x01));
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0x33));
+        verify(communicationsModule).requestDM23(any());
+        verify(communicationsModule).requestDM23(any(), eq(0x01));
+        verify(communicationsModule).requestDM23(any(), eq(0x33));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step20ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step20ControllerTest.java
@@ -32,7 +32,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -62,7 +62,7 @@ public class Part01Step20ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -97,7 +97,7 @@ public class Part01Step20ControllerTest extends AbstractControllerTest {
                                               engineSpeedModule,
                                               bannerModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               dataRepository,
                                               DateTimeModule.getInstance());
 
@@ -108,7 +108,7 @@ public class Part01Step20ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -117,7 +117,7 @@ public class Part01Step20ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -203,22 +203,22 @@ public class Part01Step20ControllerTest extends AbstractControllerTest {
             @TestItem(verifies = "6.1.20.4.b", description = "Fail if NACK not received from OBD ECUs that did not respond to global query.") })
     public void testNackNotReceivedFailure() {
         dataRepository.putObdModule(new OBDModuleInformation(0x01));
-        when(diagnosticMessageModule.requestDM28(any(ResultsListener.class),
-                                                 eq(0x01))).thenReturn(new BusResult<>(false));
+        when(communicationsModule.requestDM28(any(ResultsListener.class),
+                                              eq(0x01))).thenReturn(new BusResult<>(false));
 
         dataRepository.putObdModule(new OBDModuleInformation(0x21));
         var packet21 = DM28PermanentEmissionDTCPacket.create(0x21, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM28(any(ResultsListener.class),
-                                                 eq(0x21))).thenReturn(new BusResult<>(false, packet21));
+        when(communicationsModule.requestDM28(any(ResultsListener.class),
+                                              eq(0x21))).thenReturn(new BusResult<>(false, packet21));
 
-        when(diagnosticMessageModule.requestDM28(any(ResultsListener.class))).thenReturn(new RequestResult<>(false,
-                                                                                                             packet21));
+        when(communicationsModule.requestDM28(any(ResultsListener.class))).thenReturn(new RequestResult<>(false,
+                                                                                                          packet21));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM28(any(ResultsListener.class), eq(0x01));
-        verify(diagnosticMessageModule).requestDM28(any(ResultsListener.class), eq(0x21));
+        verify(communicationsModule).requestDM28(any(ResultsListener.class));
+        verify(communicationsModule).requestDM28(any(ResultsListener.class), eq(0x01));
+        verify(communicationsModule).requestDM28(any(ResultsListener.class), eq(0x21));
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -294,7 +294,7 @@ public class Part01Step20ControllerTest extends AbstractControllerTest {
                                                                                                   0x00,
                                                                                                   0x00,
                                                                                                   0x00));
-        when(diagnosticMessageModule.requestDM28(any(ResultsListener.class), eq(0x01)))
+        when(communicationsModule.requestDM28(any(ResultsListener.class), eq(0x01)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    packet1));
 
@@ -305,7 +305,7 @@ public class Part01Step20ControllerTest extends AbstractControllerTest {
                                                                                         OFF,
                                                                                         OFF,
                                                                                         OFF);
-        when(diagnosticMessageModule.requestDM28(any(ResultsListener.class)))
+        when(communicationsModule.requestDM28(any(ResultsListener.class)))
                                                                              .thenReturn(new RequestResult<>(false,
                                                                                                              packet1,
                                                                                                              packet17));
@@ -316,14 +316,14 @@ public class Part01Step20ControllerTest extends AbstractControllerTest {
                                                                                            OFF,
                                                                                            ON,
                                                                                            OFF);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0x17)))
+        when(communicationsModule.requestDM28(any(), eq(0x17)))
                                                                   .thenReturn(new BusResult<>(false, obdPacket17));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM28(any(ResultsListener.class), eq(0x01));
-        verify(diagnosticMessageModule).requestDM28(any(ResultsListener.class), eq(0x17));
+        verify(communicationsModule).requestDM28(any(ResultsListener.class));
+        verify(communicationsModule).requestDM28(any(ResultsListener.class), eq(0x01));
+        verify(communicationsModule).requestDM28(any(ResultsListener.class), eq(0x17));
 
         assertEquals("", listener.getResults());
 
@@ -388,8 +388,8 @@ public class Part01Step20ControllerTest extends AbstractControllerTest {
     public void testEcuReportPermanentDtcFailure() {
         dataRepository.putObdModule(new OBDModuleInformation(0x01));
         var ackPacket1 = AcknowledgmentPacket.create(0x01, NACK);
-        when(diagnosticMessageModule.requestDM28(any(ResultsListener.class),
-                                                 eq(0x01))).thenReturn(new BusResult<>(false, ackPacket1));
+        when(communicationsModule.requestDM28(any(ResultsListener.class),
+                                              eq(0x01))).thenReturn(new BusResult<>(false, ackPacket1));
 
         dataRepository.putObdModule(new OBDModuleInformation(0x03));
         var dtc3 = DiagnosticTroubleCode.create(609, 19, 0, 0);
@@ -401,18 +401,18 @@ public class Part01Step20ControllerTest extends AbstractControllerTest {
                                                             OFF,
                                                             dtc3);
 
-        when(diagnosticMessageModule.requestDM28(any()))
+        when(communicationsModule.requestDM28(any()))
                                                         .thenReturn(new RequestResult<>(false,
                                                                                         List.of(packet3),
                                                                                         List.of(ackPacket1)));
-        when(diagnosticMessageModule.requestDM28(any(), eq(0x03)))
+        when(communicationsModule.requestDM28(any(), eq(0x03)))
                                                                   .thenReturn(new BusResult<>(false, packet3));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any());
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0x01));
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0x03));
+        verify(communicationsModule).requestDM28(any());
+        verify(communicationsModule).requestDM28(any(), eq(0x01));
+        verify(communicationsModule).requestDM28(any(), eq(0x03));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -478,8 +478,8 @@ public class Part01Step20ControllerTest extends AbstractControllerTest {
     public void testEcuDoesNotReportMilOffFailure() {
         dataRepository.putObdModule(new OBDModuleInformation(0x01));
         var packet1 = DM28PermanentEmissionDTCPacket.create(0x01, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM28(any(ResultsListener.class),
-                                                 eq(0x01))).thenReturn(new BusResult<>(false, packet1));
+        when(communicationsModule.requestDM28(any(ResultsListener.class),
+                                              eq(0x01))).thenReturn(new BusResult<>(false, packet1));
 
         dataRepository.putObdModule(new OBDModuleInformation(0x03));
         var packet3 = DM28PermanentEmissionDTCPacket.create(
@@ -488,11 +488,11 @@ public class Part01Step20ControllerTest extends AbstractControllerTest {
                                                             OFF,
                                                             OFF,
                                                             OFF);
-        when(diagnosticMessageModule.requestDM28(any(ResultsListener.class), eq(0x03)))
+        when(communicationsModule.requestDM28(any(ResultsListener.class), eq(0x03)))
                                                                                        .thenReturn(new BusResult<>(false,
                                                                                                                    packet3));
 
-        when(diagnosticMessageModule.requestDM28(any(ResultsListener.class)))
+        when(communicationsModule.requestDM28(any(ResultsListener.class)))
                                                                              .thenReturn(new RequestResult<>(false,
                                                                                                              List.of(packet1,
                                                                                                                      packet3),
@@ -500,9 +500,9 @@ public class Part01Step20ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any());
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0x01));
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0x03));
+        verify(communicationsModule).requestDM28(any());
+        verify(communicationsModule).requestDM28(any(), eq(0x01));
+        verify(communicationsModule).requestDM28(any(), eq(0x03));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -556,18 +556,18 @@ public class Part01Step20ControllerTest extends AbstractControllerTest {
     public void testNoObdProvidesDm28Failure() {
         dataRepository.putObdModule(new OBDModuleInformation(0x01));
         var ackPacket1 = AcknowledgmentPacket.create(0x01, NACK);
-        when(diagnosticMessageModule.requestDM28(any(ResultsListener.class),
-                                                 eq(0x01))).thenReturn(new BusResult<>(false, ackPacket1));
+        when(communicationsModule.requestDM28(any(ResultsListener.class),
+                                              eq(0x01))).thenReturn(new BusResult<>(false, ackPacket1));
 
-        when(diagnosticMessageModule.requestDM28(any(ResultsListener.class)))
+        when(communicationsModule.requestDM28(any(ResultsListener.class)))
                                                                              .thenReturn(new RequestResult<>(false,
                                                                                                              List.of(),
                                                                                                              List.of()));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(ResultsListener.class));
-        verify(diagnosticMessageModule).requestDM28(any(ResultsListener.class), eq(0x01));
+        verify(communicationsModule).requestDM28(any(ResultsListener.class));
+        verify(communicationsModule).requestDM28(any(ResultsListener.class), eq(0x01));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -635,21 +635,21 @@ public class Part01Step20ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0x01));
         var ackPacket1 = AcknowledgmentPacket.create(0x01,
                                                      NACK);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0x01)))
+        when(communicationsModule.requestDM28(any(), eq(0x01)))
                                                                   .thenReturn(new BusResult<>(false, ackPacket1));
 
         dataRepository.putObdModule(new OBDModuleInformation(0x21));
         var packet21 = DM28PermanentEmissionDTCPacket.create(0x21, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0x21)))
+        when(communicationsModule.requestDM28(any(), eq(0x21)))
                                                                   .thenReturn(new BusResult<>(false, packet21));
-        when(diagnosticMessageModule.requestDM28(any()))
+        when(communicationsModule.requestDM28(any()))
                                                         .thenReturn(new RequestResult<>(false, packet21));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any());
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0x01));
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0x21));
+        verify(communicationsModule).requestDM28(any());
+        verify(communicationsModule).requestDM28(any(), eq(0x01));
+        verify(communicationsModule).requestDM28(any(), eq(0x21));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step21ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step21ControllerTest.java
@@ -27,7 +27,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -56,7 +56,7 @@ public class Part01Step21ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -91,7 +91,7 @@ public class Part01Step21ControllerTest extends AbstractControllerTest {
                                               engineSpeedModule,
                                               bannerModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               dataRepository,
                                               DateTimeModule.getInstance());
 
@@ -102,7 +102,7 @@ public class Part01Step21ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -111,7 +111,7 @@ public class Part01Step21ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -135,16 +135,16 @@ public class Part01Step21ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
-        when(diagnosticMessageModule.requestDM27(any()))
+        when(communicationsModule.requestDM27(any()))
                                                         .thenReturn(new RequestResult<>(false, List.of(), List.of()));
-        when(diagnosticMessageModule.requestDM27(any(), eq(0x01)))
+        when(communicationsModule.requestDM27(any(), eq(0x01)))
                                                                   .thenReturn(new BusResult<>(false, Optional.empty()));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0x01));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0x01));
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -194,22 +194,22 @@ public class Part01Step21ControllerTest extends AbstractControllerTest {
                                                                                          0x77,
                                                                                          0x88));
 
-        when(diagnosticMessageModule.requestDM27(any()))
+        when(communicationsModule.requestDM27(any()))
                                                         .thenReturn(new RequestResult<>(false,
                                                                                         List.of(packet1, packet3),
                                                                                         List.of()));
 
-        when(diagnosticMessageModule.requestDM27(any(), eq(0x01)))
+        when(communicationsModule.requestDM27(any(), eq(0x01)))
                                                                   .thenReturn(new BusResult<>(false, packet1));
-        when(diagnosticMessageModule.requestDM27(any(), eq(0x03)))
+        when(communicationsModule.requestDM27(any(), eq(0x03)))
                                                                   .thenReturn(new BusResult<>(false, obdPacket3));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0x01));
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0x03));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0x01));
+        verify(communicationsModule).requestDM27(any(), eq(0x03));
 
         assertEquals("", listener.getResults());
 
@@ -274,18 +274,18 @@ public class Part01Step21ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
         dataRepository.putObdModule(new OBDModuleInformation(3));
 
-        when(diagnosticMessageModule.requestDM27(any())).thenReturn(new RequestResult<>(false,
-                                                                                        List.of(),
-                                                                                        List.of(ackPacket)));
-        when(diagnosticMessageModule.requestDM27(any(), eq(0x01))).thenReturn(new BusResult<>(false, ackPacket));
-        when(diagnosticMessageModule.requestDM27(any(), eq(0x03))).thenReturn(new BusResult<>(false, packet3));
+        when(communicationsModule.requestDM27(any())).thenReturn(new RequestResult<>(false,
+                                                                                     List.of(),
+                                                                                     List.of(ackPacket)));
+        when(communicationsModule.requestDM27(any(), eq(0x01))).thenReturn(new BusResult<>(false, ackPacket));
+        when(communicationsModule.requestDM27(any(), eq(0x03))).thenReturn(new BusResult<>(false, packet3));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0x01));
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0x03));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0x01));
+        verify(communicationsModule).requestDM27(any(), eq(0x03));
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -347,18 +347,18 @@ public class Part01Step21ControllerTest extends AbstractControllerTest {
                                                                                        0xFF,
                                                                                        0xFF));
 
-        when(diagnosticMessageModule.requestDM27(any())).thenReturn(new RequestResult<>(false,
-                                                                                        List.of(packet3),
-                                                                                        List.of(ackPacket)));
-        when(diagnosticMessageModule.requestDM27(any(), eq(0x01))).thenReturn(new BusResult<>(false, packet1));
-        when(diagnosticMessageModule.requestDM27(any(), eq(0x03))).thenReturn(new BusResult<>(false, packet3b));
+        when(communicationsModule.requestDM27(any())).thenReturn(new RequestResult<>(false,
+                                                                                     List.of(packet3),
+                                                                                     List.of(ackPacket)));
+        when(communicationsModule.requestDM27(any(), eq(0x01))).thenReturn(new BusResult<>(false, packet1));
+        when(communicationsModule.requestDM27(any(), eq(0x03))).thenReturn(new BusResult<>(false, packet3b));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0x01));
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0x03));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0x01));
+        verify(communicationsModule).requestDM27(any(), eq(0x03));
 
         verify(mockListener).addOutcome(
                                         PART_NUMBER,
@@ -430,19 +430,19 @@ public class Part01Step21ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
         dataRepository.putObdModule(new OBDModuleInformation(3));
 
-        when(diagnosticMessageModule.requestDM27(any()))
+        when(communicationsModule.requestDM27(any()))
                                                         .thenReturn(new RequestResult<>(false,
                                                                                         List.of(packet1, packet3),
                                                                                         List.of(ackPacket)));
-        when(diagnosticMessageModule.requestDM27(any(), eq(0x01))).thenReturn(new BusResult<>(false, packet1));
-        when(diagnosticMessageModule.requestDM27(any(), eq(0x03))).thenReturn(new BusResult<>(false, Optional.empty()));
+        when(communicationsModule.requestDM27(any(), eq(0x01))).thenReturn(new BusResult<>(false, packet1));
+        when(communicationsModule.requestDM27(any(), eq(0x03))).thenReturn(new BusResult<>(false, Optional.empty()));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0x01));
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0x03));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0x01));
+        verify(communicationsModule).requestDM27(any(), eq(0x03));
 
         verify(mockListener).addOutcome(
                                         PART_NUMBER,
@@ -485,14 +485,14 @@ public class Part01Step21ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
-        when(diagnosticMessageModule.requestDM27(any())).thenReturn(RequestResult.of(packet1));
-        when(diagnosticMessageModule.requestDM27(any(), eq(0x01))).thenReturn(BusResult.of(packet1));
+        when(communicationsModule.requestDM27(any())).thenReturn(RequestResult.of(packet1));
+        when(communicationsModule.requestDM27(any(), eq(0x01))).thenReturn(BusResult.of(packet1));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0x01));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0x01));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -524,14 +524,14 @@ public class Part01Step21ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
-        when(diagnosticMessageModule.requestDM27(any())).thenReturn(RequestResult.of(packet1, packet2));
-        when(diagnosticMessageModule.requestDM27(any(), eq(0x01))).thenReturn(BusResult.of(packet1));
+        when(communicationsModule.requestDM27(any())).thenReturn(RequestResult.of(packet1, packet2));
+        when(communicationsModule.requestDM27(any(), eq(0x01))).thenReturn(BusResult.of(packet1));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0x01));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0x01));
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step22ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step22ControllerTest.java
@@ -25,7 +25,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -53,7 +53,7 @@ public class Part01Step22ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -91,7 +91,7 @@ public class Part01Step22ControllerTest extends AbstractControllerTest {
                                               engineSpeedModule,
                                               bannerModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               dataRepository,
                                               DateTimeModule.getInstance());
 
@@ -102,7 +102,7 @@ public class Part01Step22ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -111,7 +111,7 @@ public class Part01Step22ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -139,14 +139,14 @@ public class Part01Step22ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(dm27(1), 1);
         dataRepository.putObdModule(obdModuleInformation);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(new RequestResult<>(false, packet1));
-        when(diagnosticMessageModule.requestDM29(any(), eq(0x01))).thenReturn(BusResult.of(packet1));
+        when(communicationsModule.requestDM29(any())).thenReturn(new RequestResult<>(false, packet1));
+        when(communicationsModule.requestDM29(any(), eq(0x01))).thenReturn(BusResult.of(packet1));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM29(any());
-        verify(diagnosticMessageModule).requestDM29(any(), eq(0x01));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any(), eq(0x01));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -189,7 +189,7 @@ public class Part01Step22ControllerTest extends AbstractControllerTest {
         DM29DtcCounts packet71 = DM29DtcCounts.create(0x07, 0, 0, 0xFF, 0, 0, 0);
         DM29DtcCounts packet72 = DM29DtcCounts.create(0x07, 0, 1, 0xFF, 0, 0, 0);
 
-        when(diagnosticMessageModule.requestDM29(any()))
+        when(communicationsModule.requestDM29(any()))
                                                         .thenReturn(new RequestResult<>(false,
                                                                                         packet0,
                                                                                         packet1,
@@ -199,23 +199,23 @@ public class Part01Step22ControllerTest extends AbstractControllerTest {
                                                                                         packet6,
                                                                                         packet71));
 
-        when(diagnosticMessageModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(packet0));
-        when(diagnosticMessageModule.requestDM29(any(), eq(1))).thenReturn(BusResult.of(packet1));
-        when(diagnosticMessageModule.requestDM29(any(), eq(2))).thenReturn(BusResult.of(packet2));
-        when(diagnosticMessageModule.requestDM29(any(), eq(3))).thenReturn(BusResult.of(packet3));
-        when(diagnosticMessageModule.requestDM29(any(), eq(4))).thenReturn(new BusResult<>(true));
-        when(diagnosticMessageModule.requestDM29(any(), eq(7))).thenReturn(BusResult.of(packet72));
+        when(communicationsModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(packet0));
+        when(communicationsModule.requestDM29(any(), eq(1))).thenReturn(BusResult.of(packet1));
+        when(communicationsModule.requestDM29(any(), eq(2))).thenReturn(BusResult.of(packet2));
+        when(communicationsModule.requestDM29(any(), eq(3))).thenReturn(BusResult.of(packet3));
+        when(communicationsModule.requestDM29(any(), eq(4))).thenReturn(new BusResult<>(true));
+        when(communicationsModule.requestDM29(any(), eq(7))).thenReturn(BusResult.of(packet72));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM29(any());
-        verify(diagnosticMessageModule).requestDM29(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM29(any(), eq(1));
-        verify(diagnosticMessageModule).requestDM29(any(), eq(2));
-        verify(diagnosticMessageModule).requestDM29(any(), eq(3));
-        verify(diagnosticMessageModule).requestDM29(any(), eq(4));
-        verify(diagnosticMessageModule).requestDM29(any(), eq(7));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any(), eq(0));
+        verify(communicationsModule).requestDM29(any(), eq(1));
+        verify(communicationsModule).requestDM29(any(), eq(2));
+        verify(communicationsModule).requestDM29(any(), eq(3));
+        verify(communicationsModule).requestDM29(any(), eq(4));
+        verify(communicationsModule).requestDM29(any(), eq(7));
 
         assertEquals("", listener.getResults());
 
@@ -249,14 +249,14 @@ public class Part01Step22ControllerTest extends AbstractControllerTest {
     public void testEmptyPacketFailure() {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(new RequestResult<>(true));
-        when(diagnosticMessageModule.requestDM29(any(), eq(0x01))).thenReturn(new BusResult<>(true));
+        when(communicationsModule.requestDM29(any())).thenReturn(new RequestResult<>(true));
+        when(communicationsModule.requestDM29(any(), eq(0x01))).thenReturn(new BusResult<>(true));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM29(any());
-        verify(diagnosticMessageModule).requestDM29(any(), eq(0x01));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any(), eq(0x01));
 
         verify(mockListener).addOutcome(PART, STEP, FAIL, "6.1.22.2.d - No OBD ECU provided DM29");
         verify(mockListener).addOutcome(PART,

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step23ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step23ControllerTest.java
@@ -23,7 +23,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -50,7 +50,7 @@ public class Part01Step23ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -84,7 +84,7 @@ public class Part01Step23ControllerTest extends AbstractControllerTest {
                                               engineSpeedModule,
                                               bannerModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               DateTimeModule.getInstance(),
                                               DataRepository.newInstance());
 
@@ -95,7 +95,7 @@ public class Part01Step23ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -104,7 +104,7 @@ public class Part01Step23ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -126,15 +126,15 @@ public class Part01Step23ControllerTest extends AbstractControllerTest {
         DM31DtcToLampAssociation packet = new DM31DtcToLampAssociation(
                                                                        Packet.create(PGN, 0x00, data));
 
-        when(diagnosticMessageModule.requestDM31(any()))
+        when(communicationsModule.requestDM31(any()))
                                                         .thenReturn(new RequestResult<>(false,
                                                                                         Collections.singletonList(packet),
                                                                                         Collections.emptyList()));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM31(any());
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM31(any());
 
         verify(mockListener, atLeastOnce()).addOutcome(PART_NUMBER,
                                                        STEP_NUMBER,
@@ -200,15 +200,15 @@ public class Part01Step23ControllerTest extends AbstractControllerTest {
         DM31DtcToLampAssociation packet = new DM31DtcToLampAssociation(
                                                                        Packet.create(PGN, 0x00, data));
 
-        when(diagnosticMessageModule.requestDM31(any()))
+        when(communicationsModule.requestDM31(any()))
                                                         .thenReturn(new RequestResult<>(false,
                                                                                         Collections.singletonList(packet),
                                                                                         Collections.emptyList()));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM31(any());
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM31(any());
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step24ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step24ControllerTest.java
@@ -26,7 +26,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -55,7 +55,7 @@ public class Part01Step24ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -89,7 +89,7 @@ public class Part01Step24ControllerTest extends AbstractControllerTest {
                                               engineSpeedModule,
                                               bannerModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               dataRepository,
                                               DateTimeModule.getInstance());
 
@@ -100,7 +100,7 @@ public class Part01Step24ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -109,7 +109,7 @@ public class Part01Step24ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -146,7 +146,7 @@ public class Part01Step24ControllerTest extends AbstractControllerTest {
         };
         DM25ExpandedFreezeFrame packet = new DM25ExpandedFreezeFrame(Packet.create(PGN, 0x00, data));
 
-        when(diagnosticMessageModule.requestDM25(any(), eq(0x00))).thenReturn(new BusResult<>(false, packet));
+        when(communicationsModule.requestDM25(any(), eq(0x00))).thenReturn(new BusResult<>(false, packet));
 
         OBDModuleInformation obdInfo = new OBDModuleInformation(0);
         obdInfo.set(DM24SPNSupportPacket.create(0, SupportedSPN.create(123, true, true, true, 1)), 1);
@@ -154,7 +154,7 @@ public class Part01Step24ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(0x00));
+        verify(communicationsModule).requestDM25(any(), eq(0x00));
 
         verify(mockListener, atLeastOnce()).addOutcome(PART_NUMBER,
                                                        STEP_NUMBER,
@@ -172,11 +172,11 @@ public class Part01Step24ControllerTest extends AbstractControllerTest {
         obdInfo.set(DM24SPNSupportPacket.create(0, SupportedSPN.create(123, true, true, true, 1)), 1);
         dataRepository.putObdModule(obdInfo);
 
-        when(diagnosticMessageModule.requestDM25(any(), eq(0x00))).thenReturn(new BusResult<>(true));
+        when(communicationsModule.requestDM25(any(), eq(0x00))).thenReturn(new BusResult<>(true));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(0x00));
+        verify(communicationsModule).requestDM25(any(), eq(0x00));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -196,7 +196,7 @@ public class Part01Step24ControllerTest extends AbstractControllerTest {
                                                                                    0xFF,
                                                                                    0xFF));
 
-        when(diagnosticMessageModule.requestDM25(any(), eq(0x00))).thenReturn(new BusResult<>(false, packet));
+        when(communicationsModule.requestDM25(any(), eq(0x00))).thenReturn(new BusResult<>(false, packet));
 
         OBDModuleInformation obdInfo = new OBDModuleInformation(0);
         obdInfo.set(DM24SPNSupportPacket.create(0, SupportedSPN.create(123, true, true, true, 1)), 1);
@@ -204,7 +204,7 @@ public class Part01Step24ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(0x00));
+        verify(communicationsModule).requestDM25(any(), eq(0x00));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step25ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step25ControllerTest.java
@@ -30,7 +30,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -58,7 +58,7 @@ public class Part01Step25ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -92,7 +92,7 @@ public class Part01Step25ControllerTest extends AbstractControllerTest {
                                               engineSpeedModule,
                                               bannerModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               dataRepository,
                                               DateTimeModule.getInstance());
 
@@ -103,7 +103,7 @@ public class Part01Step25ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -112,7 +112,7 @@ public class Part01Step25ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -136,11 +136,11 @@ public class Part01Step25ControllerTest extends AbstractControllerTest {
         obd.set(packet, 1);
         dataRepository.putObdModule(obd);
 
-        when(diagnosticMessageModule.requestDM20(any(), eq(0x00))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM20(any(), eq(0x00))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0x00));
+        verify(communicationsModule).requestDM20(any(), eq(0x00));
 
         verify(mockListener, atLeastOnce()).addOutcome(PART_NUMBER,
                                                        STEP_NUMBER,
@@ -214,9 +214,9 @@ public class Part01Step25ControllerTest extends AbstractControllerTest {
                 0xBC, 0x14, 0xF8, 0x05, 0x00, 0x06, 0x00 };
         var packet2 = new DM20MonitorPerformanceRatioPacket(Packet.create(PGN, 0x02, data2));
 
-        when(diagnosticMessageModule.requestDM20(any(), eq(0x00))).thenReturn(BusResult.of(packet));
-        when(diagnosticMessageModule.requestDM20(any(), eq(0x01))).thenReturn(BusResult.of(packet1));
-        when(diagnosticMessageModule.requestDM20(any(), eq(0x02))).thenReturn(BusResult.of(packet2));
+        when(communicationsModule.requestDM20(any(), eq(0x00))).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM20(any(), eq(0x01))).thenReturn(BusResult.of(packet1));
+        when(communicationsModule.requestDM20(any(), eq(0x02))).thenReturn(BusResult.of(packet2));
 
         OBDModuleInformation obd = new OBDModuleInformation(0x00);
         obd.set(packet, 1);
@@ -232,9 +232,9 @@ public class Part01Step25ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0x01));
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0x02));
+        verify(communicationsModule).requestDM20(any(), eq(0x00));
+        verify(communicationsModule).requestDM20(any(), eq(0x01));
+        verify(communicationsModule).requestDM20(any(), eq(0x02));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -257,11 +257,11 @@ public class Part01Step25ControllerTest extends AbstractControllerTest {
         obd.set(packet, 1);
         dataRepository.putObdModule(obd);
 
-        when(diagnosticMessageModule.requestDM20(any(), eq(0x00))).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM20(any(), eq(0x00))).thenReturn(BusResult.of(packet));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0x00));
+        verify(communicationsModule).requestDM20(any(), eq(0x00));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -306,11 +306,11 @@ public class Part01Step25ControllerTest extends AbstractControllerTest {
         obd.set(packet1, 1);
         dataRepository.putObdModule(obd);
 
-        when(diagnosticMessageModule.requestDM20(any(), eq(0x00))).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM20(any(), eq(0x00))).thenReturn(BusResult.of(packet));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0x00));
+        verify(communicationsModule).requestDM20(any(), eq(0x00));
 
         verify(mockListener, atLeastOnce()).addOutcome(PART_NUMBER,
                                                        STEP_NUMBER,
@@ -340,13 +340,13 @@ public class Part01Step25ControllerTest extends AbstractControllerTest {
                 0xFF // Applicable System Monitor Denominator
         };
         var packet = new DM20MonitorPerformanceRatioPacket(Packet.create(PGN, 0x00, data));
-        when(diagnosticMessageModule.requestDM20(any(), eq(0x00))).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM20(any(), eq(0x00))).thenReturn(BusResult.of(packet));
 
         AcknowledgmentPacket ackPacket = AcknowledgmentPacket.create(1, ACK);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0x01))).thenReturn(BusResult.of(ackPacket));
+        when(communicationsModule.requestDM20(any(), eq(0x01))).thenReturn(BusResult.of(ackPacket));
 
         AcknowledgmentPacket nackPacket = AcknowledgmentPacket.create(2, NACK);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0x02))).thenReturn(BusResult.of(nackPacket));
+        when(communicationsModule.requestDM20(any(), eq(0x02))).thenReturn(BusResult.of(nackPacket));
 
         OBDModuleInformation obdInfo = new OBDModuleInformation(0x00);
         obdInfo.set(packet, 1);
@@ -362,9 +362,9 @@ public class Part01Step25ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0x01));
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0x02));
+        verify(communicationsModule).requestDM20(any(), eq(0x00));
+        verify(communicationsModule).requestDM20(any(), eq(0x01));
+        verify(communicationsModule).requestDM20(any(), eq(0x02));
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -395,7 +395,7 @@ public class Part01Step25ControllerTest extends AbstractControllerTest {
         // 0xA5, 0xA5, 0x5A, 0x5A, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE, 0xFF, 0xFF
         var packet = new DM20MonitorPerformanceRatioPacket(Packet.create(PGN, 0x00, data));
 
-        when(diagnosticMessageModule.requestDM20(any(), eq(0x00))).thenReturn(new BusResult<>(true, packet));
+        when(communicationsModule.requestDM20(any(), eq(0x00))).thenReturn(new BusResult<>(true, packet));
 
         OBDModuleInformation obdInfo = new OBDModuleInformation(0x00);
         obdInfo.set(packet, 1);
@@ -403,7 +403,7 @@ public class Part01Step25ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0x00));
+        verify(communicationsModule).requestDM20(any(), eq(0x00));
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -432,7 +432,7 @@ public class Part01Step25ControllerTest extends AbstractControllerTest {
                 0xFF // Applicable System Monitor Denominator
         };
         var packet = new DM20MonitorPerformanceRatioPacket(Packet.create(PGN, 0x00, data));
-        when(diagnosticMessageModule.requestDM20(any(), eq(0x00))).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM20(any(), eq(0x00))).thenReturn(BusResult.of(packet));
 
         OBDModuleInformation obdInfo = new OBDModuleInformation(0x00);
         obdInfo.set(packet, 1);
@@ -440,7 +440,7 @@ public class Part01Step25ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0x00));
+        verify(communicationsModule).requestDM20(any(), eq(0x00));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step26ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step26ControllerTest.java
@@ -45,7 +45,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -97,7 +97,7 @@ public class Part01Step26ControllerTest extends AbstractControllerTest {
     private ReportFileModule reportFileModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     private static List<SupportedSPN> spns(int... ids) {
         return Arrays.stream(ids).mapToObj(id -> {
@@ -131,7 +131,7 @@ public class Part01Step26ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               tableA1Validator,
                                               j1939DaRepository,
                                               broadcastValidator,
@@ -143,7 +143,7 @@ public class Part01Step26ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step27ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step27ControllerTest.java
@@ -36,7 +36,7 @@ import org.etools.j1939_84.model.ActionOutcome;
 import org.etools.j1939_84.model.StepResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -64,7 +64,7 @@ public class Part01Step27ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -99,7 +99,7 @@ public class Part01Step27ControllerTest extends AbstractControllerTest {
                                               engineSpeedModule,
                                               bannerModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               dateTimeModule,
                                               DataRepository.newInstance());
 
@@ -110,7 +110,7 @@ public class Part01Step27ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -122,7 +122,7 @@ public class Part01Step27ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  vehicleInformationModule,
                                  mockListener,
-                                 diagnosticMessageModule);
+                                 communicationsModule);
     }
 
     @Test

--- a/src-test/org/etools/j1939_84/controllers/part01/TableA6ValidatorTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/TableA6ValidatorTest.java
@@ -23,7 +23,7 @@ import static org.etools.j1939_84.bus.j1939.packets.MonitoredSystemStatus.findSt
 import static org.etools.j1939_84.model.Outcome.FAIL;
 import static org.etools.j1939_84.model.Outcome.INFO;
 import static org.etools.j1939_84.model.Outcome.WARN;
-import static org.etools.j1939_84.modules.DiagnosticMessageModule.getCompositeSystems;
+import static org.etools.j1939_84.modules.CommunicationsModule.getCompositeSystems;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -38,7 +38,7 @@ import org.etools.j1939_84.controllers.ResultsListener;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.FuelType;
 import org.etools.j1939_84.model.VehicleInformation;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 import org.junit.After;
 import org.junit.Before;
@@ -62,7 +62,7 @@ public class TableA6ValidatorTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     private TableA6Validator instance;
 
@@ -84,7 +84,7 @@ public class TableA6ValidatorTest {
     @After
     public void tearDown() {
         verifyNoMoreInteractions(mockListener,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  vehicleInformationModule);
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02ControllerTest.java
@@ -24,7 +24,7 @@ public class Part02ControllerTest extends AbstractPartControllerTest {
                                         DataRepository.newInstance(),
                                         engineSpeedModule,
                                         vehicleInformationModule,
-                                        diagnosticMessageModule,
+                                        communicationsModule,
                                         step01Controller,
                                         step02Controller,
                                         step03Controller,

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step01ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step01ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -56,7 +56,7 @@ public class Part02Step01ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -93,7 +93,7 @@ public class Part02Step01ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -102,7 +102,7 @@ public class Part02Step01ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step02ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step02ControllerTest.java
@@ -31,7 +31,7 @@ import org.etools.j1939_84.controllers.part01.SectionA6Validator;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -60,7 +60,7 @@ public class Part02Step02ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -97,7 +97,7 @@ public class Part02Step02ControllerTest extends AbstractControllerTest {
                                               engineSpeedModule,
                                               bannerModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               DateTimeModule.getInstance(),
                                               sectionA6Validator,
                                               dataRepository);
@@ -108,7 +108,7 @@ public class Part02Step02ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -118,7 +118,7 @@ public class Part02Step02ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  dataRepository,
                                  mockListener,
                                  sectionA6Validator);
@@ -178,17 +178,17 @@ public class Part02Step02ControllerTest extends AbstractControllerTest {
         RequestResult<DM5DiagnosticReadinessPacket> globalRequestResponse = new RequestResult<>(false,
                                                                                                 Collections.emptyList(),
                                                                                                 Collections.emptyList());
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(globalRequestResponse);
+        when(communicationsModule.requestDM5(any())).thenReturn(globalRequestResponse);
 
         BusResult<DM5DiagnosticReadinessPacket> busResult0x00 = new BusResult<>(false,
                                                                                 packet0);
-        when(diagnosticMessageModule.requestDM5(any(), eq(0x00))).thenReturn(busResult0x00);
+        when(communicationsModule.requestDM5(any(), eq(0x00))).thenReturn(busResult0x00);
         BusResult<DM5DiagnosticReadinessPacket> busResult0x17 = new BusResult<>(false,
                                                                                 packet44);
-        when(diagnosticMessageModule.requestDM5(any(), eq(0x17))).thenReturn(busResult0x17);
+        when(communicationsModule.requestDM5(any(), eq(0x17))).thenReturn(busResult0x17);
         BusResult<DM5DiagnosticReadinessPacket> busResult0x21 = new BusResult<>(false,
                                                                                 packet21);
-        when(diagnosticMessageModule.requestDM5(any(), eq(0x21))).thenReturn(busResult0x21);
+        when(communicationsModule.requestDM5(any(), eq(0x21))).thenReturn(busResult0x21);
 
         when(dataRepository.getObdModuleAddresses()).thenReturn(List.of(0x00, 0x17, 0x21));
 
@@ -196,11 +196,11 @@ public class Part02Step02ControllerTest extends AbstractControllerTest {
 
         verify(dataRepository).getObdModuleAddresses();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM5(any());
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0x17));
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0x21));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any(), eq(0x00));
+        verify(communicationsModule).requestDM5(any(), eq(0x17));
+        verify(communicationsModule).requestDM5(any(), eq(0x21));
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -264,16 +264,16 @@ public class Part02Step02ControllerTest extends AbstractControllerTest {
                                                                                                 List.of(packet0,
                                                                                                         packet21),
                                                                                                 List.of(packet44));
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(globalRequestResponse);
+        when(communicationsModule.requestDM5(any())).thenReturn(globalRequestResponse);
 
         BusResult<DM5DiagnosticReadinessPacket> busResult0x00 = new BusResult<>(false, packet0);
-        when(diagnosticMessageModule.requestDM5(any(), eq(0x00))).thenReturn(busResult0x00);
+        when(communicationsModule.requestDM5(any(), eq(0x00))).thenReturn(busResult0x00);
 
         BusResult<DM5DiagnosticReadinessPacket> busResult0x17 = new BusResult<>(false, packet44);
-        when(diagnosticMessageModule.requestDM5(any(), eq(0x17))).thenReturn(busResult0x17);
+        when(communicationsModule.requestDM5(any(), eq(0x17))).thenReturn(busResult0x17);
 
         BusResult<DM5DiagnosticReadinessPacket> busResult0x21 = new BusResult<>(false, packet21V2);
-        when(diagnosticMessageModule.requestDM5(any(), eq(0x21))).thenReturn(busResult0x21);
+        when(communicationsModule.requestDM5(any(), eq(0x21))).thenReturn(busResult0x21);
 
         when(dataRepository.getObdModuleAddresses()).thenReturn(List.of(0x00, 0x17, 0x21));
 
@@ -281,11 +281,11 @@ public class Part02Step02ControllerTest extends AbstractControllerTest {
 
         verify(dataRepository).getObdModuleAddresses();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM5(any());
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0x17));
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0x21));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any(), eq(0x00));
+        verify(communicationsModule).requestDM5(any(), eq(0x17));
+        verify(communicationsModule).requestDM5(any(), eq(0x21));
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -365,17 +365,17 @@ public class Part02Step02ControllerTest extends AbstractControllerTest {
                                                                                                 Collections.emptyList(),
                                                                                                 Collections.singletonList(
                                                                                                                           packet44));
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(globalRequestResponse);
+        when(communicationsModule.requestDM5(any())).thenReturn(globalRequestResponse);
 
         BusResult<DM5DiagnosticReadinessPacket> busResult0x00 = new BusResult<>(false,
                                                                                 packet0);
-        when(diagnosticMessageModule.requestDM5(any(), eq(0x00))).thenReturn(busResult0x00);
+        when(communicationsModule.requestDM5(any(), eq(0x00))).thenReturn(busResult0x00);
         BusResult<DM5DiagnosticReadinessPacket> busResult0x17 = new BusResult<>(false,
                                                                                 packet44);
-        when(diagnosticMessageModule.requestDM5(any(), eq(0x17))).thenReturn(busResult0x17);
+        when(communicationsModule.requestDM5(any(), eq(0x17))).thenReturn(busResult0x17);
         BusResult<DM5DiagnosticReadinessPacket> busResult0x21 = new BusResult<>(false,
                                                                                 packet21);
-        when(diagnosticMessageModule.requestDM5(any(), eq(0x21))).thenReturn(busResult0x21);
+        when(communicationsModule.requestDM5(any(), eq(0x21))).thenReturn(busResult0x21);
 
         when(dataRepository.getObdModuleAddresses()).thenReturn(List.of(0x00, 0x17, 0x21));
 
@@ -383,11 +383,11 @@ public class Part02Step02ControllerTest extends AbstractControllerTest {
 
         verify(dataRepository).getObdModuleAddresses();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM5(any());
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0x17));
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0x21));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any(), eq(0x00));
+        verify(communicationsModule).requestDM5(any(), eq(0x17));
+        verify(communicationsModule).requestDM5(any(), eq(0x21));
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -440,17 +440,17 @@ public class Part02Step02ControllerTest extends AbstractControllerTest {
                                                                                                         packet21),
                                                                                                 Collections.singletonList(
                                                                                                                           packet44));
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(globalRequestResponse);
+        when(communicationsModule.requestDM5(any())).thenReturn(globalRequestResponse);
 
         BusResult<DM5DiagnosticReadinessPacket> busResult0x00 = new BusResult<>(false,
                                                                                 Optional.empty());
-        when(diagnosticMessageModule.requestDM5(any(), eq(0x00))).thenReturn(busResult0x00);
+        when(communicationsModule.requestDM5(any(), eq(0x00))).thenReturn(busResult0x00);
         BusResult<DM5DiagnosticReadinessPacket> busResult0x17 = new BusResult<>(false,
                                                                                 Optional.empty());
-        when(diagnosticMessageModule.requestDM5(any(), eq(0x17))).thenReturn(busResult0x17);
+        when(communicationsModule.requestDM5(any(), eq(0x17))).thenReturn(busResult0x17);
         BusResult<DM5DiagnosticReadinessPacket> busResult0x21 = new BusResult<>(false,
                                                                                 packet21);
-        when(diagnosticMessageModule.requestDM5(any(), eq(0x21))).thenReturn(busResult0x21);
+        when(communicationsModule.requestDM5(any(), eq(0x21))).thenReturn(busResult0x21);
 
         when(dataRepository.getObdModuleAddresses()).thenReturn(List.of(0x00, 0x17, 0x21));
 
@@ -458,11 +458,11 @@ public class Part02Step02ControllerTest extends AbstractControllerTest {
 
         verify(dataRepository).getObdModuleAddresses();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM5(any());
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0x17));
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0x21));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any(), eq(0x00));
+        verify(communicationsModule).requestDM5(any(), eq(0x17));
+        verify(communicationsModule).requestDM5(any(), eq(0x21));
 
         verify(mockListener).addOutcome(
                                         PART_NUMBER,
@@ -543,14 +543,14 @@ public class Part02Step02ControllerTest extends AbstractControllerTest {
                                                                                                         packet17,
                                                                                                         packet23),
                                                                                                 Collections.emptyList());
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(globalRequestResponse);
+        when(communicationsModule.requestDM5(any())).thenReturn(globalRequestResponse);
 
         BusResult<DM5DiagnosticReadinessPacket> busResult0x00 = new BusResult<>(false, packet0);
-        when(diagnosticMessageModule.requestDM5(any(), eq(0x00))).thenReturn(busResult0x00);
+        when(communicationsModule.requestDM5(any(), eq(0x00))).thenReturn(busResult0x00);
         BusResult<DM5DiagnosticReadinessPacket> busResult0x17 = new BusResult<>(false, packet17);
-        when(diagnosticMessageModule.requestDM5(any(), eq(0x17))).thenReturn(busResult0x17);
+        when(communicationsModule.requestDM5(any(), eq(0x17))).thenReturn(busResult0x17);
         BusResult<DM5DiagnosticReadinessPacket> busResult0x23 = new BusResult<>(false, packet23);
-        when(diagnosticMessageModule.requestDM5(any(), eq(0x23))).thenReturn(busResult0x23);
+        when(communicationsModule.requestDM5(any(), eq(0x23))).thenReturn(busResult0x23);
 
         when(dataRepository.getObdModuleAddresses()).thenReturn(List.of(0x00, 0x17, 0x23));
 
@@ -558,11 +558,11 @@ public class Part02Step02ControllerTest extends AbstractControllerTest {
 
         verify(dataRepository).getObdModuleAddresses();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM5(any());
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0x17));
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0x23));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any(), eq(0x00));
+        verify(communicationsModule).requestDM5(any(), eq(0x17));
+        verify(communicationsModule).requestDM5(any(), eq(0x23));
 
         verify(sectionA6Validator).verify(any(), eq("6.2.2.2.a"), eq(globalRequestResponse));
 

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step03ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step03ControllerTest.java
@@ -23,7 +23,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -72,7 +72,7 @@ public class Part02Step03ControllerTest extends AbstractControllerTest {
     private ResultsListener mockListener;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private ReportFileModule reportFileModule;
@@ -92,7 +92,7 @@ public class Part02Step03ControllerTest extends AbstractControllerTest {
                                               engineSpeedModule,
                                               bannerModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               dataRepository,
                                               DateTimeModule.getInstance());
 
@@ -103,7 +103,7 @@ public class Part02Step03ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -112,9 +112,9 @@ public class Part02Step03ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener,
-                                 diagnosticMessageModule);
+                                 communicationsModule);
     }
 
     @Test
@@ -141,11 +141,11 @@ public class Part02Step03ControllerTest extends AbstractControllerTest {
 
         SupportedSPN spn2 = SupportedSPN.create(456, true, true, true, 1);
         DM24SPNSupportPacket packet0 = DM24SPNSupportPacket.create(0, spn2);
-        when(diagnosticMessageModule.requestDM24(any(), eq(0))).thenReturn(new BusResult<>(false, packet0));
+        when(communicationsModule.requestDM24(any(), eq(0))).thenReturn(new BusResult<>(false, packet0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM24(any(), eq(0));
+        verify(communicationsModule).requestDM24(any(), eq(0));
 
         assertEquals("", listener.getResults());
 
@@ -182,11 +182,11 @@ public class Part02Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdInfo0);
 
         DM24SPNSupportPacket packet0 = DM24SPNSupportPacket.create(0, spn1, spn2);
-        when(diagnosticMessageModule.requestDM24(any(), eq(0))).thenReturn(new BusResult<>(false, packet0));
+        when(communicationsModule.requestDM24(any(), eq(0))).thenReturn(new BusResult<>(false, packet0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM24(any(), eq(0));
+        verify(communicationsModule).requestDM24(any(), eq(0));
 
         assertEquals("", listener.getResults());
     }

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step04ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step04ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -51,7 +51,7 @@ public class Part02Step04ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -85,7 +85,7 @@ public class Part02Step04ControllerTest extends AbstractControllerTest {
                                               engineSpeedModule,
                                               bannerModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               dataRepository,
                                               DateTimeModule.getInstance());
 
@@ -96,7 +96,7 @@ public class Part02Step04ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -105,9 +105,9 @@ public class Part02Step04ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener,
-                                 diagnosticMessageModule);
+                                 communicationsModule);
     }
 
     @Test
@@ -129,8 +129,8 @@ public class Part02Step04ControllerTest extends AbstractControllerTest {
         };
         var packet = new DM20MonitorPerformanceRatioPacket(Packet.create(PGN, 0x00, data));
 
-        when(diagnosticMessageModule.requestDM20(any())).thenReturn(RequestResult.of(packet));
-        when(diagnosticMessageModule.requestDM20(any(), eq(0x00)))
+        when(communicationsModule.requestDM20(any())).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM20(any(), eq(0x00)))
                                                                   .thenReturn(BusResult.of(packet));
 
         OBDModuleInformation obdInfo = new OBDModuleInformation(0x00);
@@ -140,8 +140,8 @@ public class Part02Step04ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any());
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0x00));
+        verify(communicationsModule).requestDM20(any());
+        verify(communicationsModule).requestDM20(any(), eq(0x00));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -170,10 +170,10 @@ public class Part02Step04ControllerTest extends AbstractControllerTest {
         };
         var packet1 = new DM20MonitorPerformanceRatioPacket(Packet.create(PGN, 0x00, data1));
 
-        when(diagnosticMessageModule.requestDM20(any())).thenReturn(RequestResult.of(packet1));
+        when(communicationsModule.requestDM20(any())).thenReturn(RequestResult.of(packet1));
 
         var packet2 = new DM20MonitorPerformanceRatioPacket(Packet.create(PGN, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0));
-        when(diagnosticMessageModule.requestDM20(any(), eq(0x00))).thenReturn(BusResult.of(packet2));
+        when(communicationsModule.requestDM20(any(), eq(0x00))).thenReturn(BusResult.of(packet2));
 
         OBDModuleInformation obdInfo = new OBDModuleInformation(0x00);
         PerformanceRatio[] ratios = packet1.getRatios().toArray(new PerformanceRatio[0]);
@@ -182,9 +182,9 @@ public class Part02Step04ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM20(any());
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0x00));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM20(any());
+        verify(communicationsModule).requestDM20(any(), eq(0x00));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -213,8 +213,8 @@ public class Part02Step04ControllerTest extends AbstractControllerTest {
         };
         var packet = new DM20MonitorPerformanceRatioPacket(Packet.create(PGN, 0x00, data));
 
-        when(diagnosticMessageModule.requestDM20(any())).thenReturn(RequestResult.of(packet));
-        when(diagnosticMessageModule.requestDM20(any(), eq(0x00))).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM20(any())).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM20(any(), eq(0x00))).thenReturn(BusResult.of(packet));
 
         OBDModuleInformation obdInfo = new OBDModuleInformation(0x00);
         PerformanceRatio[] ratios = packet.getRatios().toArray(new PerformanceRatio[0]);
@@ -223,8 +223,8 @@ public class Part02Step04ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any());
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0x00));
+        verify(communicationsModule).requestDM20(any());
+        verify(communicationsModule).requestDM20(any(), eq(0x00));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -253,11 +253,11 @@ public class Part02Step04ControllerTest extends AbstractControllerTest {
         };
         var packet = new DM20MonitorPerformanceRatioPacket(Packet.create(PGN, 0x00, data1));
 
-        when(diagnosticMessageModule.requestDM20(any())).thenReturn(RequestResult.of(packet));
-        when(diagnosticMessageModule.requestDM20(any(), eq(0x00)))
+        when(communicationsModule.requestDM20(any())).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM20(any(), eq(0x00)))
                                                                   .thenReturn(BusResult.of(packet));
 
-        when(diagnosticMessageModule.requestDM20(any(), eq(0x17))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM20(any(), eq(0x17))).thenReturn(BusResult.empty());
 
         OBDModuleInformation obdInfo = new OBDModuleInformation(0x00);
         PerformanceRatio[] ratios = packet.getRatios().toArray(new PerformanceRatio[0]);
@@ -269,9 +269,9 @@ public class Part02Step04ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any());
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0x17));
+        verify(communicationsModule).requestDM20(any());
+        verify(communicationsModule).requestDM20(any(), eq(0x00));
+        verify(communicationsModule).requestDM20(any(), eq(0x17));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -301,8 +301,8 @@ public class Part02Step04ControllerTest extends AbstractControllerTest {
         };
         var packet = new DM20MonitorPerformanceRatioPacket(Packet.create(PGN, 0x00, data));
 
-        when(diagnosticMessageModule.requestDM20(any())).thenReturn(RequestResult.of(packet));
-        when(diagnosticMessageModule.requestDM20(any(), eq(0x00))).thenReturn(BusResult.of(packet));
+        when(communicationsModule.requestDM20(any())).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM20(any(), eq(0x00))).thenReturn(BusResult.of(packet));
 
         OBDModuleInformation obdInfo = new OBDModuleInformation(0x00);
         var ratio = new PerformanceRatio(0x222222, 0xAAAA, 0xBBBB, 0x00);
@@ -311,8 +311,8 @@ public class Part02Step04ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any());
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0x00));
+        verify(communicationsModule).requestDM20(any());
+        verify(communicationsModule).requestDM20(any(), eq(0x00));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -373,7 +373,7 @@ public class Part02Step04ControllerTest extends AbstractControllerTest {
             };
             var packet = new DM20MonitorPerformanceRatioPacket(Packet.create(PGN, 0x00, data));
             packetList.add(packet);
-            when(diagnosticMessageModule.requestDM20(any(), eq(0x00))).thenReturn(BusResult.of(packet));
+            when(communicationsModule.requestDM20(any(), eq(0x00))).thenReturn(BusResult.of(packet));
 
             OBDModuleInformation obdInfo = new OBDModuleInformation(0x00);
             PerformanceRatio[] ratios = packet.getRatios().toArray(new PerformanceRatio[0]);
@@ -406,7 +406,7 @@ public class Part02Step04ControllerTest extends AbstractControllerTest {
             };
             var packet = new DM20MonitorPerformanceRatioPacket(Packet.create(PGN, 0x17, data));
             packetList.add(packet);
-            when(diagnosticMessageModule.requestDM20(any(), eq(0x17))).thenReturn(BusResult.of(packet));
+            when(communicationsModule.requestDM20(any(), eq(0x17))).thenReturn(BusResult.of(packet));
 
             OBDModuleInformation obdInfo = new OBDModuleInformation(0x17);
             PerformanceRatio[] ratios = packet.getRatios().toArray(new PerformanceRatio[0]);
@@ -414,13 +414,13 @@ public class Part02Step04ControllerTest extends AbstractControllerTest {
             dataRepository.putObdModule(obdInfo);
         }
 
-        when(diagnosticMessageModule.requestDM20(any())).thenReturn(new RequestResult<>(false, packetList, List.of()));
+        when(communicationsModule.requestDM20(any())).thenReturn(new RequestResult<>(false, packetList, List.of()));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any());
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0x17));
+        verify(communicationsModule).requestDM20(any());
+        verify(communicationsModule).requestDM20(any(), eq(0x00));
+        verify(communicationsModule).requestDM20(any(), eq(0x17));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -428,11 +428,11 @@ public class Part02Step04ControllerTest extends AbstractControllerTest {
 
     @Test
     public void testNoPackets() {
-        when(diagnosticMessageModule.requestDM20(any())).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM20(any())).thenReturn(RequestResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any());
+        verify(communicationsModule).requestDM20(any());
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step05ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step05ControllerTest.java
@@ -24,7 +24,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -54,7 +54,7 @@ public class Part02Step05ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -89,7 +89,7 @@ public class Part02Step05ControllerTest extends AbstractControllerTest {
                                               vehicleInformationModule,
                                               dataRepository,
                                               DateTimeModule.getInstance(),
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -98,7 +98,7 @@ public class Part02Step05ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -108,7 +108,7 @@ public class Part02Step05ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  vehicleInformationModule,
                                  mockListener,
-                                 diagnosticMessageModule);
+                                 communicationsModule);
     }
 
     @Test

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step06ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step06ControllerTest.java
@@ -23,7 +23,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -57,7 +57,7 @@ public class Part02Step06ControllerTest extends AbstractControllerTest {
     @Mock
     private VehicleInformationModule vehicleInformationModule;
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     private DataRepository dataRepository;
 
@@ -76,7 +76,7 @@ public class Part02Step06ControllerTest extends AbstractControllerTest {
                                                                      vehicleInformationModule,
                                                                      dataRepository,
                                                                      DateTimeModule.getInstance(),
-                                                                     diagnosticMessageModule);
+                                                                     communicationsModule);
 
         setup(instance,
               listener,
@@ -85,7 +85,7 @@ public class Part02Step06ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -95,7 +95,7 @@ public class Part02Step06ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  vehicleInformationModule,
                                  mockListener,
-                                 diagnosticMessageModule);
+                                 communicationsModule);
     }
 
     @Test
@@ -106,12 +106,12 @@ public class Part02Step06ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation1);
 
         var packet1 = DM56EngineFamilyPacket.create(1, 2021, true, "Engine Family Different");
-        when(diagnosticMessageModule.requestDM56(any(), eq(1))).thenReturn(List.of(packet1));
+        when(communicationsModule.requestDM56(any(), eq(1))).thenReturn(List.of(packet1));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM56(any(), eq(1));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM56(any(), eq(1));
 
         verify(mockListener).addOutcome(2,
                                         6,
@@ -130,11 +130,11 @@ public class Part02Step06ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var packet0 = DM56EngineFamilyPacket.create(0, 2020, true, "Engine Family");
-        when(diagnosticMessageModule.requestDM56(any(), eq(0))).thenReturn(List.of(packet0));
+        when(communicationsModule.requestDM56(any(), eq(0))).thenReturn(List.of(packet0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM56(any(), eq(0));
+        verify(communicationsModule).requestDM56(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -144,11 +144,11 @@ public class Part02Step06ControllerTest extends AbstractControllerTest {
     @Test
     public void testNoPackets() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
-        when(diagnosticMessageModule.requestDM56(any(), eq(0))).thenReturn(List.of());
+        when(communicationsModule.requestDM56(any(), eq(0))).thenReturn(List.of());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM56(any(), eq(0));
+        verify(communicationsModule).requestDM56(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step07ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step07ControllerTest.java
@@ -26,7 +26,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -54,7 +54,7 @@ public class Part02Step07ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -91,7 +91,7 @@ public class Part02Step07ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -100,7 +100,7 @@ public class Part02Step07ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -110,7 +110,7 @@ public class Part02Step07ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step08ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step08ControllerTest.java
@@ -27,7 +27,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -50,7 +50,7 @@ public class Part02Step08ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -86,7 +86,7 @@ public class Part02Step08ControllerTest extends AbstractControllerTest {
                                               engineSpeedModule,
                                               bannerModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               dataRepository,
                                               DateTimeModule.getInstance());
 
@@ -97,7 +97,7 @@ public class Part02Step08ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -106,7 +106,7 @@ public class Part02Step08ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -127,11 +127,11 @@ public class Part02Step08ControllerTest extends AbstractControllerTest {
 
     @Test
     public void testNoResponsesNoModules() {
-        when(diagnosticMessageModule.requestDM26(any())).thenReturn(new RequestResult<>(false));
+        when(communicationsModule.requestDM26(any())).thenReturn(new RequestResult<>(false));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM26(any());
+        verify(communicationsModule).requestDM26(any());
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -140,13 +140,13 @@ public class Part02Step08ControllerTest extends AbstractControllerTest {
     @Test
     public void testNoResponses() {
         dataRepository.putObdModule(new OBDModuleInformation(0x01));
-        when(diagnosticMessageModule.requestDM26(any(), eq(0x01))).thenReturn(new RequestResult<>(true));
-        when(diagnosticMessageModule.requestDM26(any())).thenReturn(new RequestResult<>(true));
+        when(communicationsModule.requestDM26(any(), eq(0x01))).thenReturn(new RequestResult<>(true));
+        when(communicationsModule.requestDM26(any())).thenReturn(new RequestResult<>(true));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM26(any());
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0x01));
+        verify(communicationsModule).requestDM26(any());
+        verify(communicationsModule).requestDM26(any(), eq(0x01));
 
         verify(mockListener).addOutcome(PART,
                                         STEP,
@@ -189,7 +189,7 @@ public class Part02Step08ControllerTest extends AbstractControllerTest {
                                                                                                          0xEE,
                                                                                                          0xFF,
                                                                                                          0x00));
-        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(new RequestResult<>(false, packet00));
+        when(communicationsModule.requestDM26(any(), eq(0))).thenReturn(new RequestResult<>(false, packet00));
 
         // Module 1 has the same both times and will not report an error
         DM26TripDiagnosticReadinessPacket packet1 = new DM26TripDiagnosticReadinessPacket(
@@ -206,7 +206,7 @@ public class Part02Step08ControllerTest extends AbstractControllerTest {
         OBDModuleInformation obdModule1 = new OBDModuleInformation(1);
         obdModule1.set(packet1, 1);
         dataRepository.putObdModule(obdModule1);
-        when(diagnosticMessageModule.requestDM26(any(), eq(1))).thenReturn(new RequestResult<>(false, packet1));
+        when(communicationsModule.requestDM26(any(), eq(1))).thenReturn(new RequestResult<>(false, packet1));
 
         // Module 2 will not respond from the first time, but will respond this time
         dataRepository.putObdModule(new OBDModuleInformation(2));
@@ -221,13 +221,13 @@ public class Part02Step08ControllerTest extends AbstractControllerTest {
                                                                                                         0xFF,
                                                                                                         0xFF,
                                                                                                         0xFF));
-        when(diagnosticMessageModule.requestDM26(any(), eq(2))).thenReturn(new RequestResult<>(false, packet2));
+        when(communicationsModule.requestDM26(any(), eq(2))).thenReturn(new RequestResult<>(false, packet2));
 
         // Module 3 will not respond
         dataRepository.putObdModule(new OBDModuleInformation(3));
-        when(diagnosticMessageModule.requestDM26(any(), eq(3))).thenReturn(new RequestResult<>(true));
+        when(communicationsModule.requestDM26(any(), eq(3))).thenReturn(new RequestResult<>(true));
 
-        when(diagnosticMessageModule.requestDM26(any()))
+        when(communicationsModule.requestDM26(any()))
                                                         .thenReturn(new RequestResult<>(false,
                                                                                         packet0,
                                                                                         packet1,
@@ -235,11 +235,11 @@ public class Part02Step08ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM26(any());
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0x01));
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0x02));
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0x03));
+        verify(communicationsModule).requestDM26(any());
+        verify(communicationsModule).requestDM26(any(), eq(0x00));
+        verify(communicationsModule).requestDM26(any(), eq(0x01));
+        verify(communicationsModule).requestDM26(any(), eq(0x02));
+        verify(communicationsModule).requestDM26(any(), eq(0x03));
 
         String expectedResults = "" + NL;
         expectedResults += "Vehicle Composite of DM26:" + NL;
@@ -385,13 +385,13 @@ public class Part02Step08ControllerTest extends AbstractControllerTest {
         obdModule1.set(packet1, 1);
         dataRepository.putObdModule(obdModule1);
 
-        when(diagnosticMessageModule.requestDM26(any())).thenReturn(new RequestResult<>(false, packet1));
-        when(diagnosticMessageModule.requestDM26(any(), eq(0x01))).thenReturn(new RequestResult<>(false, packet1));
+        when(communicationsModule.requestDM26(any())).thenReturn(new RequestResult<>(false, packet1));
+        when(communicationsModule.requestDM26(any(), eq(0x01))).thenReturn(new RequestResult<>(false, packet1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM26(any());
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0x01));
+        verify(communicationsModule).requestDM26(any());
+        verify(communicationsModule).requestDM26(any(), eq(0x01));
 
         String expectedResults = NL;
         expectedResults += "Vehicle Composite of DM26:" + NL;

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step09ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step09ControllerTest.java
@@ -25,7 +25,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -46,7 +46,7 @@ public class Part02Step09ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -81,7 +81,7 @@ public class Part02Step09ControllerTest extends AbstractControllerTest {
                                                                      vehicleInformationModule,
                                                                      dataRepository,
                                                                      DateTimeModule.getInstance(),
-                                                                     diagnosticMessageModule);
+                                                                     communicationsModule);
         setup(instance,
               listener,
               j1939,
@@ -89,7 +89,7 @@ public class Part02Step09ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -99,7 +99,7 @@ public class Part02Step09ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  vehicleInformationModule,
                                  mockListener,
-                                 diagnosticMessageModule);
+                                 communicationsModule);
     }
 
     @Test
@@ -110,16 +110,16 @@ public class Part02Step09ControllerTest extends AbstractControllerTest {
 
         var globalResults = new RequestResult<>(false, packet0);
 
-        when(diagnosticMessageModule.requestDM21(any())).thenReturn(globalResults);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(new BusResult<>(false, packet1));
+        when(communicationsModule.requestDM21(any())).thenReturn(globalResults);
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(new BusResult<>(false, packet1));
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM21(any());
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM21(any());
+        verify(communicationsModule).requestDM21(any(), eq(0));
 
         verify(mockListener).addOutcome(2,
                                         9,
@@ -138,16 +138,16 @@ public class Part02Step09ControllerTest extends AbstractControllerTest {
 
         var globalResults = new RequestResult<>(false, packet0, packet17);
 
-        when(diagnosticMessageModule.requestDM21(any())).thenReturn(globalResults);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(new BusResult<>(false, packet0));
+        when(communicationsModule.requestDM21(any())).thenReturn(globalResults);
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(new BusResult<>(false, packet0));
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM21(any());
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM21(any());
+        verify(communicationsModule).requestDM21(any(), eq(0));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -160,19 +160,19 @@ public class Part02Step09ControllerTest extends AbstractControllerTest {
 
         var globalResults = new RequestResult<>(false, packet0);
 
-        when(diagnosticMessageModule.requestDM21(any())).thenReturn(globalResults);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(new BusResult<>(false, packet0));
-        when(diagnosticMessageModule.requestDM21(any(), eq(1))).thenReturn(new BusResult<>(true));
+        when(communicationsModule.requestDM21(any())).thenReturn(globalResults);
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(new BusResult<>(false, packet0));
+        when(communicationsModule.requestDM21(any(), eq(1))).thenReturn(new BusResult<>(true));
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM21(any());
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(1));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM21(any());
+        verify(communicationsModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(1));
 
         verify(mockListener).addOutcome(2,
                                         9,
@@ -190,16 +190,16 @@ public class Part02Step09ControllerTest extends AbstractControllerTest {
 
         var globalResults = new RequestResult<>(false, packet0);
 
-        when(diagnosticMessageModule.requestDM21(any())).thenReturn(globalResults);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(new BusResult<>(false, packet0));
+        when(communicationsModule.requestDM21(any())).thenReturn(globalResults);
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(new BusResult<>(false, packet0));
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM21(any());
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM21(any());
+        verify(communicationsModule).requestDM21(any(), eq(0));
 
         verify(mockListener).addOutcome(2,
                                         9,
@@ -217,16 +217,16 @@ public class Part02Step09ControllerTest extends AbstractControllerTest {
 
         var globalResults = new RequestResult<>(false, packet0);
 
-        when(diagnosticMessageModule.requestDM21(any())).thenReturn(globalResults);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(new BusResult<>(false, packet0));
+        when(communicationsModule.requestDM21(any())).thenReturn(globalResults);
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(new BusResult<>(false, packet0));
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM21(any());
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM21(any());
+        verify(communicationsModule).requestDM21(any(), eq(0));
 
         verify(mockListener).addOutcome(2,
                                         9,
@@ -240,12 +240,12 @@ public class Part02Step09ControllerTest extends AbstractControllerTest {
     @Test
     public void testNoPackets() {
 
-        when(diagnosticMessageModule.requestDM21(any())).thenReturn(new RequestResult<>(false));
+        when(communicationsModule.requestDM21(any())).thenReturn(new RequestResult<>(false));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM21(any());
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM21(any());
 
         verify(mockListener).addOutcome(2,
                                         9,
@@ -268,16 +268,16 @@ public class Part02Step09ControllerTest extends AbstractControllerTest {
 
         var globalResults = new RequestResult<>(false, packet0);
 
-        when(diagnosticMessageModule.requestDM21(any())).thenReturn(globalResults);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(new BusResult<>(false, packet0));
+        when(communicationsModule.requestDM21(any())).thenReturn(globalResults);
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(new BusResult<>(false, packet0));
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM21(any());
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM21(any());
+        verify(communicationsModule).requestDM21(any(), eq(0));
 
         verify(mockListener).addOutcome(2,
                                         9,
@@ -295,16 +295,16 @@ public class Part02Step09ControllerTest extends AbstractControllerTest {
 
         var globalResults = new RequestResult<>(false, packet0);
 
-        when(diagnosticMessageModule.requestDM21(any())).thenReturn(globalResults);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(new BusResult<>(false, packet0));
+        when(communicationsModule.requestDM21(any())).thenReturn(globalResults);
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(new BusResult<>(false, packet0));
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM21(any());
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM21(any());
+        verify(communicationsModule).requestDM21(any(), eq(0));
 
         verify(mockListener).addOutcome(2,
                                         9,

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step10ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step10ControllerTest.java
@@ -27,7 +27,7 @@ import org.etools.j1939_84.controllers.part01.Part01Step12Controller;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -71,7 +71,7 @@ public class Part02Step10ControllerTest extends AbstractControllerTest {
     private ResultsListener mockListener;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private ReportFileModule reportFileModule;
@@ -90,7 +90,7 @@ public class Part02Step10ControllerTest extends AbstractControllerTest {
                                               bannerModule,
                                               dataRepository,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               DateTimeModule.getInstance());
 
         setup(instance,
@@ -100,7 +100,7 @@ public class Part02Step10ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -110,7 +110,7 @@ public class Part02Step10ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  vehicleInformationModule,
                                  mockListener,
-                                 diagnosticMessageModule);
+                                 communicationsModule);
     }
 
     @Test
@@ -127,14 +127,14 @@ public class Part02Step10ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(obdModule0);
 
-        when(diagnosticMessageModule.requestTestResults(any(), eq(0), eq(247), eq(5319), eq(31)))
+        when(communicationsModule.requestTestResults(any(), eq(0), eq(247), eq(5319), eq(31)))
                                                                                                  .thenReturn(List.of(DM30ScaledTestResultsPacket.create(0,
                                                                                                                                                         0,
                                                                                                                                                         testResult1)));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0x00), eq(247), eq(5319), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(0x00), eq(247), eq(5319), eq(31));
         verify(mockListener).addOutcome(PART,
                                         STEP,
                                         FAIL,
@@ -160,13 +160,13 @@ public class Part02Step10ControllerTest extends AbstractControllerTest {
 
         DM30ScaledTestResultsPacket dm30_1 = DM30ScaledTestResultsPacket.create(0, 0, testResult1);
         DM30ScaledTestResultsPacket dm30_2 = DM30ScaledTestResultsPacket.create(0, 0, testResult2);
-        when(diagnosticMessageModule.requestTestResults(any(), eq(0), eq(247), eq(spn1.getSpn()), eq(31)))
+        when(communicationsModule.requestTestResults(any(), eq(0), eq(247), eq(spn1.getSpn()), eq(31)))
                                                                                                           .thenReturn(List.of(dm30_1,
                                                                                                                               dm30_2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0x00), eq(247), eq(spn1.getSpn()), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(0x00), eq(247), eq(spn1.getSpn()), eq(31));
 
         verify(mockListener).addOutcome(PART,
                                         STEP,
@@ -209,18 +209,18 @@ public class Part02Step10ControllerTest extends AbstractControllerTest {
         OBDModuleInformation obdModule3 = new OBDModuleInformation(3);
         dataRepository.putObdModule(obdModule3);
 
-        when(diagnosticMessageModule.requestTestResults(any(), eq(0), eq(247), eq(spn1.getSpn()), eq(31)))
+        when(communicationsModule.requestTestResults(any(), eq(0), eq(247), eq(spn1.getSpn()), eq(31)))
                                                                                                           .thenReturn(List.of(DM30ScaledTestResultsPacket.create(0,
                                                                                                                                                                  0,
                                                                                                                                                                  testResult1)));
-        when(diagnosticMessageModule.requestTestResults(any(), eq(0), eq(247), eq(spn2.getSpn()), eq(31)))
+        when(communicationsModule.requestTestResults(any(), eq(0), eq(247), eq(spn2.getSpn()), eq(31)))
                                                                                                           .thenReturn(List.of(DM30ScaledTestResultsPacket.create(0,
                                                                                                                                                                  0,
                                                                                                                                                                  testResult2)));
 
         runTest();
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0x00), eq(247), eq(spn1.getSpn()), eq(31));
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0x00), eq(247), eq(spn2.getSpn()), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(0x00), eq(247), eq(spn1.getSpn()), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(0x00), eq(247), eq(spn2.getSpn()), eq(31));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -231,7 +231,7 @@ public class Part02Step10ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
+        verify(communicationsModule).setJ1939(j1939);
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -251,19 +251,19 @@ public class Part02Step10ControllerTest extends AbstractControllerTest {
         obdModule0.set(DM24SPNSupportPacket.create(0, spn1, spn2), 1);
         dataRepository.putObdModule(obdModule0);
 
-        when(diagnosticMessageModule.requestTestResults(any(), eq(0), eq(247), eq(spn1.getSpn()), eq(31)))
+        when(communicationsModule.requestTestResults(any(), eq(0), eq(247), eq(spn1.getSpn()), eq(31)))
                                                                                                           .thenReturn(List.of(DM30ScaledTestResultsPacket.create(0,
                                                                                                                                                                  0,
                                                                                                                                                                  testResult1)));
-        when(diagnosticMessageModule.requestTestResults(any(), eq(0), eq(247), eq(spn2.getSpn()), eq(31)))
+        when(communicationsModule.requestTestResults(any(), eq(0), eq(247), eq(spn2.getSpn()), eq(31)))
                                                                                                           .thenReturn(List.of(DM30ScaledTestResultsPacket.create(0,
                                                                                                                                                                  0,
                                                                                                                                                                  testResult2)));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0x00), eq(247), eq(spn1.getSpn()), eq(31));
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0x00), eq(247), eq(spn2.getSpn()), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(0x00), eq(247), eq(spn1.getSpn()), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(0x00), eq(247), eq(spn2.getSpn()), eq(31));
 
         verify(mockListener).addOutcome(PART,
                                         STEP,

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step11ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step11ControllerTest.java
@@ -24,7 +24,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -48,7 +48,7 @@ public class Part02Step11ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -85,7 +85,7 @@ public class Part02Step11ControllerTest extends AbstractControllerTest {
                                               vehicleInformationModule,
                                               dataRepository,
                                               DateTimeModule.getInstance(),
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -94,7 +94,7 @@ public class Part02Step11ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -103,7 +103,7 @@ public class Part02Step11ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -127,14 +127,14 @@ public class Part02Step11ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
-        when(diagnosticMessageModule.requestDM27(any())).thenReturn(new RequestResult<>(false));
-        when(diagnosticMessageModule.requestDM27(any(), eq(0x01))).thenReturn(new BusResult<>(false));
+        when(communicationsModule.requestDM27(any())).thenReturn(new RequestResult<>(false));
+        when(communicationsModule.requestDM27(any(), eq(0x01))).thenReturn(new BusResult<>(false));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0x01));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0x01));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -157,10 +157,10 @@ public class Part02Step11ControllerTest extends AbstractControllerTest {
         OBDModuleInformation obdModule1 = new OBDModuleInformation(1);
         obdModule1.set(packet1, 1);
         dataRepository.putObdModule(obdModule1);
-        when(diagnosticMessageModule.requestDM27(any(), eq(0x01))).thenReturn(BusResult.of(packet1));
+        when(communicationsModule.requestDM27(any(), eq(0x01))).thenReturn(BusResult.of(packet1));
 
         dataRepository.putObdModule(new OBDModuleInformation(2));
-        when(diagnosticMessageModule.requestDM27(any(), eq(0x02))).thenReturn(new BusResult<>(true));
+        when(communicationsModule.requestDM27(any(), eq(0x02))).thenReturn(new BusResult<>(true));
 
         DM27AllPendingDTCsPacket packet3 = new DM27AllPendingDTCsPacket(
                                                                         Packet.create(PGN,
@@ -188,17 +188,17 @@ public class Part02Step11ControllerTest extends AbstractControllerTest {
                                                                                          0x66,
                                                                                          0x77,
                                                                                          0x88));
-        when(diagnosticMessageModule.requestDM27(any(), eq(0x03))).thenReturn(BusResult.of(obdPacket3));
+        when(communicationsModule.requestDM27(any(), eq(0x03))).thenReturn(BusResult.of(obdPacket3));
 
-        when(diagnosticMessageModule.requestDM27(any())).thenReturn(RequestResult.of(packet1, packet3));
+        when(communicationsModule.requestDM27(any())).thenReturn(RequestResult.of(packet1, packet3));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0x01));
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0x02));
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0x03));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0x01));
+        verify(communicationsModule).requestDM27(any(), eq(0x02));
+        verify(communicationsModule).requestDM27(any(), eq(0x03));
 
         assertEquals("", listener.getResults());
 
@@ -222,15 +222,15 @@ public class Part02Step11ControllerTest extends AbstractControllerTest {
         OBDModuleInformation obdModule1 = new OBDModuleInformation(1);
         obdModule1.set(packet1, 1);
         dataRepository.putObdModule(obdModule1);
-        when(diagnosticMessageModule.requestDM27(any(), eq(0x01))).thenReturn(BusResult.of(packet1));
+        when(communicationsModule.requestDM27(any(), eq(0x01))).thenReturn(BusResult.of(packet1));
 
-        when(diagnosticMessageModule.requestDM27(any())).thenReturn(RequestResult.of(packet1));
+        when(communicationsModule.requestDM27(any())).thenReturn(RequestResult.of(packet1));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0x01));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0x01));
 
         assertEquals("", listener.getResults());
     }

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step12ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step12ControllerTest.java
@@ -25,7 +25,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -51,7 +51,7 @@ public class Part02Step12ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -92,7 +92,7 @@ public class Part02Step12ControllerTest extends AbstractControllerTest {
                                               vehicleInformationModule,
                                               dataRepository,
                                               DateTimeModule.getInstance(),
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -101,7 +101,7 @@ public class Part02Step12ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -110,7 +110,7 @@ public class Part02Step12ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -138,13 +138,13 @@ public class Part02Step12ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(dm27(1), 1);
         dataRepository.putObdModule(obdModuleInformation);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(packet1));
-        when(diagnosticMessageModule.requestDM29(any(), eq(0x01))).thenReturn(BusResult.of(packet1));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(packet1));
+        when(communicationsModule.requestDM29(any(), eq(0x01))).thenReturn(BusResult.of(packet1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
-        verify(diagnosticMessageModule).requestDM29(any(), eq(0x01));
+        verify(communicationsModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any(), eq(0x01));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -158,13 +158,13 @@ public class Part02Step12ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(module2);
         DM29DtcCounts packet2 = DM29DtcCounts.create(0x02, 0, 0x00, 0x00, 0x04, 0x00, 0xFF);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(packet2));
-        when(diagnosticMessageModule.requestDM29(any(), eq(2))).thenReturn(BusResult.of(packet2));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(packet2));
+        when(communicationsModule.requestDM29(any(), eq(2))).thenReturn(BusResult.of(packet2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
-        verify(diagnosticMessageModule).requestDM29(any(), eq(2));
+        verify(communicationsModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any(), eq(2));
 
         assertEquals("", listener.getResults());
 
@@ -180,13 +180,13 @@ public class Part02Step12ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(3));
         DM29DtcCounts packet3 = DM29DtcCounts.create(0x03, 0, 0x00, 0, 0x00, 0x00, 0x00);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(packet3));
-        when(diagnosticMessageModule.requestDM29(any(), eq(3))).thenReturn(BusResult.of(packet3));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(packet3));
+        when(communicationsModule.requestDM29(any(), eq(3))).thenReturn(BusResult.of(packet3));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
-        verify(diagnosticMessageModule).requestDM29(any(), eq(3));
+        verify(communicationsModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any(), eq(3));
 
         assertEquals("", listener.getResults());
 
@@ -201,17 +201,17 @@ public class Part02Step12ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(3));
         DM29DtcCounts packet3 = DM29DtcCounts.create(0x03, 0, 0x00, 0xFF, 0x00, 0x00, 0x00);
 
-        when(diagnosticMessageModule.requestDM29(any(), eq(3))).thenReturn(BusResult.of(packet3));
+        when(communicationsModule.requestDM29(any(), eq(3))).thenReturn(BusResult.of(packet3));
 
         // Module 6 will be a non-obd module with bad values
         DM29DtcCounts packet6 = DM29DtcCounts.create(0x06, 0, 0, 0xFF, 0, 0, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(packet3, packet6));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(packet3, packet6));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any(), eq(3));
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any(), eq(3));
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getResults());
 
@@ -234,13 +234,13 @@ public class Part02Step12ControllerTest extends AbstractControllerTest {
         DM29DtcCounts packet71 = DM29DtcCounts.create(0x07, 0, 0, 0xFF, 0, 0, 0);
         DM29DtcCounts packet72 = DM29DtcCounts.create(0x07, 0, 1, 0xFF, 0, 0, 0);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(packet71));
-        when(diagnosticMessageModule.requestDM29(any(), eq(7))).thenReturn(BusResult.of(packet72));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(packet71));
+        when(communicationsModule.requestDM29(any(), eq(7))).thenReturn(BusResult.of(packet72));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
-        verify(diagnosticMessageModule).requestDM29(any(), eq(7));
+        verify(communicationsModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any(), eq(7));
 
         assertEquals("", listener.getResults());
 
@@ -262,16 +262,16 @@ public class Part02Step12ControllerTest extends AbstractControllerTest {
         // Module 4 will not respond at all
         dataRepository.putObdModule(new OBDModuleInformation(4));
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(packet0));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(packet0));
 
-        when(diagnosticMessageModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(packet0));
-        when(diagnosticMessageModule.requestDM29(any(), eq(4))).thenReturn(new BusResult<>(true));
+        when(communicationsModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(packet0));
+        when(communicationsModule.requestDM29(any(), eq(4))).thenReturn(new BusResult<>(true));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
-        verify(diagnosticMessageModule).requestDM29(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM29(any(), eq(4));
+        verify(communicationsModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any(), eq(0));
+        verify(communicationsModule).requestDM29(any(), eq(4));
 
         assertEquals("", listener.getResults());
 
@@ -285,14 +285,14 @@ public class Part02Step12ControllerTest extends AbstractControllerTest {
     public void testEmptyPacketFailure() {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(new RequestResult<>(true));
-        when(diagnosticMessageModule.requestDM29(any(), eq(0x01))).thenReturn(new BusResult<>(true));
+        when(communicationsModule.requestDM29(any())).thenReturn(new RequestResult<>(true));
+        when(communicationsModule.requestDM29(any(), eq(0x01))).thenReturn(new BusResult<>(true));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM29(any());
-        verify(diagnosticMessageModule).requestDM29(any(), eq(0x01));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any(), eq(0x01));
 
         verify(mockListener).addOutcome(PART, STEP, FAIL, "6.2.12.2.d - No OBD ECU provided DM29");
         verify(mockListener).addOutcome(PART,

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step13ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step13ControllerTest.java
@@ -36,7 +36,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -65,7 +65,7 @@ public class Part02Step13ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -102,7 +102,7 @@ public class Part02Step13ControllerTest extends AbstractControllerTest {
                                               vehicleInformationModule,
                                               dataRepository,
                                               DateTimeModule.getInstance(),
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -111,7 +111,7 @@ public class Part02Step13ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -120,7 +120,7 @@ public class Part02Step13ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -129,11 +129,11 @@ public class Part02Step13ControllerTest extends AbstractControllerTest {
         OBDModuleInformation obdModuleInformation = new OBDModuleInformation(0);
         dataRepository.putObdModule(obdModuleInformation);
 
-        when(diagnosticMessageModule.requestDM31(any(), eq(0x00))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM31(any(), eq(0x00))).thenReturn(RequestResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any(), eq(0x00));
+        verify(communicationsModule).requestDM31(any(), eq(0x00));
 
         verify(mockListener, atLeastOnce()).addOutcome(PART_NUMBER,
                                                        STEP_NUMBER,
@@ -150,14 +150,14 @@ public class Part02Step13ControllerTest extends AbstractControllerTest {
 
         AcknowledgmentPacket ackPacket0x00 = AcknowledgmentPacket.create(0, NACK);
 
-        when(diagnosticMessageModule.requestDM31(any(), eq(0x00)))
+        when(communicationsModule.requestDM31(any(), eq(0x00)))
                                                                   .thenReturn(new RequestResult<>(false,
                                                                                                   List.of(),
                                                                                                   List.of(ackPacket0x00)));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any(), eq(0x00));
+        verify(communicationsModule).requestDM31(any(), eq(0x00));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -172,23 +172,23 @@ public class Part02Step13ControllerTest extends AbstractControllerTest {
         DiagnosticTroubleCode dtc = create(609, 19, 1, 1);
         DTCLampStatus dtcLampStatus = create(dtc, OFF, SLOW_FLASH, OTHER, OTHER);
         DM31DtcToLampAssociation packet = DM31DtcToLampAssociation.create(0, 0, dtcLampStatus);
-        when(diagnosticMessageModule.requestDM31(any(), eq(0x00))).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM31(any(), eq(0x00))).thenReturn(RequestResult.of(packet));
 
         DiagnosticTroubleCode dtc1 = create(4334, 77, 0, 23);
         DTCLampStatus dtcLampStatus1 = create(dtc1, ON, FAST_FLASH, OTHER, OTHER);
         DM31DtcToLampAssociation packet1 = DM31DtcToLampAssociation.create(1, 0, dtcLampStatus1);
-        when(diagnosticMessageModule.requestDM31(any(), eq(0x01))).thenReturn(RequestResult.of(packet1));
+        when(communicationsModule.requestDM31(any(), eq(0x01))).thenReturn(RequestResult.of(packet1));
 
         DiagnosticTroubleCode dtc2 = create(62002, 77, 0, 23);
         DTCLampStatus dtcLampStatus2 = create(dtc2, ON, ON, ON, ON);
         DM31DtcToLampAssociation packet2 = DM31DtcToLampAssociation.create(2, 0, dtcLampStatus2);
-        when(diagnosticMessageModule.requestDM31(any(), eq(0x02))).thenReturn(RequestResult.of(packet2));
+        when(communicationsModule.requestDM31(any(), eq(0x02))).thenReturn(RequestResult.of(packet2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM31(any(), eq(0x01));
-        verify(diagnosticMessageModule).requestDM31(any(), eq(0x02));
+        verify(communicationsModule).requestDM31(any(), eq(0x00));
+        verify(communicationsModule).requestDM31(any(), eq(0x01));
+        verify(communicationsModule).requestDM31(any(), eq(0x02));
 
         verify(mockListener, atLeastOnce()).addOutcome(PART_NUMBER,
                                                        STEP_NUMBER,
@@ -242,11 +242,11 @@ public class Part02Step13ControllerTest extends AbstractControllerTest {
                 0xFF, // Lamp Status/State
         };
         DM31DtcToLampAssociation packet = new DM31DtcToLampAssociation(Packet.create(PGN, 0x00, data));
-        when(diagnosticMessageModule.requestDM31(any(), eq(0))).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM31(any(), eq(0))).thenReturn(RequestResult.of(packet));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any(), eq(0));
+        verify(communicationsModule).requestDM31(any(), eq(0));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step14ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step14ControllerTest.java
@@ -26,7 +26,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -50,7 +50,7 @@ public class Part02Step14ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -86,7 +86,7 @@ public class Part02Step14ControllerTest extends AbstractControllerTest {
                                               vehicleInformationModule,
                                               dataRepository,
                                               DateTimeModule.getInstance(),
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -95,7 +95,7 @@ public class Part02Step14ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -104,7 +104,7 @@ public class Part02Step14ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -141,7 +141,7 @@ public class Part02Step14ControllerTest extends AbstractControllerTest {
         };
         DM25ExpandedFreezeFrame packet = new DM25ExpandedFreezeFrame(Packet.create(PGN, 0x00, data));
 
-        when(diagnosticMessageModule.requestDM25(any(), eq(0x00))).thenReturn(new BusResult<>(false, packet));
+        when(communicationsModule.requestDM25(any(), eq(0x00))).thenReturn(new BusResult<>(false, packet));
 
         OBDModuleInformation obdInfo = new OBDModuleInformation(0);
         obdInfo.set(DM24SPNSupportPacket.create(0, SupportedSPN.create(123, true, true, true, 1)), 1);
@@ -149,7 +149,7 @@ public class Part02Step14ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(0x00));
+        verify(communicationsModule).requestDM25(any(), eq(0x00));
 
         verify(mockListener, atLeastOnce()).addOutcome(PART_NUMBER,
                                                        STEP_NUMBER,
@@ -167,11 +167,11 @@ public class Part02Step14ControllerTest extends AbstractControllerTest {
         obdInfo.set(DM24SPNSupportPacket.create(0, SupportedSPN.create(123, true, true, true, 1)), 1);
         dataRepository.putObdModule(obdInfo);
 
-        when(diagnosticMessageModule.requestDM25(any(), eq(0x00))).thenReturn(new BusResult<>(true));
+        when(communicationsModule.requestDM25(any(), eq(0x00))).thenReturn(new BusResult<>(true));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(0x00));
+        verify(communicationsModule).requestDM25(any(), eq(0x00));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -191,7 +191,7 @@ public class Part02Step14ControllerTest extends AbstractControllerTest {
                                                                                    0xFF,
                                                                                    0xFF));
 
-        when(diagnosticMessageModule.requestDM25(any(), eq(0x00))).thenReturn(new BusResult<>(false, packet));
+        when(communicationsModule.requestDM25(any(), eq(0x00))).thenReturn(new BusResult<>(false, packet));
 
         OBDModuleInformation obdInfo = new OBDModuleInformation(0);
         obdInfo.set(DM24SPNSupportPacket.create(0, SupportedSPN.create(123, true, true, true, 1)), 1);
@@ -199,7 +199,7 @@ public class Part02Step14ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(0x00));
+        verify(communicationsModule).requestDM25(any(), eq(0x00));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step15ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step15ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -51,7 +51,7 @@ public class Part02Step15ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -87,7 +87,7 @@ public class Part02Step15ControllerTest extends AbstractControllerTest {
                                               vehicleInformationModule,
                                               dataRepository,
                                               DateTimeModule.getInstance(),
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -96,7 +96,7 @@ public class Part02Step15ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -105,7 +105,7 @@ public class Part02Step15ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -134,9 +134,9 @@ public class Part02Step15ControllerTest extends AbstractControllerTest {
         var globalPacket = create(0, 0, EngineHoursTimer.create(1, 4, 10));
         var dsPacket = create(0, 0, EngineHoursTimer.create(1, 4, 10));
 
-        when(diagnosticMessageModule.requestDM33(any())).thenReturn(RequestResult.of(globalPacket));
+        when(communicationsModule.requestDM33(any())).thenReturn(RequestResult.of(globalPacket));
 
-        when(diagnosticMessageModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.of(dsPacket));
+        when(communicationsModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.of(dsPacket));
 
         var vehInfo = new VehicleInformation();
         vehInfo.setEngineModelYear(2020);
@@ -146,8 +146,8 @@ public class Part02Step15ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM33(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM33(any());
+        verify(communicationsModule).requestDM33(any(), eq(0x00));
+        verify(communicationsModule).requestDM33(any());
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -157,8 +157,8 @@ public class Part02Step15ControllerTest extends AbstractControllerTest {
     @Test
     public void testNoResponsesCIEngine() {
 
-        when(diagnosticMessageModule.requestDM33(any())).thenReturn(RequestResult.empty());
-        when(diagnosticMessageModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM33(any())).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.empty());
 
         var vehInfo = new VehicleInformation();
         vehInfo.setEngineModelYear(2020);
@@ -168,8 +168,8 @@ public class Part02Step15ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM33(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM33(any());
+        verify(communicationsModule).requestDM33(any(), eq(0x00));
+        verify(communicationsModule).requestDM33(any());
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -184,8 +184,8 @@ public class Part02Step15ControllerTest extends AbstractControllerTest {
     @Test
     public void testNoResponsesSIEngine() {
 
-        when(diagnosticMessageModule.requestDM33(any())).thenReturn(RequestResult.empty());
-        when(diagnosticMessageModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM33(any())).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.empty());
 
         var vehInfo = new VehicleInformation();
         vehInfo.setEngineModelYear(2020);
@@ -195,8 +195,8 @@ public class Part02Step15ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM33(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM33(any());
+        verify(communicationsModule).requestDM33(any(), eq(0x00));
+        verify(communicationsModule).requestDM33(any());
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -205,8 +205,8 @@ public class Part02Step15ControllerTest extends AbstractControllerTest {
     @Test
     public void testNoResponsesSIEnginePost2024() {
 
-        when(diagnosticMessageModule.requestDM33(any())).thenReturn(RequestResult.empty());
-        when(diagnosticMessageModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM33(any())).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.empty());
 
         var vehInfo = new VehicleInformation();
         vehInfo.setEngineModelYear(2024);
@@ -216,8 +216,8 @@ public class Part02Step15ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM33(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM33(any());
+        verify(communicationsModule).requestDM33(any(), eq(0x00));
+        verify(communicationsModule).requestDM33(any());
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -233,8 +233,8 @@ public class Part02Step15ControllerTest extends AbstractControllerTest {
     @Test
     public void testNoResponsesCIEngine2024() {
 
-        when(diagnosticMessageModule.requestDM33(any())).thenReturn(RequestResult.empty());
-        when(diagnosticMessageModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM33(any())).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.empty());
 
         var vehInfo = new VehicleInformation();
         vehInfo.setEngineModelYear(2024);
@@ -244,8 +244,8 @@ public class Part02Step15ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM33(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM33(any());
+        verify(communicationsModule).requestDM33(any(), eq(0x00));
+        verify(communicationsModule).requestDM33(any());
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -261,9 +261,9 @@ public class Part02Step15ControllerTest extends AbstractControllerTest {
     public void testFailNoGlobalResponse() {
         var packet = create(0, 0, EngineHoursTimer.create(0, 0, 0));
 
-        when(diagnosticMessageModule.requestDM33(any())).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM33(any())).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.of(packet));
 
         var vehInfo = new VehicleInformation();
         vehInfo.setEngineModelYear(2020);
@@ -273,8 +273,8 @@ public class Part02Step15ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM33(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM33(any());
+        verify(communicationsModule).requestDM33(any(), eq(0x00));
+        verify(communicationsModule).requestDM33(any());
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -295,9 +295,9 @@ public class Part02Step15ControllerTest extends AbstractControllerTest {
     public void testWarnValueOfFB() {
         var packet = create(0, 0, EngineHoursTimer.create(0xFB, 0, 0));
 
-        when(diagnosticMessageModule.requestDM33(any())).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM33(any())).thenReturn(RequestResult.of(packet));
 
-        when(diagnosticMessageModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.of(packet));
 
         var vehInfo = new VehicleInformation();
         vehInfo.setEngineModelYear(2020);
@@ -307,8 +307,8 @@ public class Part02Step15ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM33(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM33(any());
+        verify(communicationsModule).requestDM33(any(), eq(0x00));
+        verify(communicationsModule).requestDM33(any());
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -324,9 +324,9 @@ public class Part02Step15ControllerTest extends AbstractControllerTest {
         var globalPacket = create(0, 0, EngineHoursTimer.create(1, 4, 10));
         var dsPacket = create(0, 0, EngineHoursTimer.create(1, 7, 13));
 
-        when(diagnosticMessageModule.requestDM33(any())).thenReturn(RequestResult.of(globalPacket));
+        when(communicationsModule.requestDM33(any())).thenReturn(RequestResult.of(globalPacket));
 
-        when(diagnosticMessageModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.of(dsPacket));
+        when(communicationsModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.of(dsPacket));
 
         var vehInfo = new VehicleInformation();
         vehInfo.setEngineModelYear(2020);
@@ -336,8 +336,8 @@ public class Part02Step15ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM33(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM33(any());
+        verify(communicationsModule).requestDM33(any(), eq(0x00));
+        verify(communicationsModule).requestDM33(any());
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step16ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step16ControllerTest.java
@@ -34,7 +34,7 @@ import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -57,7 +57,7 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
     private DataRepository dataRepository;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -93,7 +93,7 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
                                               vehicleInformationModule,
                                               dataRepository,
                                               DateTimeModule.getInstance(),
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -102,7 +102,7 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -111,7 +111,7 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -138,8 +138,8 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
     @Test
     public void testNoResponsesSIEngine() {
 
-        when(diagnosticMessageModule.requestDM34(any())).thenReturn(new RequestResult<>(false));
-        when(diagnosticMessageModule.requestDM34(any(), eq(0))).thenReturn(new RequestResult<>(false));
+        when(communicationsModule.requestDM34(any())).thenReturn(new RequestResult<>(false));
+        when(communicationsModule.requestDM34(any(), eq(0))).thenReturn(new RequestResult<>(false));
 
         var vehInfo = new VehicleInformation();
         vehInfo.setFuelType(FuelType.GAS);
@@ -151,8 +151,8 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM34(any());
-        verify(diagnosticMessageModule).requestDM34(any(), eq(0));
+        verify(communicationsModule).requestDM34(any());
+        verify(communicationsModule).requestDM34(any(), eq(0));
 
         verify(mockListener).addOutcome(PART,
                                         STEP,
@@ -168,7 +168,7 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
     @Test
     public void testNoResponsesCIEngine() {
 
-        when(diagnosticMessageModule.requestDM34(any())).thenReturn(new RequestResult<>(false, List.of()));
+        when(communicationsModule.requestDM34(any())).thenReturn(new RequestResult<>(false, List.of()));
 
         var vehInfo = new VehicleInformation();
         vehInfo.setFuelType(FuelType.DSL);
@@ -178,7 +178,7 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM34(any());
+        verify(communicationsModule).requestDM34(any());
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -198,9 +198,9 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
         moduleInfo.set(packet, 1);
         dataRepository.putObdModule(moduleInfo);
 
-        when(diagnosticMessageModule.requestDM34(any())).thenReturn(new RequestResult<>(false, packet));
+        when(communicationsModule.requestDM34(any())).thenReturn(new RequestResult<>(false, packet));
 
-        when(diagnosticMessageModule.requestDM34(any(), eq(0))).thenReturn(new RequestResult<>(false, packet));
+        when(communicationsModule.requestDM34(any(), eq(0))).thenReturn(new RequestResult<>(false, packet));
 
         var vehInfo = new VehicleInformation();
         vehInfo.setFuelType(FuelType.DSL);
@@ -208,8 +208,8 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM34(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM34(any());
+        verify(communicationsModule).requestDM34(any(), eq(0x00));
+        verify(communicationsModule).requestDM34(any());
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -245,9 +245,9 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
         var globalPacket = create(0, 0, OUTSIDE, OUTSIDE, OUTSIDE, OUTSIDE, OUTSIDE, OUTSIDE);
         var dsPacket = create(0, 0, OUTSIDE, OUTSIDE, OUTSIDE, OUTSIDE, OUTSIDE, NOT_AVAILABLE);
 
-        when(diagnosticMessageModule.requestDM34(any())).thenReturn(new RequestResult<>(false, globalPacket));
+        when(communicationsModule.requestDM34(any())).thenReturn(new RequestResult<>(false, globalPacket));
 
-        when(diagnosticMessageModule.requestDM34(any(), eq(0))).thenReturn(new RequestResult<>(false, dsPacket));
+        when(communicationsModule.requestDM34(any(), eq(0))).thenReturn(new RequestResult<>(false, dsPacket));
 
         var vehInfo = new VehicleInformation();
         vehInfo.setFuelType(FuelType.DSL);
@@ -258,8 +258,8 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM34(any());
-        verify(diagnosticMessageModule).requestDM34(any(), eq(0));
+        verify(communicationsModule).requestDM34(any());
+        verify(communicationsModule).requestDM34(any(), eq(0));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -274,8 +274,8 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
         var globalPacket = create(0, 0, INSIDE, OUTSIDE, OUTSIDE, OUTSIDE, OUTSIDE, OUTSIDE);
         var dsPacket = AcknowledgmentPacket.create(0, NACK, 0, 0xF9, DM34NTEStatus.PGN);
 
-        when(diagnosticMessageModule.requestDM34(any())).thenReturn(new RequestResult<>(false, globalPacket));
-        when(diagnosticMessageModule.requestDM34(any(), eq(0))).thenReturn(new RequestResult<>(false, dsPacket));
+        when(communicationsModule.requestDM34(any())).thenReturn(new RequestResult<>(false, globalPacket));
+        when(communicationsModule.requestDM34(any(), eq(0))).thenReturn(new RequestResult<>(false, dsPacket));
 
         var vehInfo = new VehicleInformation();
         vehInfo.setFuelType(FuelType.DSL);
@@ -286,8 +286,8 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM34(any());
-        verify(diagnosticMessageModule).requestDM34(any(), eq(0));
+        verify(communicationsModule).requestDM34(any());
+        verify(communicationsModule).requestDM34(any(), eq(0));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -303,8 +303,8 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
         var globalPacket = create(0, 0, OUTSIDE, INSIDE, OUTSIDE, OUTSIDE, OUTSIDE, OUTSIDE);
         var dsPacket = AcknowledgmentPacket.create(0, NACK, 0, 0xF9, DM34NTEStatus.PGN);
 
-        when(diagnosticMessageModule.requestDM34(any())).thenReturn(new RequestResult<>(false, globalPacket));
-        when(diagnosticMessageModule.requestDM34(any(), eq(0))).thenReturn(new RequestResult<>(false, dsPacket));
+        when(communicationsModule.requestDM34(any())).thenReturn(new RequestResult<>(false, globalPacket));
+        when(communicationsModule.requestDM34(any(), eq(0))).thenReturn(new RequestResult<>(false, dsPacket));
 
         var vehInfo = new VehicleInformation();
         vehInfo.setFuelType(FuelType.DSL);
@@ -315,8 +315,8 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM34(any());
-        verify(diagnosticMessageModule).requestDM34(any(), eq(0));
+        verify(communicationsModule).requestDM34(any());
+        verify(communicationsModule).requestDM34(any(), eq(0));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -332,8 +332,8 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
         var globalPacket = create(0, 0, OUTSIDE, OUTSIDE, OUTSIDE, INSIDE, OUTSIDE, OUTSIDE);
         var dsPacket = AcknowledgmentPacket.create(0, NACK, 0, 0xF9, DM34NTEStatus.PGN);
 
-        when(diagnosticMessageModule.requestDM34(any())).thenReturn(new RequestResult<>(false, globalPacket));
-        when(diagnosticMessageModule.requestDM34(any(), eq(0))).thenReturn(new RequestResult<>(false, dsPacket));
+        when(communicationsModule.requestDM34(any())).thenReturn(new RequestResult<>(false, globalPacket));
+        when(communicationsModule.requestDM34(any(), eq(0))).thenReturn(new RequestResult<>(false, dsPacket));
 
         var vehInfo = new VehicleInformation();
         vehInfo.setFuelType(FuelType.DSL);
@@ -344,8 +344,8 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM34(any());
-        verify(diagnosticMessageModule).requestDM34(any(), eq(0));
+        verify(communicationsModule).requestDM34(any());
+        verify(communicationsModule).requestDM34(any(), eq(0));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -363,8 +363,8 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
         var dsPacket = AcknowledgmentPacket.create(0, NACK, 0, 0xF9, DM34NTEStatus.PGN);
         System.out.println(globalPacket.getPacket());
         System.out.println(packet.getPacket());
-        when(diagnosticMessageModule.requestDM34(any())).thenReturn(new RequestResult<>(false, packet));
-        when(diagnosticMessageModule.requestDM34(any(), eq(0))).thenReturn(new RequestResult<>(false, dsPacket));
+        when(communicationsModule.requestDM34(any())).thenReturn(new RequestResult<>(false, packet));
+        when(communicationsModule.requestDM34(any(), eq(0))).thenReturn(new RequestResult<>(false, dsPacket));
 
         var vehInfo = new VehicleInformation();
         vehInfo.setFuelType(FuelType.DSL);
@@ -375,8 +375,8 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM34(any());
-        verify(diagnosticMessageModule).requestDM34(any(), eq(0));
+        verify(communicationsModule).requestDM34(any());
+        verify(communicationsModule).requestDM34(any(), eq(0));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -390,8 +390,8 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
         var dsPacket = AcknowledgmentPacket.create(0, NACK, 0, 0xF9, DM34NTEStatus.PGN);
         System.out.println(globalPacket.getPacket());
         System.out.println(packet.getPacket());
-        when(diagnosticMessageModule.requestDM34(any())).thenReturn(new RequestResult<>(false, packet));
-        when(diagnosticMessageModule.requestDM34(any(), eq(0))).thenReturn(new RequestResult<>(false, dsPacket));
+        when(communicationsModule.requestDM34(any())).thenReturn(new RequestResult<>(false, packet));
+        when(communicationsModule.requestDM34(any(), eq(0))).thenReturn(new RequestResult<>(false, dsPacket));
 
         var vehInfo = new VehicleInformation();
         vehInfo.setFuelType(FuelType.DSL);
@@ -402,8 +402,8 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM34(any());
-        verify(diagnosticMessageModule).requestDM34(any(), eq(0));
+        verify(communicationsModule).requestDM34(any());
+        verify(communicationsModule).requestDM34(any(), eq(0));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step17ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step17ControllerTest.java
@@ -45,7 +45,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -97,7 +97,7 @@ public class Part02Step17ControllerTest extends AbstractControllerTest {
     private ReportFileModule reportFileModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     private static List<SupportedSPN> spns(int... ids) {
         return Arrays.stream(ids).mapToObj(id -> {
@@ -131,7 +131,7 @@ public class Part02Step17ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               tableA1Validator,
                                               j1939DaRepository,
                                               broadcastValidator,
@@ -143,7 +143,7 @@ public class Part02Step17ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step18ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step18ControllerTest.java
@@ -27,7 +27,7 @@ import org.etools.j1939_84.controllers.ResultsListener;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -56,7 +56,7 @@ public class Part02Step18ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -93,7 +93,7 @@ public class Part02Step18ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -102,7 +102,7 @@ public class Part02Step18ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -114,7 +114,7 @@ public class Part02Step18ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  vehicleInformationModule,
                                  mockListener,
-                                 diagnosticMessageModule);
+                                 communicationsModule);
     }
 
     @Test

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03ControllerTest.java
@@ -24,7 +24,7 @@ public class Part03ControllerTest extends AbstractPartControllerTest {
                                         DataRepository.newInstance(),
                                         engineSpeedModule,
                                         vehicleInformationModule,
-                                        diagnosticMessageModule,
+                                        communicationsModule,
                                         step01Controller,
                                         step02Controller,
                                         step03Controller,

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step01ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step01ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -50,7 +50,7 @@ public class Part03Step01ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -87,7 +87,7 @@ public class Part03Step01ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -96,7 +96,7 @@ public class Part03Step01ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step02ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step02ControllerTest.java
@@ -35,7 +35,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -57,7 +57,7 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -97,7 +97,7 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -106,7 +106,7 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -144,13 +144,13 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var nack = AcknowledgmentPacket.create(0, AcknowledgmentPacket.Response.NACK);
-        when(diagnosticMessageModule.requestDM6(any(), eq(0))).thenReturn(new RequestResult<>(false, nack));
+        when(communicationsModule.requestDM6(any(), eq(0))).thenReturn(new RequestResult<>(false, nack));
 
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
         var dm6_1 = DM6PendingEmissionDTCPacket.create(1, OFF, OFF, OFF, OFF, dtc1);
-        when(diagnosticMessageModule.requestDM6(any(), eq(1))).thenReturn(new RequestResult<>(false, dm6_1));
+        when(communicationsModule.requestDM6(any(), eq(1))).thenReturn(new RequestResult<>(false, dm6_1));
 
-        when(diagnosticMessageModule.requestDM6(any())).thenReturn(new RequestResult<>(false, dm6_1));
+        when(communicationsModule.requestDM6(any())).thenReturn(new RequestResult<>(false, dm6_1));
 
         runTest();
 
@@ -161,16 +161,16 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
         expectedResults += "Attempt 1" + NL;
         assertEquals(expectedResults, listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM6(any());
-        verify(diagnosticMessageModule).requestDM6(any(), eq(1));
-        verify(diagnosticMessageModule).requestDM6(any(), eq(0));
+        verify(communicationsModule).requestDM6(any());
+        verify(communicationsModule).requestDM6(any(), eq(1));
+        verify(communicationsModule).requestDM6(any(), eq(0));
 
         assertEquals(0, dateTimeModule.getTimeAsLong());
     }
 
     @Test
     public void testNoResponses() throws InterruptedException {
-        when(diagnosticMessageModule.requestDM6(any())).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM6(any())).thenReturn(RequestResult.empty());
 
         runTest();
 
@@ -181,7 +181,7 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
         expectedResults += "Attempt 1" + NL;
         assertEquals(expectedResults, listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM6(any());
+        verify(communicationsModule).requestDM6(any());
 
         assertEquals(0, dateTimeModule.getTimeAsLong());
 
@@ -193,7 +193,7 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
         var dm6 = DM6PendingEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM6(any())).thenReturn(new RequestResult<>(false, dm6));
+        when(communicationsModule.requestDM6(any())).thenReturn(new RequestResult<>(false, dm6));
 
         String promptMsg = "No ECU has reported a Pending Emission DTC." + NL + NL + "Do you wish to continue?";
         String promptTitle = "No Pending Emission DTCs Found";
@@ -220,7 +220,7 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
         assertEquals(expectedResults.toString(), listener.getResults());
 
         verify(mockListener).onUrgentMessage(eq(promptMsg), eq(promptTitle), eq(QUESTION), any());
-        verify(diagnosticMessageModule, times(300)).requestDM6(any());
+        verify(communicationsModule, times(300)).requestDM6(any());
         verify(mockListener).onUrgentMessage(eq(promptMsg), eq(promptTitle), eq(QUESTION), any());
         verify(mockListener, times(2)).addOutcome(PART_NUMBER,
                                                   STEP_NUMBER,
@@ -237,8 +237,8 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
         var dtc2 = DiagnosticTroubleCode.create(456, 3, 0, 1);
         var dm6 = DM6PendingEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc1, dtc2);
-        when(diagnosticMessageModule.requestDM6(any())).thenReturn(new RequestResult<>(false, dm6));
-        when(diagnosticMessageModule.requestDM6(any(), eq(0))).thenReturn(new RequestResult<>(false, dm6));
+        when(communicationsModule.requestDM6(any())).thenReturn(new RequestResult<>(false, dm6));
+        when(communicationsModule.requestDM6(any(), eq(0))).thenReturn(new RequestResult<>(false, dm6));
 
         runTest();
 
@@ -249,8 +249,8 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
         expectedResults += "Attempt 1" + NL;
         assertEquals(expectedResults, listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM6(any());
-        verify(diagnosticMessageModule).requestDM6(any(), eq(0));
+        verify(communicationsModule).requestDM6(any());
+        verify(communicationsModule).requestDM6(any(), eq(0));
 
         assertEquals(0, dateTimeModule.getTimeAsLong());
 
@@ -267,8 +267,8 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
         var dm6_0 = DM6PendingEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc1);
         var dm6_1 = DM6PendingEmissionDTCPacket.create(1, OFF, OFF, OFF, OFF, dtc1);
-        when(diagnosticMessageModule.requestDM6(any())).thenReturn(new RequestResult<>(false, dm6_0, dm6_1));
-        when(diagnosticMessageModule.requestDM6(any(), eq(0))).thenReturn(new RequestResult<>(false, dm6_0));
+        when(communicationsModule.requestDM6(any())).thenReturn(new RequestResult<>(false, dm6_0, dm6_1));
+        when(communicationsModule.requestDM6(any(), eq(0))).thenReturn(new RequestResult<>(false, dm6_0));
 
         runTest();
 
@@ -279,8 +279,8 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
         expectedResults += "Attempt 1" + NL;
         assertEquals(expectedResults, listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM6(any());
-        verify(diagnosticMessageModule).requestDM6(any(), eq(0));
+        verify(communicationsModule).requestDM6(any());
+        verify(communicationsModule).requestDM6(any(), eq(0));
 
         assertEquals(0, dateTimeModule.getTimeAsLong());
 
@@ -296,13 +296,13 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var dm6_0 = DM6PendingEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM6(any(), eq(0))).thenReturn(new RequestResult<>(false, dm6_0));
+        when(communicationsModule.requestDM6(any(), eq(0))).thenReturn(new RequestResult<>(false, dm6_0));
 
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
         var dm6_1 = DM6PendingEmissionDTCPacket.create(1, OFF, OFF, OFF, OFF, dtc1);
-        when(diagnosticMessageModule.requestDM6(any(), eq(1))).thenReturn(new RequestResult<>(false, dm6_1));
+        when(communicationsModule.requestDM6(any(), eq(1))).thenReturn(new RequestResult<>(false, dm6_1));
 
-        when(diagnosticMessageModule.requestDM6(any())).thenReturn(new RequestResult<>(false, dm6_0, dm6_1));
+        when(communicationsModule.requestDM6(any())).thenReturn(new RequestResult<>(false, dm6_0, dm6_1));
 
         runTest();
 
@@ -313,9 +313,9 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
         expectedResults += "Attempt 1" + NL;
         assertEquals(expectedResults, listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM6(any());
-        verify(diagnosticMessageModule).requestDM6(any(), eq(1));
-        verify(diagnosticMessageModule).requestDM6(any(), eq(0));
+        verify(communicationsModule).requestDM6(any());
+        verify(communicationsModule).requestDM6(any(), eq(1));
+        verify(communicationsModule).requestDM6(any(), eq(0));
 
         assertEquals(0, dateTimeModule.getTimeAsLong());
     }
@@ -325,8 +325,8 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
         var dm6 = DM6PendingEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc1);
-        when(diagnosticMessageModule.requestDM6(any())).thenReturn(new RequestResult<>(false, dm6));
-        when(diagnosticMessageModule.requestDM6(any(), eq(0))).thenReturn(new RequestResult<>(false, dm6));
+        when(communicationsModule.requestDM6(any())).thenReturn(new RequestResult<>(false, dm6));
+        when(communicationsModule.requestDM6(any(), eq(0))).thenReturn(new RequestResult<>(false, dm6));
 
         runTest();
 
@@ -337,8 +337,8 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
         expectedResults += "Attempt 1" + NL;
         assertEquals(expectedResults, listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM6(any());
-        verify(diagnosticMessageModule).requestDM6(any(), eq(0));
+        verify(communicationsModule).requestDM6(any());
+        verify(communicationsModule).requestDM6(any(), eq(0));
 
         assertEquals(0, dateTimeModule.getTimeAsLong());
 
@@ -354,8 +354,8 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
         var dm6_1 = DM6PendingEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc1);
         var dm6_2 = DM6PendingEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc1);
-        when(diagnosticMessageModule.requestDM6(any())).thenReturn(new RequestResult<>(false, dm6_1));
-        when(diagnosticMessageModule.requestDM6(any(), eq(0))).thenReturn(new RequestResult<>(false, dm6_2));
+        when(communicationsModule.requestDM6(any())).thenReturn(new RequestResult<>(false, dm6_1));
+        when(communicationsModule.requestDM6(any(), eq(0))).thenReturn(new RequestResult<>(false, dm6_2));
 
         runTest();
 
@@ -366,8 +366,8 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
         expectedResults += "Attempt 1" + NL;
         assertEquals(expectedResults, listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM6(any());
-        verify(diagnosticMessageModule).requestDM6(any(), eq(0));
+        verify(communicationsModule).requestDM6(any());
+        verify(communicationsModule).requestDM6(any(), eq(0));
 
         assertEquals(0, dateTimeModule.getTimeAsLong());
 
@@ -383,9 +383,9 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
         var dm6 = DM6PendingEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc1);
-        when(diagnosticMessageModule.requestDM6(any())).thenReturn(new RequestResult<>(false, dm6));
-        when(diagnosticMessageModule.requestDM6(any(), eq(0))).thenReturn(new RequestResult<>(false, dm6));
-        when(diagnosticMessageModule.requestDM6(any(), eq(1))).thenReturn(new RequestResult<>(false));
+        when(communicationsModule.requestDM6(any())).thenReturn(new RequestResult<>(false, dm6));
+        when(communicationsModule.requestDM6(any(), eq(0))).thenReturn(new RequestResult<>(false, dm6));
+        when(communicationsModule.requestDM6(any(), eq(1))).thenReturn(new RequestResult<>(false));
 
         runTest();
 
@@ -396,9 +396,9 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
         expectedResults += "Attempt 1" + NL;
         assertEquals(expectedResults, listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM6(any());
-        verify(diagnosticMessageModule).requestDM6(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM6(any(), eq(1));
+        verify(communicationsModule).requestDM6(any());
+        verify(communicationsModule).requestDM6(any(), eq(0));
+        verify(communicationsModule).requestDM6(any(), eq(1));
 
         assertEquals(0, dateTimeModule.getTimeAsLong());
 

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step03ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step03ControllerTest.java
@@ -35,7 +35,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -57,7 +57,7 @@ public class Part03Step03ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -96,7 +96,7 @@ public class Part03Step03ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -105,7 +105,7 @@ public class Part03Step03ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -116,7 +116,7 @@ public class Part03Step03ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -145,13 +145,13 @@ public class Part03Step03ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
-        when(diagnosticMessageModule.requestDM27(any())).thenReturn(new RequestResult<>(false));
-        when(diagnosticMessageModule.requestDM27(any(), eq(0x01))).thenReturn(new BusResult<>(false));
+        when(communicationsModule.requestDM27(any())).thenReturn(new RequestResult<>(false));
+        when(communicationsModule.requestDM27(any(), eq(0x01))).thenReturn(new BusResult<>(false));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0x01));
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0x01));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -191,16 +191,16 @@ public class Part03Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
         dataRepository.putObdModule(new OBDModuleInformation(3));
 
-        when(diagnosticMessageModule.requestDM27(any())).thenReturn(new RequestResult<>(false, ackPacket));
-        when(diagnosticMessageModule.requestDM27(any(), eq(0x01))).thenReturn(new BusResult<>(false, ackPacket));
-        when(diagnosticMessageModule.requestDM27(any(), eq(0x03))).thenReturn(new BusResult<>(false, packet3));
+        when(communicationsModule.requestDM27(any())).thenReturn(new RequestResult<>(false, ackPacket));
+        when(communicationsModule.requestDM27(any(), eq(0x01))).thenReturn(new BusResult<>(false, ackPacket));
+        when(communicationsModule.requestDM27(any(), eq(0x03))).thenReturn(new BusResult<>(false, packet3));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0x01));
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0x03));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0x01));
+        verify(communicationsModule).requestDM27(any(), eq(0x03));
 
         assertEquals("", listener.getResults());
 
@@ -242,15 +242,15 @@ public class Part03Step03ControllerTest extends AbstractControllerTest {
         obdModule3.set(packet3, 3);
         dataRepository.putObdModule(obdModule3);
 
-        when(diagnosticMessageModule.requestDM27(any())).thenReturn(new RequestResult<>(false, packet1));
-        when(diagnosticMessageModule.requestDM27(any(), eq(0x01))).thenReturn(new BusResult<>(false, packet1));
-        when(diagnosticMessageModule.requestDM27(any(), eq(0x03))).thenReturn(new BusResult<>(false, ackPacket3));
+        when(communicationsModule.requestDM27(any())).thenReturn(new RequestResult<>(false, packet1));
+        when(communicationsModule.requestDM27(any(), eq(0x01))).thenReturn(new BusResult<>(false, packet1));
+        when(communicationsModule.requestDM27(any(), eq(0x03))).thenReturn(new BusResult<>(false, ackPacket3));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0x01));
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0x03));
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0x01));
+        verify(communicationsModule).requestDM27(any(), eq(0x03));
 
         assertEquals(List.of(dtc1),
                      dataRepository.getObdModule(0x01).getLatest(DM6PendingEmissionDTCPacket.class).getDtcs());
@@ -277,13 +277,13 @@ public class Part03Step03ControllerTest extends AbstractControllerTest {
         obdModule1.set(DM6PendingEmissionDTCPacket.create(1, OFF, OFF, OFF, OFF, dtc), 3);
         dataRepository.putObdModule(obdModule1);
 
-        when(diagnosticMessageModule.requestDM27(any())).thenReturn(new RequestResult<>(false, packet1));
-        when(diagnosticMessageModule.requestDM27(any(), eq(0x01))).thenReturn(new BusResult<>(false, packet1));
+        when(communicationsModule.requestDM27(any())).thenReturn(new RequestResult<>(false, packet1));
+        when(communicationsModule.requestDM27(any(), eq(0x01))).thenReturn(new BusResult<>(false, packet1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0x01));
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0x01));
 
         assertEquals(dataRepository.getObdModule(packet1.getSourceAddress()).getLatest(DM27AllPendingDTCsPacket.class),
                      packet1);
@@ -320,15 +320,15 @@ public class Part03Step03ControllerTest extends AbstractControllerTest {
         obdModule2.set(DM6PendingEmissionDTCPacket.create(2, OFF, OFF, OFF, OFF, dtc22), 3);
         dataRepository.putObdModule(obdModule2);
 
-        when(diagnosticMessageModule.requestDM27(any())).thenReturn(new RequestResult<>(false, packet1, packet2));
-        when(diagnosticMessageModule.requestDM27(any(), eq(0x01))).thenReturn(new BusResult<>(false, packet1));
-        when(diagnosticMessageModule.requestDM27(any(), eq(0x02))).thenReturn(new BusResult<>(false, packet2));
+        when(communicationsModule.requestDM27(any())).thenReturn(new RequestResult<>(false, packet1, packet2));
+        when(communicationsModule.requestDM27(any(), eq(0x01))).thenReturn(new BusResult<>(false, packet1));
+        when(communicationsModule.requestDM27(any(), eq(0x02))).thenReturn(new BusResult<>(false, packet2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0x01));
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0x02));
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0x01));
+        verify(communicationsModule).requestDM27(any(), eq(0x02));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step04ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step04ControllerTest.java
@@ -27,7 +27,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -49,7 +49,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -88,7 +88,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -97,7 +97,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -109,7 +109,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  vehicleInformationModule,
                                  mockListener,
-                                 diagnosticMessageModule);
+                                 communicationsModule);
     }
 
     @Test
@@ -134,14 +134,14 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
 
     @Test
     public void testNoMessages() {
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.empty());
 
         runTest();
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -152,7 +152,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForMILCountGreaterThanZero() {
         DM29DtcCounts dm29 = DM29DtcCounts.create(0, 0, 1, 1, 1, 0, 0);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         OBDModuleInformation moduleInfo = new OBDModuleInformation(0);
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
@@ -165,7 +165,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -176,7 +176,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForPreviousMILCountGreaterThanZero() {
         DM29DtcCounts dm29 = DM29DtcCounts.create(0, 0, 1, 1, 0, 1, 0);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         OBDModuleInformation moduleInfo = new OBDModuleInformation(0);
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
@@ -189,7 +189,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -200,7 +200,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForPermanentDTCCountGreaterThanZero() {
         DM29DtcCounts dm29 = DM29DtcCounts.create(0, 0, 1, 1, 0, 0, 1);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         OBDModuleInformation moduleInfo = new OBDModuleInformation(0);
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
@@ -213,7 +213,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -224,7 +224,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForNoEmissionPendingCount() {
         DM29DtcCounts dm29 = DM29DtcCounts.create(0, 0, 0, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         OBDModuleInformation moduleInfo = new OBDModuleInformation(0);
         moduleInfo.set(DM27AllPendingDTCsPacket.create(0, OFF, OFF, OFF, OFF), 3);
@@ -235,7 +235,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -246,7 +246,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForDifferenceFromDM6WithMore() {
         DM29DtcCounts dm29 = DM29DtcCounts.create(0, 0, 1, 1, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         OBDModuleInformation moduleInfo = new OBDModuleInformation(0);
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
@@ -260,7 +260,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -271,7 +271,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForDifferenceFromDM6WithLess() {
         DM29DtcCounts dm29 = DM29DtcCounts.create(0, 0, 1, 1, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         OBDModuleInformation moduleInfo = new OBDModuleInformation(0);
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
@@ -283,7 +283,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -294,7 +294,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForDifferencePendingCounts() {
         DM29DtcCounts dm29 = DM29DtcCounts.create(0, 0, 1, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         OBDModuleInformation moduleInfo = new OBDModuleInformation(0);
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
@@ -307,7 +307,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -318,7 +318,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForLessThanDM27DTCs() {
         DM29DtcCounts dm29 = DM29DtcCounts.create(0, 0, 1, 1, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         OBDModuleInformation moduleInfo = new OBDModuleInformation(0);
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
@@ -332,7 +332,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -343,7 +343,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForWrongNotSupportedValue() {
         DM29DtcCounts dm29 = DM29DtcCounts.create(0, 0, 1, 1, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         OBDModuleInformation moduleInfo = new OBDModuleInformation(0);
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
@@ -355,7 +355,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -366,14 +366,14 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForNonOBD() {
         DM29DtcCounts dm29 = DM29DtcCounts.create(0, 0, 1, 1, 1, 1, 1);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         runTest();
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -414,7 +414,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForMoreThanOnePendingCounts() {
         DM29DtcCounts dm29 = DM29DtcCounts.create(0, 0, 2, 2, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         OBDModuleInformation moduleInfo = new OBDModuleInformation(0);
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
@@ -428,7 +428,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -444,7 +444,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
     public void testFailureForMoreThanOneModuleReportingPendingCounts() {
         DM29DtcCounts dm29_0 = DM29DtcCounts.create(0, 0, 1, 1, 0, 0, 0);
         DM29DtcCounts dm29_1 = DM29DtcCounts.create(1, 0, 1, 1, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0, dm29_1));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0, dm29_1));
 
         OBDModuleInformation moduleInfo0 = new OBDModuleInformation(0);
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
@@ -463,7 +463,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -478,7 +478,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
     @Test
     public void testNoFailures() {
         DM29DtcCounts dm29 = DM29DtcCounts.create(0, 0, 1, 1, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         OBDModuleInformation moduleInfo0 = new OBDModuleInformation(0);
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
@@ -491,7 +491,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
     }
 }

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step05ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step05ControllerTest.java
@@ -32,7 +32,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -54,7 +54,7 @@ public class Part03Step05ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -93,7 +93,7 @@ public class Part03Step05ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -102,7 +102,7 @@ public class Part03Step05ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -114,7 +114,7 @@ public class Part03Step05ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  vehicleInformationModule,
                                  mockListener,
-                                 diagnosticMessageModule);
+                                 communicationsModule);
     }
 
     @Test
@@ -162,7 +162,7 @@ public class Part03Step05ControllerTest extends AbstractControllerTest {
     public void testNoFailuresWithPacketOff() {
         var dtc = DiagnosticTroubleCode.create(123, 12, 0, 1);
         var dm31 = DM31DtcToLampAssociation.create(0, 0, DTCLampStatus.create(dtc, OFF, OFF, OFF, OFF));
-        when(diagnosticMessageModule.requestDM31(any(), eq(0))).thenReturn(new RequestResult<>(false, dm31));
+        when(communicationsModule.requestDM31(any(), eq(0))).thenReturn(new RequestResult<>(false, dm31));
 
         OBDModuleInformation obdModuleInformation = new OBDModuleInformation(0);
         obdModuleInformation.set(DM6PendingEmissionDTCPacket.create(1, OFF, OFF, OFF, OFF, dtc), 3);
@@ -170,7 +170,7 @@ public class Part03Step05ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any(), eq(0));
+        verify(communicationsModule).requestDM31(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -180,7 +180,7 @@ public class Part03Step05ControllerTest extends AbstractControllerTest {
     public void testNoFailuresWithPacketAlternativeOff() {
         var dtc = DiagnosticTroubleCode.create(123, 12, 0, 1);
         var dm31 = DM31DtcToLampAssociation.create(0, 0, DTCLampStatus.create(dtc, OFF, ALTERNATE_OFF, OFF, OFF));
-        when(diagnosticMessageModule.requestDM31(any(), eq(0))).thenReturn(new RequestResult<>(false, dm31));
+        when(communicationsModule.requestDM31(any(), eq(0))).thenReturn(new RequestResult<>(false, dm31));
 
         OBDModuleInformation obdModuleInformation = new OBDModuleInformation(0);
         obdModuleInformation.set(DM6PendingEmissionDTCPacket.create(1, OFF, OFF, OFF, OFF, dtc), 3);
@@ -188,7 +188,7 @@ public class Part03Step05ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any(), eq(0));
+        verify(communicationsModule).requestDM31(any(), eq(0));
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         WARN,
@@ -201,7 +201,7 @@ public class Part03Step05ControllerTest extends AbstractControllerTest {
     @Test
     public void testNoFailuresWithNack() {
         var ack = AcknowledgmentPacket.create(0, NACK);
-        when(diagnosticMessageModule.requestDM31(any(), eq(0))).thenReturn(new RequestResult<>(false, ack));
+        when(communicationsModule.requestDM31(any(), eq(0))).thenReturn(new RequestResult<>(false, ack));
 
         var dtc = DiagnosticTroubleCode.create(123, 12, 0, 1);
         OBDModuleInformation obdModuleInformation = new OBDModuleInformation(0);
@@ -210,7 +210,7 @@ public class Part03Step05ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any(), eq(0));
+        verify(communicationsModule).requestDM31(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -218,7 +218,7 @@ public class Part03Step05ControllerTest extends AbstractControllerTest {
 
     @Test
     public void testFailureForNoNack() {
-        when(diagnosticMessageModule.requestDM31(any(), eq(0))).thenReturn(new RequestResult<>(true));
+        when(communicationsModule.requestDM31(any(), eq(0))).thenReturn(new RequestResult<>(true));
 
         var dtc = DiagnosticTroubleCode.create(123, 12, 0, 1);
         OBDModuleInformation obdModuleInformation = new OBDModuleInformation(0);
@@ -227,7 +227,7 @@ public class Part03Step05ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any(), eq(0));
+        verify(communicationsModule).requestDM31(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -242,7 +242,7 @@ public class Part03Step05ControllerTest extends AbstractControllerTest {
     public void testFailureForMilNotOff() {
         var dtc = DiagnosticTroubleCode.create(123, 12, 0, 1);
         var dm31 = DM31DtcToLampAssociation.create(0, 0, DTCLampStatus.create(dtc, OFF, ON, OFF, OFF));
-        when(diagnosticMessageModule.requestDM31(any(), eq(0))).thenReturn(new RequestResult<>(false, dm31));
+        when(communicationsModule.requestDM31(any(), eq(0))).thenReturn(new RequestResult<>(false, dm31));
 
         OBDModuleInformation obdModuleInformation = new OBDModuleInformation(0);
         obdModuleInformation.set(DM6PendingEmissionDTCPacket.create(1, OFF, OFF, OFF, OFF, dtc), 3);
@@ -250,7 +250,7 @@ public class Part03Step05ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any(), eq(0));
+        verify(communicationsModule).requestDM31(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step06ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step06ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -50,7 +50,7 @@ public class Part03Step06ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -89,7 +89,7 @@ public class Part03Step06ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -98,7 +98,7 @@ public class Part03Step06ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -110,7 +110,7 @@ public class Part03Step06ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  vehicleInformationModule,
                                  mockListener,
-                                 diagnosticMessageModule);
+                                 communicationsModule);
     }
 
     @Test
@@ -140,11 +140,11 @@ public class Part03Step06ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_21));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_21));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -157,11 +157,11 @@ public class Part03Step06ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_21));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_21));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -174,11 +174,11 @@ public class Part03Step06ControllerTest extends AbstractControllerTest {
 
     @Test
     public void testNoMessages() {
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of());
+        when(communicationsModule.readDM1(any())).thenReturn(List.of());
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -190,11 +190,11 @@ public class Part03Step06ControllerTest extends AbstractControllerTest {
     public void testFailureForNoOBDSupport() {
         var dm1 = DM1ActiveDTCsPacket.create(0, OFF, OFF, OFF, OFF);
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -210,11 +210,11 @@ public class Part03Step06ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_21));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_21));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step07ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step07ControllerTest.java
@@ -29,7 +29,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -51,7 +51,7 @@ public class Part03Step07ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -90,7 +90,7 @@ public class Part03Step07ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -99,7 +99,7 @@ public class Part03Step07ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -111,7 +111,7 @@ public class Part03Step07ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  vehicleInformationModule,
                                  mockListener,
-                                 diagnosticMessageModule);
+                                 communicationsModule);
     }
 
     @Test
@@ -141,18 +141,18 @@ public class Part03Step07ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var dm2 = DM2PreviouslyActiveDTC.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(new RequestResult<>(false, dm2));
+        when(communicationsModule.requestDM2(any())).thenReturn(new RequestResult<>(false, dm2));
 
-        when(diagnosticMessageModule.requestDM2(any(), eq(0))).thenReturn(new BusResult<>(false, dm2));
+        when(communicationsModule.requestDM2(any(), eq(0))).thenReturn(new BusResult<>(false, dm2));
 
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM2(any(), eq(1))).thenReturn(new BusResult<>(false, nack));
+        when(communicationsModule.requestDM2(any(), eq(1))).thenReturn(new BusResult<>(false, nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
-        verify(diagnosticMessageModule).requestDM2(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM2(any(), eq(1));
+        verify(communicationsModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any(), eq(0));
+        verify(communicationsModule).requestDM2(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -165,17 +165,17 @@ public class Part03Step07ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var dm2 = DM2PreviouslyActiveDTC.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(new RequestResult<>(false, dm2));
+        when(communicationsModule.requestDM2(any())).thenReturn(new RequestResult<>(false, dm2));
 
-        when(diagnosticMessageModule.requestDM2(any(), eq(0))).thenReturn(new BusResult<>(false, dm2));
+        when(communicationsModule.requestDM2(any(), eq(0))).thenReturn(new BusResult<>(false, dm2));
 
-        when(diagnosticMessageModule.requestDM2(any(), eq(1))).thenReturn(new BusResult<>(true));
+        when(communicationsModule.requestDM2(any(), eq(1))).thenReturn(new BusResult<>(true));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
-        verify(diagnosticMessageModule).requestDM2(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM2(any(), eq(1));
+        verify(communicationsModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any(), eq(0));
+        verify(communicationsModule).requestDM2(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -192,13 +192,13 @@ public class Part03Step07ControllerTest extends AbstractControllerTest {
 
         var dtc = DiagnosticTroubleCode.create(123, 12, 0, 1);
         var dm2 = DM2PreviouslyActiveDTC.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(new RequestResult<>(false, dm2));
-        when(diagnosticMessageModule.requestDM2(any(), eq(0))).thenReturn(new BusResult<>(false, dm2));
+        when(communicationsModule.requestDM2(any())).thenReturn(new RequestResult<>(false, dm2));
+        when(communicationsModule.requestDM2(any(), eq(0))).thenReturn(new BusResult<>(false, dm2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
-        verify(diagnosticMessageModule).requestDM2(any(), eq(0));
+        verify(communicationsModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -214,13 +214,13 @@ public class Part03Step07ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
         var dm2 = DM2PreviouslyActiveDTC.create(0, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(new RequestResult<>(false, dm2));
-        when(diagnosticMessageModule.requestDM2(any(), eq(0))).thenReturn(new BusResult<>(false, dm2));
+        when(communicationsModule.requestDM2(any())).thenReturn(new RequestResult<>(false, dm2));
+        when(communicationsModule.requestDM2(any(), eq(0))).thenReturn(new BusResult<>(false, dm2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
-        verify(diagnosticMessageModule).requestDM2(any(), eq(0));
+        verify(communicationsModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -234,11 +234,11 @@ public class Part03Step07ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForNonOBDMilNotOff() {
         var dm2 = DM2PreviouslyActiveDTC.create(0, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(new RequestResult<>(false, dm2));
+        when(communicationsModule.requestDM2(any())).thenReturn(new RequestResult<>(false, dm2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -254,15 +254,15 @@ public class Part03Step07ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
         var globalDM2 = DM2PreviouslyActiveDTC.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(new RequestResult<>(false, globalDM2));
+        when(communicationsModule.requestDM2(any())).thenReturn(new RequestResult<>(false, globalDM2));
 
         var dsDM2 = DM2PreviouslyActiveDTC.create(0, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM2(any(), eq(0))).thenReturn(new BusResult<>(false, dsDM2));
+        when(communicationsModule.requestDM2(any(), eq(0))).thenReturn(new BusResult<>(false, dsDM2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
-        verify(diagnosticMessageModule).requestDM2(any(), eq(0));
+        verify(communicationsModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step08ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step08ControllerTest.java
@@ -21,7 +21,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -43,7 +43,7 @@ public class Part03Step08ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -82,7 +82,7 @@ public class Part03Step08ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -91,7 +91,7 @@ public class Part03Step08ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -103,7 +103,7 @@ public class Part03Step08ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  vehicleInformationModule,
                                  mockListener,
-                                 diagnosticMessageModule);
+                                 communicationsModule);
     }
 
     @Test
@@ -128,11 +128,11 @@ public class Part03Step08ControllerTest extends AbstractControllerTest {
 
     @Test
     public void testNoPackets() {
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(new RequestResult<>(false));
+        when(communicationsModule.requestDM5(any())).thenReturn(new RequestResult<>(false));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any());
 
         assertEquals("", listener.getResults());
     }
@@ -140,11 +140,11 @@ public class Part03Step08ControllerTest extends AbstractControllerTest {
     @Test
     public void testNAisFiltered() {
         var dm5 = DM5DiagnosticReadinessPacket.create(0, 0xFF, 0xFF, 0x23);
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(new RequestResult<>(false, dm5));
+        when(communicationsModule.requestDM5(any())).thenReturn(new RequestResult<>(false, dm5));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any());
 
         assertEquals("", listener.getResults());
     }
@@ -152,11 +152,11 @@ public class Part03Step08ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForActiveCount() {
         var dm5 = DM5DiagnosticReadinessPacket.create(0, 1, 0xFF, 0x23);
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(new RequestResult<>(false, dm5));
+        when(communicationsModule.requestDM5(any())).thenReturn(new RequestResult<>(false, dm5));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any());
 
         assertEquals("", listener.getResults());
 
@@ -169,11 +169,11 @@ public class Part03Step08ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForPreviouslyActiveCount() {
         var dm5 = DM5DiagnosticReadinessPacket.create(0, 0, 1, 0x23);
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(new RequestResult<>(false, dm5));
+        when(communicationsModule.requestDM5(any())).thenReturn(new RequestResult<>(false, dm5));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any());
 
         assertEquals("", listener.getResults());
 
@@ -186,11 +186,11 @@ public class Part03Step08ControllerTest extends AbstractControllerTest {
     @Test
     public void testNoFailure() {
         var dm5 = DM5DiagnosticReadinessPacket.create(0, 0, 0, 0x23);
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(new RequestResult<>(false, dm5));
+        when(communicationsModule.requestDM5(any())).thenReturn(new RequestResult<>(false, dm5));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any());
 
         assertEquals("", listener.getResults());
     }
@@ -198,11 +198,11 @@ public class Part03Step08ControllerTest extends AbstractControllerTest {
     @Test
     public void testOBDModulesAreFiltered() {
         var dm5 = DM5DiagnosticReadinessPacket.create(0, 1, 1, 0);
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(new RequestResult<>(false, dm5));
+        when(communicationsModule.requestDM5(any())).thenReturn(new RequestResult<>(false, dm5));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any());
 
         assertEquals("", listener.getResults());
     }

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step09ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step09ControllerTest.java
@@ -31,7 +31,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -53,7 +53,7 @@ public class Part03Step09ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -92,7 +92,7 @@ public class Part03Step09ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -101,7 +101,7 @@ public class Part03Step09ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -113,7 +113,7 @@ public class Part03Step09ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  vehicleInformationModule,
                                  mockListener,
-                                 diagnosticMessageModule);
+                                 communicationsModule);
     }
 
     @Test
@@ -142,13 +142,13 @@ public class Part03Step09ControllerTest extends AbstractControllerTest {
 
         var dm12_0 = DM12MILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
         var dm12_21 = DM12MILOnEmissionDTCPacket.create(0x21, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12_0, dm12_21));
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12_0));
+        when(communicationsModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12_0, dm12_21));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any());
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any(), eq(0));
 
         assertEquals("", listener.getResults());
     }
@@ -160,17 +160,17 @@ public class Part03Step09ControllerTest extends AbstractControllerTest {
 
         var dm12_0 = DM12MILOnEmissionDTCPacket.create(0, ALTERNATE_OFF, OFF, OFF, OFF);
         var dm12_21 = DM12MILOnEmissionDTCPacket.create(0x21, NOT_SUPPORTED, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12_0, dm12_21));
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12_0));
+        when(communicationsModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12_0, dm12_21));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12_0));
 
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM12(any(), eq(1))).thenReturn(new BusResult<>(false, nack));
+        when(communicationsModule.requestDM12(any(), eq(1))).thenReturn(new BusResult<>(false, nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any());
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM12(any(), eq(1));
+        verify(communicationsModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any(), eq(1));
 
         assertEquals("", listener.getResults());
     }
@@ -182,13 +182,13 @@ public class Part03Step09ControllerTest extends AbstractControllerTest {
         var dtc = DiagnosticTroubleCode.create(123, 12, 0, 1);
         var dm12 = DM12MILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc);
 
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12));
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12));
+        when(communicationsModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any());
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any(), eq(0));
 
         assertEquals("", listener.getResults());
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -203,13 +203,13 @@ public class Part03Step09ControllerTest extends AbstractControllerTest {
 
         var dm12 = DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF);
 
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12));
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12));
+        when(communicationsModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any());
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any(), eq(0));
 
         assertEquals("", listener.getResults());
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -223,13 +223,13 @@ public class Part03Step09ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm12_0 = DM12MILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
         var dm12_1 = DM12MILOnEmissionDTCPacket.create(1, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12_0, dm12_1));
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12_0));
+        when(communicationsModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12_0, dm12_1));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any());
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any(), eq(0));
 
         assertEquals("", listener.getResults());
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -245,13 +245,13 @@ public class Part03Step09ControllerTest extends AbstractControllerTest {
         var dm12_1 = DM12MILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
         var dm12_2 = DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF);
 
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12_1));
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12_2));
+        when(communicationsModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12_1));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12_2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any());
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any(), eq(0));
 
         assertEquals("", listener.getResults());
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -267,15 +267,15 @@ public class Part03Step09ControllerTest extends AbstractControllerTest {
 
         var dm12 = DM12MILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
 
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12));
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(true, dm12));
-        when(diagnosticMessageModule.requestDM12(any(), eq(1))).thenReturn(new BusResult<>(true));
+        when(communicationsModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(true, dm12));
+        when(communicationsModule.requestDM12(any(), eq(1))).thenReturn(new BusResult<>(true));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any());
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM12(any(), eq(1));
+        verify(communicationsModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any(), eq(1));
 
         assertEquals("", listener.getResults());
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -287,11 +287,11 @@ public class Part03Step09ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForNoOBDResponse() {
 
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(new RequestResult<>(false));
+        when(communicationsModule.requestDM12(any())).thenReturn(new RequestResult<>(false));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any());
 
         assertEquals("", listener.getResults());
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, "6.3.9.2.d - No OBD ECU provided a DM12");

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step10ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step10ControllerTest.java
@@ -30,7 +30,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -52,7 +52,7 @@ public class Part03Step10ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -91,7 +91,7 @@ public class Part03Step10ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -100,7 +100,7 @@ public class Part03Step10ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -112,7 +112,7 @@ public class Part03Step10ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  vehicleInformationModule,
                                  mockListener,
-                                 diagnosticMessageModule);
+                                 communicationsModule);
     }
 
     @Test
@@ -141,13 +141,13 @@ public class Part03Step10ControllerTest extends AbstractControllerTest {
 
         var dm23_0 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
         var dm23_21 = DM23PreviouslyMILOnEmissionDTCPacket.create(0x21, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM23(any())).thenReturn(new RequestResult<>(false, dm23_0, dm23_21));
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm23_0));
+        when(communicationsModule.requestDM23(any())).thenReturn(new RequestResult<>(false, dm23_0, dm23_21));
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm23_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any());
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any());
+        verify(communicationsModule).requestDM23(any(), eq(0));
 
         assertEquals("", listener.getResults());
     }
@@ -159,17 +159,17 @@ public class Part03Step10ControllerTest extends AbstractControllerTest {
 
         var dm23_0 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
         var dm23_21 = DM23PreviouslyMILOnEmissionDTCPacket.create(0x21, NOT_SUPPORTED, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM23(any())).thenReturn(new RequestResult<>(false, dm23_0, dm23_21));
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm23_0));
+        when(communicationsModule.requestDM23(any())).thenReturn(new RequestResult<>(false, dm23_0, dm23_21));
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm23_0));
 
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM23(any(), eq(1))).thenReturn(new BusResult<>(false, nack));
+        when(communicationsModule.requestDM23(any(), eq(1))).thenReturn(new BusResult<>(false, nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any());
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM23(any(), eq(1));
+        verify(communicationsModule).requestDM23(any());
+        verify(communicationsModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any(), eq(1));
 
         assertEquals("", listener.getResults());
     }
@@ -181,13 +181,13 @@ public class Part03Step10ControllerTest extends AbstractControllerTest {
         var dtc = DiagnosticTroubleCode.create(123, 12, 0, 1);
         var dm23 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc);
 
-        when(diagnosticMessageModule.requestDM23(any())).thenReturn(new RequestResult<>(false, dm23));
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm23));
+        when(communicationsModule.requestDM23(any())).thenReturn(new RequestResult<>(false, dm23));
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm23));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any());
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any());
+        verify(communicationsModule).requestDM23(any(), eq(0));
 
         assertEquals("", listener.getResults());
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -202,13 +202,13 @@ public class Part03Step10ControllerTest extends AbstractControllerTest {
 
         var dm23 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF);
 
-        when(diagnosticMessageModule.requestDM23(any())).thenReturn(new RequestResult<>(false, dm23));
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm23));
+        when(communicationsModule.requestDM23(any())).thenReturn(new RequestResult<>(false, dm23));
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm23));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any());
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any());
+        verify(communicationsModule).requestDM23(any(), eq(0));
 
         assertEquals("", listener.getResults());
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -222,13 +222,13 @@ public class Part03Step10ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm23_0 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
         var dm23_1 = DM23PreviouslyMILOnEmissionDTCPacket.create(1, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM23(any())).thenReturn(new RequestResult<>(false, dm23_0, dm23_1));
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm23_0));
+        when(communicationsModule.requestDM23(any())).thenReturn(new RequestResult<>(false, dm23_0, dm23_1));
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm23_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any());
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any());
+        verify(communicationsModule).requestDM23(any(), eq(0));
 
         assertEquals("", listener.getResults());
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -244,13 +244,13 @@ public class Part03Step10ControllerTest extends AbstractControllerTest {
         var dm23_1 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
         var dm23_2 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF);
 
-        when(diagnosticMessageModule.requestDM23(any())).thenReturn(new RequestResult<>(false, dm23_1));
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm23_2));
+        when(communicationsModule.requestDM23(any())).thenReturn(new RequestResult<>(false, dm23_1));
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm23_2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any());
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any());
+        verify(communicationsModule).requestDM23(any(), eq(0));
 
         assertEquals("", listener.getResults());
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -266,15 +266,15 @@ public class Part03Step10ControllerTest extends AbstractControllerTest {
 
         var dm23 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
 
-        when(diagnosticMessageModule.requestDM23(any())).thenReturn(new RequestResult<>(false, dm23));
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(true, dm23));
-        when(diagnosticMessageModule.requestDM23(any(), eq(1))).thenReturn(new BusResult<>(true));
+        when(communicationsModule.requestDM23(any())).thenReturn(new RequestResult<>(false, dm23));
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(true, dm23));
+        when(communicationsModule.requestDM23(any(), eq(1))).thenReturn(new BusResult<>(true));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any());
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM23(any(), eq(1));
+        verify(communicationsModule).requestDM23(any());
+        verify(communicationsModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any(), eq(1));
 
         assertEquals("", listener.getResults());
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -286,11 +286,11 @@ public class Part03Step10ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForNoOBDResponse() {
 
-        when(diagnosticMessageModule.requestDM23(any())).thenReturn(new RequestResult<>(false));
+        when(communicationsModule.requestDM23(any())).thenReturn(new RequestResult<>(false));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any());
+        verify(communicationsModule).requestDM23(any());
 
         assertEquals("", listener.getResults());
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, "6.3.10.2.d - No OBD ECU provided a DM23");

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step11ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step11ControllerTest.java
@@ -30,7 +30,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -52,7 +52,7 @@ public class Part03Step11ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -91,7 +91,7 @@ public class Part03Step11ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -100,7 +100,7 @@ public class Part03Step11ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -112,7 +112,7 @@ public class Part03Step11ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  vehicleInformationModule,
                                  mockListener,
-                                 diagnosticMessageModule);
+                                 communicationsModule);
     }
 
     @Test
@@ -141,13 +141,13 @@ public class Part03Step11ControllerTest extends AbstractControllerTest {
 
         var dm23_0 = DM28PermanentEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
         var dm23_21 = DM28PermanentEmissionDTCPacket.create(0x21, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM28(any())).thenReturn(new RequestResult<>(false, dm23_0, dm23_21));
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(new BusResult<>(false, dm23_0));
+        when(communicationsModule.requestDM28(any())).thenReturn(new RequestResult<>(false, dm23_0, dm23_21));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(new BusResult<>(false, dm23_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any());
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any());
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getResults());
     }
@@ -159,17 +159,17 @@ public class Part03Step11ControllerTest extends AbstractControllerTest {
 
         var dm23_0 = DM28PermanentEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
         var dm23_21 = DM28PermanentEmissionDTCPacket.create(0x21, NOT_SUPPORTED, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM28(any())).thenReturn(new RequestResult<>(false, dm23_0, dm23_21));
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(new BusResult<>(false, dm23_0));
+        when(communicationsModule.requestDM28(any())).thenReturn(new RequestResult<>(false, dm23_0, dm23_21));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(new BusResult<>(false, dm23_0));
 
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM28(any(), eq(1))).thenReturn(new BusResult<>(false, nack));
+        when(communicationsModule.requestDM28(any(), eq(1))).thenReturn(new BusResult<>(false, nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any());
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM28(any(), eq(1));
+        verify(communicationsModule).requestDM28(any());
+        verify(communicationsModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(1));
 
         assertEquals("", listener.getResults());
     }
@@ -181,13 +181,13 @@ public class Part03Step11ControllerTest extends AbstractControllerTest {
         var dtc = DiagnosticTroubleCode.create(123, 12, 0, 1);
         var dm23 = DM28PermanentEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc);
 
-        when(diagnosticMessageModule.requestDM28(any())).thenReturn(new RequestResult<>(false, dm23));
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(new BusResult<>(false, dm23));
+        when(communicationsModule.requestDM28(any())).thenReturn(new RequestResult<>(false, dm23));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(new BusResult<>(false, dm23));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any());
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any());
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getResults());
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -202,13 +202,13 @@ public class Part03Step11ControllerTest extends AbstractControllerTest {
 
         var dm23 = DM28PermanentEmissionDTCPacket.create(0, ON, OFF, OFF, OFF);
 
-        when(diagnosticMessageModule.requestDM28(any())).thenReturn(new RequestResult<>(false, dm23));
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(new BusResult<>(false, dm23));
+        when(communicationsModule.requestDM28(any())).thenReturn(new RequestResult<>(false, dm23));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(new BusResult<>(false, dm23));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any());
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any());
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getResults());
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -222,13 +222,13 @@ public class Part03Step11ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm23_0 = DM28PermanentEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
         var dm23_1 = DM28PermanentEmissionDTCPacket.create(1, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM28(any())).thenReturn(new RequestResult<>(false, dm23_0, dm23_1));
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(new BusResult<>(false, dm23_0));
+        when(communicationsModule.requestDM28(any())).thenReturn(new RequestResult<>(false, dm23_0, dm23_1));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(new BusResult<>(false, dm23_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any());
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any());
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getResults());
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -244,13 +244,13 @@ public class Part03Step11ControllerTest extends AbstractControllerTest {
         var dm23_1 = DM28PermanentEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
         var dm23_2 = DM28PermanentEmissionDTCPacket.create(0, ON, OFF, OFF, OFF);
 
-        when(diagnosticMessageModule.requestDM28(any())).thenReturn(new RequestResult<>(false, dm23_1));
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(new BusResult<>(false, dm23_2));
+        when(communicationsModule.requestDM28(any())).thenReturn(new RequestResult<>(false, dm23_1));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(new BusResult<>(false, dm23_2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any());
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any());
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getResults());
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -266,15 +266,15 @@ public class Part03Step11ControllerTest extends AbstractControllerTest {
 
         var dm23 = DM28PermanentEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
 
-        when(diagnosticMessageModule.requestDM28(any())).thenReturn(new RequestResult<>(false, dm23));
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(new BusResult<>(true, dm23));
-        when(diagnosticMessageModule.requestDM28(any(), eq(1))).thenReturn(new BusResult<>(true));
+        when(communicationsModule.requestDM28(any())).thenReturn(new RequestResult<>(false, dm23));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(new BusResult<>(true, dm23));
+        when(communicationsModule.requestDM28(any(), eq(1))).thenReturn(new BusResult<>(true));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any());
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM28(any(), eq(1));
+        verify(communicationsModule).requestDM28(any());
+        verify(communicationsModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(1));
 
         assertEquals("", listener.getResults());
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -286,11 +286,11 @@ public class Part03Step11ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForNoOBDResponse() {
 
-        when(diagnosticMessageModule.requestDM28(any())).thenReturn(new RequestResult<>(false));
+        when(communicationsModule.requestDM28(any())).thenReturn(new RequestResult<>(false));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any());
+        verify(communicationsModule).requestDM28(any());
 
         assertEquals("", listener.getResults());
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, "6.3.11.2.d - No OBD ECU provided a DM28");

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step12ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step12ControllerTest.java
@@ -27,7 +27,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -49,7 +49,7 @@ public class Part03Step12ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -88,7 +88,7 @@ public class Part03Step12ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -97,7 +97,7 @@ public class Part03Step12ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -109,7 +109,7 @@ public class Part03Step12ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  vehicleInformationModule,
                                  mockListener,
-                                 diagnosticMessageModule);
+                                 communicationsModule);
     }
 
     @Test
@@ -143,15 +143,15 @@ public class Part03Step12ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var dm24 = DM24SPNSupportPacket.create(0, spn);
-        when(diagnosticMessageModule.requestDM24(any(), eq(0))).thenReturn(new BusResult<>(false, dm24));
+        when(communicationsModule.requestDM24(any(), eq(0))).thenReturn(new BusResult<>(false, dm24));
 
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM24(any(), eq(1))).thenReturn(new BusResult<>(false, nack));
+        when(communicationsModule.requestDM24(any(), eq(1))).thenReturn(new BusResult<>(false, nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM24(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM24(any(), eq(1));
+        verify(communicationsModule).requestDM24(any(), eq(0));
+        verify(communicationsModule).requestDM24(any(), eq(1));
 
         assertEquals("", listener.getResults());
 
@@ -167,11 +167,11 @@ public class Part03Step12ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(moduleInfo);
 
         var dm24 = DM24SPNSupportPacket.create(0, spn2);
-        when(diagnosticMessageModule.requestDM24(any(), eq(0))).thenReturn(new BusResult<>(false, dm24));
+        when(communicationsModule.requestDM24(any(), eq(0))).thenReturn(new BusResult<>(false, dm24));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM24(any(), eq(0));
+        verify(communicationsModule).requestDM24(any(), eq(0));
 
         String expected = "";
         expected += "SPs Supported in Expanded Freeze Frame from Engine #1 (0): [" + NL;
@@ -197,11 +197,11 @@ public class Part03Step12ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(moduleInfo);
 
         var dm24 = DM24SPNSupportPacket.create(0, spn2);
-        when(diagnosticMessageModule.requestDM24(any(), eq(0))).thenReturn(new BusResult<>(false, dm24));
+        when(communicationsModule.requestDM24(any(), eq(0))).thenReturn(new BusResult<>(false, dm24));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM24(any(), eq(0));
+        verify(communicationsModule).requestDM24(any(), eq(0));
 
         assertEquals("", listener.getResults());
 
@@ -216,11 +216,11 @@ public class Part03Step12ControllerTest extends AbstractControllerTest {
         OBDModuleInformation moduleInfo = new OBDModuleInformation(0);
         dataRepository.putObdModule(moduleInfo);
 
-        when(diagnosticMessageModule.requestDM24(any(), eq(0))).thenReturn(new BusResult<>(false));
+        when(communicationsModule.requestDM24(any(), eq(0))).thenReturn(new BusResult<>(false));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM24(any(), eq(0));
+        verify(communicationsModule).requestDM24(any(), eq(0));
 
         assertEquals("", listener.getResults());
 

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step13ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step13ControllerTest.java
@@ -36,7 +36,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -58,7 +58,7 @@ public class Part03Step13ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -161,7 +161,7 @@ public class Part03Step13ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               translator,
                                               validator);
 
@@ -172,7 +172,7 @@ public class Part03Step13ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -183,10 +183,10 @@ public class Part03Step13ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener,
                                  validator,
-                                 diagnosticMessageModule);
+                                 communicationsModule);
     }
 
     @Test
@@ -217,11 +217,11 @@ public class Part03Step13ControllerTest extends AbstractControllerTest {
         moduleInfo.set(createDM24(), 1);
         dataRepository.putObdModule(moduleInfo);
 
-        when(diagnosticMessageModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(createDM25()));
+        when(communicationsModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(createDM25()));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(0));
+        verify(communicationsModule).requestDM25(any(), eq(0));
         verify(validator).reportWarnings(any(), any(), eq("6.3.13.2.e"));
 
         String expected = "";
@@ -316,13 +316,13 @@ public class Part03Step13ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(moduleInfo);
 
         DM25ExpandedFreezeFrame dm25 = DM25ExpandedFreezeFrame.create(0, new FreezeFrame(dtc, Spn.create(91, 10)));
-        when(diagnosticMessageModule.requestDM25(any(), eq(0)))
+        when(communicationsModule.requestDM25(any(), eq(0)))
                                                                .thenReturn(new BusResult<>(true))
                                                                .thenReturn(BusResult.of(dm25));
 
         runTest();
 
-        verify(diagnosticMessageModule, times(2)).requestDM25(any(), eq(0));
+        verify(communicationsModule, times(2)).requestDM25(any(), eq(0));
         verify(validator).reportWarnings(any(), any(), eq("6.3.13.2.e"));
 
         String expected = "";
@@ -353,11 +353,11 @@ public class Part03Step13ControllerTest extends AbstractControllerTest {
 
         DiagnosticTroubleCode dtc = DiagnosticTroubleCode.create(102, 4, 0, 1);
         DM25ExpandedFreezeFrame dm25 = DM25ExpandedFreezeFrame.create(0, new FreezeFrame(dtc, Spn.create(91, 10)));
-        when(diagnosticMessageModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
+        when(communicationsModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(0));
+        verify(communicationsModule).requestDM25(any(), eq(0));
         verify(validator).reportWarnings(any(), any(), eq("6.3.13.2.e"));
 
         String expected = "";
@@ -390,11 +390,11 @@ public class Part03Step13ControllerTest extends AbstractControllerTest {
         DM25ExpandedFreezeFrame dm25 = DM25ExpandedFreezeFrame.create(0,
                                                                       new FreezeFrame(dtc1, Spn.create(91, 10)),
                                                                       new FreezeFrame(dtc2, Spn.create(91, 100)));
-        when(diagnosticMessageModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
+        when(communicationsModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(0));
+        verify(communicationsModule).requestDM25(any(), eq(0));
         verify(validator, times(2)).reportWarnings(any(), any(), eq("6.3.13.2.e"));
 
         String expected = "";
@@ -434,11 +434,11 @@ public class Part03Step13ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(moduleInfo);
 
         DM25ExpandedFreezeFrame dm25 = DM25ExpandedFreezeFrame.create(0, new FreezeFrame(dtc, Spn.create(91, 10)));
-        when(diagnosticMessageModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
+        when(communicationsModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(0));
+        verify(communicationsModule).requestDM25(any(), eq(0));
         verify(validator).reportWarnings(any(), any(), eq("6.3.13.2.e"));
 
         String expected = "";
@@ -462,13 +462,13 @@ public class Part03Step13ControllerTest extends AbstractControllerTest {
         OBDModuleInformation moduleInfo = new OBDModuleInformation(0);
         dataRepository.putObdModule(moduleInfo);
 
-        when(diagnosticMessageModule.requestDM25(any(), eq(0)))
+        when(communicationsModule.requestDM25(any(), eq(0)))
                                                                .thenReturn(new BusResult<>(true))
                                                                .thenReturn(new BusResult<>(true));
 
         runTest();
 
-        verify(diagnosticMessageModule, times(2)).requestDM25(any(), eq(0));
+        verify(communicationsModule, times(2)).requestDM25(any(), eq(0));
 
         assertEquals("", listener.getResults());
 

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step14ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step14ControllerTest.java
@@ -26,7 +26,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -48,7 +48,7 @@ public class Part03Step14ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -87,7 +87,7 @@ public class Part03Step14ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -96,7 +96,7 @@ public class Part03Step14ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -108,7 +108,7 @@ public class Part03Step14ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  vehicleInformationModule,
                                  mockListener,
-                                 diagnosticMessageModule);
+                                 communicationsModule);
     }
 
     @Test
@@ -149,7 +149,7 @@ public class Part03Step14ControllerTest extends AbstractControllerTest {
                 0xBB, // Applicable System Monitor Denominator
         };
         var dm20Packet = new DM20MonitorPerformanceRatioPacket(Packet.create(PGN, 0x00, data));
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20Packet));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20Packet));
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
@@ -159,13 +159,13 @@ public class Part03Step14ControllerTest extends AbstractControllerTest {
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(0));
     }
 
     @Test
     public void testEmptyPackets() {
 
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.empty());
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
@@ -176,6 +176,6 @@ public class Part03Step14ControllerTest extends AbstractControllerTest {
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(0));
     }
 }

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step15ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step15ControllerTest.java
@@ -26,7 +26,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -48,7 +48,7 @@ public class Part03Step15ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -87,7 +87,7 @@ public class Part03Step15ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -96,7 +96,7 @@ public class Part03Step15ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -108,7 +108,7 @@ public class Part03Step15ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  vehicleInformationModule,
                                  mockListener,
-                                 diagnosticMessageModule);
+                                 communicationsModule);
     }
 
     @Test
@@ -138,14 +138,14 @@ public class Part03Step15ControllerTest extends AbstractControllerTest {
 
         DM21DiagnosticReadinessPacket dm21 = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 0, 0);
 
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(new BusResult<>(false, dm21));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(new BusResult<>(false, dm21));
 
         runTest();
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(0));
 
     }
 
@@ -164,10 +164,10 @@ public class Part03Step15ControllerTest extends AbstractControllerTest {
         AcknowledgmentPacket ackPacket = AcknowledgmentPacket.create(1, NACK);
         DM21DiagnosticReadinessPacket dm21_2 = DM21DiagnosticReadinessPacket.create(2, 0, 0, 0, 90, 0);
         DM21DiagnosticReadinessPacket dm21_3 = DM21DiagnosticReadinessPacket.create(3, 0, 0, 0, 90, 0);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(new BusResult<>(false, dm21));
-        when(diagnosticMessageModule.requestDM21(any(), eq(1))).thenReturn(new BusResult<>(false, ackPacket));
-        when(diagnosticMessageModule.requestDM21(any(), eq(2))).thenReturn(new BusResult<>(false, dm21_2));
-        when(diagnosticMessageModule.requestDM21(any(), eq(3))).thenReturn(new BusResult<>(false, dm21_3));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(new BusResult<>(false, dm21));
+        when(communicationsModule.requestDM21(any(), eq(1))).thenReturn(new BusResult<>(false, ackPacket));
+        when(communicationsModule.requestDM21(any(), eq(2))).thenReturn(new BusResult<>(false, dm21_2));
+        when(communicationsModule.requestDM21(any(), eq(3))).thenReturn(new BusResult<>(false, dm21_3));
 
         runTest();
 
@@ -175,10 +175,10 @@ public class Part03Step15ControllerTest extends AbstractControllerTest {
         assertEquals("", listener.getMessages());
 
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(1));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(2));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(3));
+        verify(communicationsModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(1));
+        verify(communicationsModule).requestDM21(any(), eq(2));
+        verify(communicationsModule).requestDM21(any(), eq(3));
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -202,10 +202,10 @@ public class Part03Step15ControllerTest extends AbstractControllerTest {
 
         DM21DiagnosticReadinessPacket dm21 = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 0, 0);
 
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(new BusResult<>(false, dm21));
-        when(diagnosticMessageModule.requestDM21(any(), eq(1))).thenReturn(new BusResult<>(true));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(new BusResult<>(false, dm21));
+        when(communicationsModule.requestDM21(any(), eq(1))).thenReturn(new BusResult<>(true));
         var ack = AcknowledgmentPacket.create(2, ACK);
-        when(diagnosticMessageModule.requestDM21(any(), eq(2))).thenReturn(new BusResult<>(false, ack));
+        when(communicationsModule.requestDM21(any(), eq(2))).thenReturn(new BusResult<>(false, ack));
 
         runTest();
 
@@ -213,9 +213,9 @@ public class Part03Step15ControllerTest extends AbstractControllerTest {
         assertEquals("", listener.getMessages());
 
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(1));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(2));
+        verify(communicationsModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(1));
+        verify(communicationsModule).requestDM21(any(), eq(2));
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step16ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step16ControllerTest.java
@@ -25,7 +25,7 @@ import org.etools.j1939_84.controllers.ResultsListener;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.modules.BannerModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -48,7 +48,7 @@ public class Part03Step16ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -81,7 +81,7 @@ public class Part03Step16ControllerTest extends AbstractControllerTest {
                                               DataRepository.newInstance(),
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -90,7 +90,7 @@ public class Part03Step16ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -100,7 +100,7 @@ public class Part03Step16ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  vehicleInformationModule,
                                  mockListener,
-                                 diagnosticMessageModule);
+                                 communicationsModule);
     }
 
     @Test

--- a/src-test/org/etools/j1939_84/controllers/part04/Part04ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part04/Part04ControllerTest.java
@@ -24,7 +24,7 @@ public class Part04ControllerTest extends AbstractPartControllerTest {
                                         DataRepository.newInstance(),
                                         engineSpeedModule,
                                         vehicleInformationModule,
-                                        diagnosticMessageModule,
+                                        communicationsModule,
                                         step01Controller,
                                         step02Controller,
                                         step03Controller,

--- a/src-test/org/etools/j1939_84/controllers/part04/Part04Step01ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part04/Part04Step01ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -50,7 +50,7 @@ public class Part04Step01ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -87,7 +87,7 @@ public class Part04Step01ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -96,7 +96,7 @@ public class Part04Step01ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -106,7 +106,7 @@ public class Part04Step01ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part04/Part04Step02ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part04/Part04Step02ControllerTest.java
@@ -37,7 +37,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -59,7 +59,7 @@ public class Part04Step02ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -99,7 +99,7 @@ public class Part04Step02ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -108,7 +108,7 @@ public class Part04Step02ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -118,7 +118,7 @@ public class Part04Step02ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -148,13 +148,13 @@ public class Part04Step02ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var nack = AcknowledgmentPacket.create(0, AcknowledgmentPacket.Response.NACK);
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, nack));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, nack));
 
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
         var dm12_1 = DM12MILOnEmissionDTCPacket.create(1, ON, OFF, OFF, OFF, dtc1);
-        when(diagnosticMessageModule.requestDM12(any(), eq(1))).thenReturn(new BusResult<>(false, dm12_1));
+        when(communicationsModule.requestDM12(any(), eq(1))).thenReturn(new BusResult<>(false, dm12_1));
 
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12_1));
+        when(communicationsModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12_1));
 
         runTest();
 
@@ -165,9 +165,9 @@ public class Part04Step02ControllerTest extends AbstractControllerTest {
         expectedResults += "Attempt 1" + NL;
         assertEquals(expectedResults, listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM12(any());
-        verify(diagnosticMessageModule).requestDM12(any(), eq(1));
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any(), eq(1));
+        verify(communicationsModule).requestDM12(any(), eq(0));
 
         assertEquals(0, dateTimeModule.getTimeAsLong());
 
@@ -177,7 +177,7 @@ public class Part04Step02ControllerTest extends AbstractControllerTest {
     @Test
     public void testNoResponses() {
 
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(new RequestResult<>(true));
+        when(communicationsModule.requestDM12(any())).thenReturn(new RequestResult<>(true));
 
         String promptMsg = "No ECU has reported a confirmed and active DTC." + NL + "Do you wish to continue?";
         String promptTitle = "No Confirmed and Active DTCs Found";
@@ -206,7 +206,7 @@ public class Part04Step02ControllerTest extends AbstractControllerTest {
         assertEquals(expectedResults.toString(), listener.getResults());
 
         verify(mockListener).onUrgentMessage(eq(promptMsg), eq(promptTitle), eq(QUESTION), any());
-        verify(diagnosticMessageModule, times(300)).requestDM12(any());
+        verify(communicationsModule, times(300)).requestDM12(any());
         verify(mockListener).onUrgentMessage(eq(promptMsg), eq(promptTitle), eq(QUESTION), any());
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -225,7 +225,7 @@ public class Part04Step02ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
         var dm12 = DM12MILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12));
+        when(communicationsModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12));
 
         String promptMsg = "No ECU has reported a confirmed and active DTC." + NL + "Do you wish to continue?";
         String promptTitle = "No Confirmed and Active DTCs Found";
@@ -236,7 +236,7 @@ public class Part04Step02ControllerTest extends AbstractControllerTest {
             return null;
         }).when(mockListener).onUrgentMessage(eq(promptMsg), eq(promptTitle), eq(QUESTION), any());
 
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12));
 
         runTest();
 
@@ -256,8 +256,8 @@ public class Part04Step02ControllerTest extends AbstractControllerTest {
         assertEquals(expectedResults.toString(), listener.getResults());
 
         verify(mockListener).onUrgentMessage(eq(promptMsg), eq(promptTitle), eq(QUESTION), any());
-        verify(diagnosticMessageModule, times(300)).requestDM12(any());
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule, times(300)).requestDM12(any());
+        verify(communicationsModule).requestDM12(any(), eq(0));
         verify(mockListener).onUrgentMessage(eq(promptMsg), eq(promptTitle), eq(QUESTION), any());
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -281,8 +281,8 @@ public class Part04Step02ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm12 = DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc1, dtc2);
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12));
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12));
+        when(communicationsModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12));
 
         runTest();
 
@@ -293,8 +293,8 @@ public class Part04Step02ControllerTest extends AbstractControllerTest {
         expectedResults += "Attempt 1" + NL;
         assertEquals(expectedResults, listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM12(any());
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any(), eq(0));
 
         assertEquals(0, dateTimeModule.getTimeAsLong());
 
@@ -314,8 +314,8 @@ public class Part04Step02ControllerTest extends AbstractControllerTest {
 
         var dm12_0 = DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc1);
         var dm12_1 = DM12MILOnEmissionDTCPacket.create(1, ON, OFF, OFF, OFF, dtc1);
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12_0, dm12_1));
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12_0));
+        when(communicationsModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12_0, dm12_1));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12_0));
 
         runTest();
 
@@ -326,8 +326,8 @@ public class Part04Step02ControllerTest extends AbstractControllerTest {
         expectedResults += "Attempt 1" + NL;
         assertEquals(expectedResults, listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM12(any());
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any(), eq(0));
 
         assertEquals(0, dateTimeModule.getTimeAsLong());
 
@@ -343,13 +343,13 @@ public class Part04Step02ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var dm12_0 = DM12MILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12_0));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12_0));
 
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
         var dm12_1 = DM12MILOnEmissionDTCPacket.create(1, ON, OFF, OFF, OFF, dtc1);
-        when(diagnosticMessageModule.requestDM12(any(), eq(1))).thenReturn(new BusResult<>(false, dm12_1));
+        when(communicationsModule.requestDM12(any(), eq(1))).thenReturn(new BusResult<>(false, dm12_1));
 
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12_0, dm12_1));
+        when(communicationsModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12_0, dm12_1));
 
         runTest();
 
@@ -360,9 +360,9 @@ public class Part04Step02ControllerTest extends AbstractControllerTest {
         expectedResults += "Attempt 1" + NL;
         assertEquals(expectedResults, listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM12(any());
-        verify(diagnosticMessageModule).requestDM12(any(), eq(1));
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any(), eq(1));
+        verify(communicationsModule).requestDM12(any(), eq(0));
 
         assertEquals(0, dateTimeModule.getTimeAsLong());
 
@@ -377,8 +377,8 @@ public class Part04Step02ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(DM6PendingEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc1), 3);
         dataRepository.putObdModule(obdModuleInformation);
         var dm12 = DM12MILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc1);
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12));
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12));
+        when(communicationsModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12));
 
         runTest();
 
@@ -389,8 +389,8 @@ public class Part04Step02ControllerTest extends AbstractControllerTest {
         expectedResults += "Attempt 1" + NL;
         assertEquals(expectedResults, listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM12(any());
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any(), eq(0));
 
         assertEquals(0, dateTimeModule.getTimeAsLong());
 
@@ -410,8 +410,8 @@ public class Part04Step02ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm12 = DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc2);
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12));
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12));
+        when(communicationsModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12));
 
         runTest();
 
@@ -422,8 +422,8 @@ public class Part04Step02ControllerTest extends AbstractControllerTest {
         expectedResults += "Attempt 1" + NL;
         assertEquals(expectedResults, listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM12(any());
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any(), eq(0));
 
         assertEquals(0, dateTimeModule.getTimeAsLong());
 
@@ -442,8 +442,8 @@ public class Part04Step02ControllerTest extends AbstractControllerTest {
 
         var dm12_1 = DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc1);
         var dm12_2 = DM12MILOnEmissionDTCPacket.create(0, ON, ON, OFF, OFF, dtc1);
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12_1));
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12_2));
+        when(communicationsModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12_1));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12_2));
 
         runTest();
 
@@ -454,8 +454,8 @@ public class Part04Step02ControllerTest extends AbstractControllerTest {
         expectedResults += "Attempt 1" + NL;
         assertEquals(expectedResults, listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM12(any());
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any(), eq(0));
 
         assertEquals(0, dateTimeModule.getTimeAsLong());
 
@@ -475,10 +475,10 @@ public class Part04Step02ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var dm12 = DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc1);
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12));
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12));
+        when(communicationsModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12));
 
-        when(diagnosticMessageModule.requestDM12(any(), eq(1))).thenReturn(new BusResult<>(true));
+        when(communicationsModule.requestDM12(any(), eq(1))).thenReturn(new BusResult<>(true));
 
         runTest();
 
@@ -489,9 +489,9 @@ public class Part04Step02ControllerTest extends AbstractControllerTest {
         expectedResults += "Attempt 1" + NL;
         assertEquals(expectedResults, listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM12(any());
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM12(any(), eq(1));
+        verify(communicationsModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any(), eq(1));
 
         assertEquals(0, dateTimeModule.getTimeAsLong());
 

--- a/src-test/org/etools/j1939_84/controllers/part04/Part04Step03ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part04/Part04Step03ControllerTest.java
@@ -27,7 +27,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -49,7 +49,7 @@ public class Part04Step03ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -86,7 +86,7 @@ public class Part04Step03ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -95,7 +95,7 @@ public class Part04Step03ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -105,7 +105,7 @@ public class Part04Step03ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -138,11 +138,11 @@ public class Part04Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(moduleInformation);
 
         var dm1 = DM1ActiveDTCsPacket.create(0, ON, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -152,11 +152,11 @@ public class Part04Step03ControllerTest extends AbstractControllerTest {
     @Test
     public void testNoActiveDTCFailure() {
         var dm1 = DM1ActiveDTCsPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -184,11 +184,11 @@ public class Part04Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(moduleInfo1);
         var dm1_1 = DM1ActiveDTCsPacket.create(1, OFF, OFF, OFF, OFF);
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_1));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -215,11 +215,11 @@ public class Part04Step03ControllerTest extends AbstractControllerTest {
         var dtc = DiagnosticTroubleCode.create(123, 12, 1, 1);
 
         var dm1 = DM1ActiveDTCsPacket.create(0, ON, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -241,11 +241,11 @@ public class Part04Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(moduleInfo0);
 
         var dm1 = DM1ActiveDTCsPacket.create(0, ON, OFF, OFF, OFF, dtc1, dtc2);
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -271,11 +271,11 @@ public class Part04Step03ControllerTest extends AbstractControllerTest {
         moduleInfo1.set(DM12MILOnEmissionDTCPacket.create(1, ON, OFF, OFF, OFF, dtc1), 4);
         dataRepository.putObdModule(moduleInfo1);
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_1));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part04/Part04Step04ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part04/Part04Step04ControllerTest.java
@@ -30,7 +30,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -52,7 +52,7 @@ public class Part04Step04ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -89,7 +89,7 @@ public class Part04Step04ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -98,7 +98,7 @@ public class Part04Step04ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -108,7 +108,7 @@ public class Part04Step04ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -156,18 +156,18 @@ public class Part04Step04ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModule1);
 
         var dm2 = DM2PreviouslyActiveDTC.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(RequestResult.of(dm2));
+        when(communicationsModule.requestDM2(any())).thenReturn(RequestResult.of(dm2));
 
-        when(diagnosticMessageModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dm2));
+        when(communicationsModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dm2));
 
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM2(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM2(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
-        verify(diagnosticMessageModule).requestDM2(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM2(any(), eq(1));
+        verify(communicationsModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any(), eq(0));
+        verify(communicationsModule).requestDM2(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -197,17 +197,17 @@ public class Part04Step04ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModule1);
 
         var dm2 = DM2PreviouslyActiveDTC.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(RequestResult.of(dm2));
+        when(communicationsModule.requestDM2(any())).thenReturn(RequestResult.of(dm2));
 
-        when(diagnosticMessageModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dm2));
+        when(communicationsModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dm2));
 
-        when(diagnosticMessageModule.requestDM2(any(), eq(1))).thenReturn(new BusResult<>(true));
+        when(communicationsModule.requestDM2(any(), eq(1))).thenReturn(new BusResult<>(true));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
-        verify(diagnosticMessageModule).requestDM2(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM2(any(), eq(1));
+        verify(communicationsModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any(), eq(0));
+        verify(communicationsModule).requestDM2(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -227,13 +227,13 @@ public class Part04Step04ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModule0);
 
         var dm2 = DM2PreviouslyActiveDTC.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(RequestResult.of(dm2));
-        when(diagnosticMessageModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dm2));
+        when(communicationsModule.requestDM2(any())).thenReturn(RequestResult.of(dm2));
+        when(communicationsModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dm2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
-        verify(diagnosticMessageModule).requestDM2(any(), eq(0));
+        verify(communicationsModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -257,13 +257,13 @@ public class Part04Step04ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModule0);
 
         var dm2 = DM2PreviouslyActiveDTC.create(0, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(RequestResult.of(dm2));
-        when(diagnosticMessageModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dm2));
+        when(communicationsModule.requestDM2(any())).thenReturn(RequestResult.of(dm2));
+        when(communicationsModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dm2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
-        verify(diagnosticMessageModule).requestDM2(any(), eq(0));
+        verify(communicationsModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -287,15 +287,15 @@ public class Part04Step04ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModule0);
 
         var globalDM2 = DM2PreviouslyActiveDTC.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(RequestResult.of(globalDM2));
+        when(communicationsModule.requestDM2(any())).thenReturn(RequestResult.of(globalDM2));
 
         var dsDM2 = DM2PreviouslyActiveDTC.create(0, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dsDM2));
+        when(communicationsModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dsDM2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
-        verify(diagnosticMessageModule).requestDM2(any(), eq(0));
+        verify(communicationsModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part04/Part04Step05ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part04/Part04Step05ControllerTest.java
@@ -31,7 +31,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -53,7 +53,7 @@ public class Part04Step05ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -90,7 +90,7 @@ public class Part04Step05ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -99,7 +99,7 @@ public class Part04Step05ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -109,7 +109,7 @@ public class Part04Step05ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -157,16 +157,16 @@ public class Part04Step05ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModule1);
 
         var dm23 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm23));
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm23));
 
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM23(any(), eq(1))).thenReturn(new BusResult<>(false, nack));
+        when(communicationsModule.requestDM23(any(), eq(1))).thenReturn(new BusResult<>(false, nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM23(any(), eq(1));
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -197,13 +197,13 @@ public class Part04Step05ControllerTest extends AbstractControllerTest {
 
         var dm2 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
 
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm2));
-        when(diagnosticMessageModule.requestDM23(any(), eq(1))).thenReturn(new BusResult<>(true));
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm2));
+        when(communicationsModule.requestDM23(any(), eq(1))).thenReturn(new BusResult<>(true));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM23(any(), eq(1));
+        verify(communicationsModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -223,11 +223,11 @@ public class Part04Step05ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModule0);
 
         var dm23 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm23));
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm23));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -260,15 +260,15 @@ public class Part04Step05ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModule1);
 
         var dm23 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, FAST_FLASH, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm23));
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm23));
 
         var dm23Ack = AcknowledgmentPacket.create(0, ACK);
-        when(diagnosticMessageModule.requestDM23(any(), eq(1))).thenReturn(new BusResult<>(false, dm23Ack));
+        when(communicationsModule.requestDM23(any(), eq(1))).thenReturn(new BusResult<>(false, dm23Ack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM23(any(), eq(1));
+        verify(communicationsModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -293,11 +293,11 @@ public class Part04Step05ControllerTest extends AbstractControllerTest {
                                                          DiagnosticTroubleCode.create(123, 12, 0, 1)),
                        4);
         dataRepository.putObdModule(obdModule0);
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, Optional.empty()));
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, Optional.empty()));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part04/Part04Step06ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part04/Part04Step06ControllerTest.java
@@ -26,7 +26,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -48,7 +48,7 @@ public class Part04Step06ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -85,7 +85,7 @@ public class Part04Step06ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -94,7 +94,7 @@ public class Part04Step06ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -104,7 +104,7 @@ public class Part04Step06ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -137,11 +137,11 @@ public class Part04Step06ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var dm5_1 = DM5DiagnosticReadinessPacket.create(1, 0xFF, 0xFF, 0x22);
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(RequestResult.of(dm5_0, dm5_1));
+        when(communicationsModule.requestDM5(any())).thenReturn(RequestResult.of(dm5_0, dm5_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -154,11 +154,11 @@ public class Part04Step06ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(module0);
 
         var dm5 = DM5DiagnosticReadinessPacket.create(0, 0, 0, 0x22);
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(RequestResult.of(dm5));
+        when(communicationsModule.requestDM5(any())).thenReturn(RequestResult.of(dm5));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -176,11 +176,11 @@ public class Part04Step06ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(module0);
 
         var dm5 = DM5DiagnosticReadinessPacket.create(0, 2, 0, 0x22);
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(RequestResult.of(dm5));
+        when(communicationsModule.requestDM5(any())).thenReturn(RequestResult.of(dm5));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -198,11 +198,11 @@ public class Part04Step06ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(module0);
 
         var dm5 = DM5DiagnosticReadinessPacket.create(0, 1, 1, 0x22);
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(RequestResult.of(dm5));
+        when(communicationsModule.requestDM5(any())).thenReturn(RequestResult.of(dm5));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part04/Part04Step07ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part04/Part04Step07ControllerTest.java
@@ -31,7 +31,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -53,7 +53,7 @@ public class Part04Step07ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -101,7 +101,7 @@ public class Part04Step07ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -110,7 +110,7 @@ public class Part04Step07ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -120,7 +120,7 @@ public class Part04Step07ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -161,15 +161,15 @@ public class Part04Step07ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm31 = createDM31(123, ON);
-        when(diagnosticMessageModule.requestDM31(any(), eq(0))).thenReturn(new RequestResult<>(false, dm31));
+        when(communicationsModule.requestDM31(any(), eq(0))).thenReturn(new RequestResult<>(false, dm31));
 
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM31(any(), eq(1))).thenReturn(new RequestResult<>(false, nack));
+        when(communicationsModule.requestDM31(any(), eq(1))).thenReturn(new RequestResult<>(false, nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM31(any(), eq(1));
+        verify(communicationsModule).requestDM31(any(), eq(0));
+        verify(communicationsModule).requestDM31(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -182,11 +182,11 @@ public class Part04Step07ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm31 = createDM31(456, ON);
-        when(diagnosticMessageModule.requestDM31(any(), eq(0))).thenReturn(new RequestResult<>(false, dm31));
+        when(communicationsModule.requestDM31(any(), eq(0))).thenReturn(new RequestResult<>(false, dm31));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any(), eq(0));
+        verify(communicationsModule).requestDM31(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -204,11 +204,11 @@ public class Part04Step07ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm31 = createDM31(123, OFF);
-        when(diagnosticMessageModule.requestDM31(any(), eq(0))).thenReturn(new RequestResult<>(false, dm31));
+        when(communicationsModule.requestDM31(any(), eq(0))).thenReturn(new RequestResult<>(false, dm31));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any(), eq(0));
+        verify(communicationsModule).requestDM31(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -225,11 +225,11 @@ public class Part04Step07ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(createDM12(0, 123, 12), 4);
         dataRepository.putObdModule(obdModuleInformation);
 
-        when(diagnosticMessageModule.requestDM31(any(), eq(0))).thenReturn(new RequestResult<>(true));
+        when(communicationsModule.requestDM31(any(), eq(0))).thenReturn(new RequestResult<>(true));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any(), eq(0));
+        verify(communicationsModule).requestDM31(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part04/Part04Step08ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part04/Part04Step08ControllerTest.java
@@ -31,7 +31,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -53,7 +53,7 @@ public class Part04Step08ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -100,7 +100,7 @@ public class Part04Step08ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -109,7 +109,7 @@ public class Part04Step08ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -119,7 +119,7 @@ public class Part04Step08ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -151,24 +151,24 @@ public class Part04Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm6_0 = createDM6(0, 0, 0, ON);
-        when(diagnosticMessageModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.of(dm6_0));
+        when(communicationsModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.of(dm6_0));
 
         // Module 1 provides a NACK
         OBDModuleInformation obdModuleInformation1 = new OBDModuleInformation(1);
         dataRepository.putObdModule(obdModuleInformation1);
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM6(any(), eq(1))).thenReturn(new RequestResult<>(false, nack));
+        when(communicationsModule.requestDM6(any(), eq(1))).thenReturn(new RequestResult<>(false, nack));
 
         // Module 2 is not an OBD Module
         var dm6_2 = createDM6(2, 0, 0, ON);
 
-        when(diagnosticMessageModule.requestDM6(any())).thenReturn(RequestResult.of(dm6_0, dm6_2));
+        when(communicationsModule.requestDM6(any())).thenReturn(RequestResult.of(dm6_0, dm6_2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM6(any());
-        verify(diagnosticMessageModule).requestDM6(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM6(any(), eq(1));
+        verify(communicationsModule).requestDM6(any());
+        verify(communicationsModule).requestDM6(any(), eq(0));
+        verify(communicationsModule).requestDM6(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -183,14 +183,14 @@ public class Part04Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm6 = createDM6(0, 231, 12, ON);
-        when(diagnosticMessageModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.of(dm6));
+        when(communicationsModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.of(dm6));
 
-        when(diagnosticMessageModule.requestDM6(any())).thenReturn(RequestResult.of(dm6));
+        when(communicationsModule.requestDM6(any())).thenReturn(RequestResult.of(dm6));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM6(any());
-        verify(diagnosticMessageModule).requestDM6(any(), eq(0));
+        verify(communicationsModule).requestDM6(any());
+        verify(communicationsModule).requestDM6(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -208,14 +208,14 @@ public class Part04Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm6 = createDM6(0, 0, 0, ON);
-        when(diagnosticMessageModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.of(dm6));
+        when(communicationsModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.of(dm6));
 
-        when(diagnosticMessageModule.requestDM6(any())).thenReturn(RequestResult.of(dm6));
+        when(communicationsModule.requestDM6(any())).thenReturn(RequestResult.of(dm6));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM6(any());
-        verify(diagnosticMessageModule).requestDM6(any(), eq(0));
+        verify(communicationsModule).requestDM6(any());
+        verify(communicationsModule).requestDM6(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -230,11 +230,11 @@ public class Part04Step08ControllerTest extends AbstractControllerTest {
     public void testFailureForNoOBDResponse() {
         var dm6 = createDM6(2, 0, 0, ON);
 
-        when(diagnosticMessageModule.requestDM6(any())).thenReturn(RequestResult.of(dm6));
+        when(communicationsModule.requestDM6(any())).thenReturn(RequestResult.of(dm6));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM6(any());
+        verify(communicationsModule).requestDM6(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -252,15 +252,15 @@ public class Part04Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm6_0 = createDM6(0, 0, 0, ON);
-        when(diagnosticMessageModule.requestDM6(any())).thenReturn(RequestResult.of(dm6_0));
+        when(communicationsModule.requestDM6(any())).thenReturn(RequestResult.of(dm6_0));
 
         var dm6_1 = createDM6(0, 0, 0, OFF);
-        when(diagnosticMessageModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.of(dm6_1));
+        when(communicationsModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.of(dm6_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM6(any());
-        verify(diagnosticMessageModule).requestDM6(any(), eq(0));
+        verify(communicationsModule).requestDM6(any());
+        verify(communicationsModule).requestDM6(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -279,20 +279,20 @@ public class Part04Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm6_0 = createDM6(0, 0, 0, ON);
-        when(diagnosticMessageModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.of(dm6_0));
+        when(communicationsModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.of(dm6_0));
 
         // Module 1 doesn't provide a NACK
         OBDModuleInformation obdModuleInformation1 = new OBDModuleInformation(1);
         dataRepository.putObdModule(obdModuleInformation1);
-        when(diagnosticMessageModule.requestDM6(any(), eq(1))).thenReturn(new RequestResult<>(true));
+        when(communicationsModule.requestDM6(any(), eq(1))).thenReturn(new RequestResult<>(true));
 
-        when(diagnosticMessageModule.requestDM6(any())).thenReturn(RequestResult.of(dm6_0));
+        when(communicationsModule.requestDM6(any())).thenReturn(RequestResult.of(dm6_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM6(any());
-        verify(diagnosticMessageModule).requestDM6(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM6(any(), eq(1));
+        verify(communicationsModule).requestDM6(any());
+        verify(communicationsModule).requestDM6(any(), eq(0));
+        verify(communicationsModule).requestDM6(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part04/Part04Step09ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part04/Part04Step09ControllerTest.java
@@ -32,7 +32,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -54,7 +54,7 @@ public class Part04Step09ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -101,7 +101,7 @@ public class Part04Step09ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -110,7 +110,7 @@ public class Part04Step09ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -120,7 +120,7 @@ public class Part04Step09ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -152,24 +152,24 @@ public class Part04Step09ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm27_0 = createDM27(0, 0, 0, ON);
-        when(diagnosticMessageModule.requestDM27(any(), eq(0))).thenReturn(new BusResult<>(false, dm27_0));
+        when(communicationsModule.requestDM27(any(), eq(0))).thenReturn(new BusResult<>(false, dm27_0));
 
         // Module 1 provides a NACK
         OBDModuleInformation obdModuleInformation1 = new OBDModuleInformation(1);
         dataRepository.putObdModule(obdModuleInformation1);
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM27(any(), eq(1))).thenReturn(new BusResult<>(false, nack));
+        when(communicationsModule.requestDM27(any(), eq(1))).thenReturn(new BusResult<>(false, nack));
 
         // Module 2 is not an OBD Module
         var dm27_2 = createDM27(2, 0, 0, ON);
 
-        when(diagnosticMessageModule.requestDM27(any())).thenReturn(new RequestResult<>(false, dm27_0, dm27_2));
+        when(communicationsModule.requestDM27(any())).thenReturn(new RequestResult<>(false, dm27_0, dm27_2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM27(any(), eq(1));
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0));
+        verify(communicationsModule).requestDM27(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -184,14 +184,14 @@ public class Part04Step09ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm27 = createDM27(0, 231, 12, ON);
-        when(diagnosticMessageModule.requestDM27(any(), eq(0))).thenReturn(new BusResult<>(false, dm27));
+        when(communicationsModule.requestDM27(any(), eq(0))).thenReturn(new BusResult<>(false, dm27));
 
-        when(diagnosticMessageModule.requestDM27(any())).thenReturn(new RequestResult<>(false, dm27));
+        when(communicationsModule.requestDM27(any())).thenReturn(new RequestResult<>(false, dm27));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0));
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -209,14 +209,14 @@ public class Part04Step09ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm27 = createDM27(0, 0, 0, ON);
-        when(diagnosticMessageModule.requestDM27(any(), eq(0))).thenReturn(new BusResult<>(false, dm27));
+        when(communicationsModule.requestDM27(any(), eq(0))).thenReturn(new BusResult<>(false, dm27));
 
-        when(diagnosticMessageModule.requestDM27(any())).thenReturn(new RequestResult<>(false, dm27));
+        when(communicationsModule.requestDM27(any())).thenReturn(new RequestResult<>(false, dm27));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0));
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -234,15 +234,15 @@ public class Part04Step09ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm27_0 = createDM27(0, 0, 0, ON);
-        when(diagnosticMessageModule.requestDM27(any())).thenReturn(new RequestResult<>(false, dm27_0));
+        when(communicationsModule.requestDM27(any())).thenReturn(new RequestResult<>(false, dm27_0));
 
         var dm27_1 = createDM27(0, 0, 0, OFF);
-        when(diagnosticMessageModule.requestDM27(any(), eq(0))).thenReturn(new BusResult<>(false, dm27_1));
+        when(communicationsModule.requestDM27(any(), eq(0))).thenReturn(new BusResult<>(false, dm27_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0));
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -261,20 +261,20 @@ public class Part04Step09ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm27_0 = createDM27(0, 0, 0, ON);
-        when(diagnosticMessageModule.requestDM27(any(), eq(0))).thenReturn(new BusResult<>(false, dm27_0));
+        when(communicationsModule.requestDM27(any(), eq(0))).thenReturn(new BusResult<>(false, dm27_0));
 
         // Module 1 doesn't provide a NACK
         OBDModuleInformation obdModuleInformation1 = new OBDModuleInformation(1);
         dataRepository.putObdModule(obdModuleInformation1);
-        when(diagnosticMessageModule.requestDM27(any(), eq(1))).thenReturn(new BusResult<>(true));
+        when(communicationsModule.requestDM27(any(), eq(1))).thenReturn(new BusResult<>(true));
 
-        when(diagnosticMessageModule.requestDM27(any())).thenReturn(new RequestResult<>(false, dm27_0));
+        when(communicationsModule.requestDM27(any())).thenReturn(new RequestResult<>(false, dm27_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM27(any(), eq(1));
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0));
+        verify(communicationsModule).requestDM27(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part04/Part04Step10ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part04/Part04Step10ControllerTest.java
@@ -31,7 +31,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -53,7 +53,7 @@ public class Part04Step10ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -90,7 +90,7 @@ public class Part04Step10ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -99,7 +99,7 @@ public class Part04Step10ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -109,7 +109,7 @@ public class Part04Step10ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -143,16 +143,16 @@ public class Part04Step10ControllerTest extends AbstractControllerTest {
 
         var spn = Spn.create(102, 900);
         var dm25 = DM25ExpandedFreezeFrame.create(0, new FreezeFrame(dtc, spn));
-        when(diagnosticMessageModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
+        when(communicationsModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM25(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM25(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM25(any(), eq(1));
+        verify(communicationsModule).requestDM25(any(), eq(0));
+        verify(communicationsModule).requestDM25(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -178,11 +178,11 @@ public class Part04Step10ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM25(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM25(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(1));
+        verify(communicationsModule).requestDM25(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -203,15 +203,15 @@ public class Part04Step10ControllerTest extends AbstractControllerTest {
 
         var spn = Spn.create(102, 900);
         var dm25 = DM25ExpandedFreezeFrame.create(0, new FreezeFrame(dtc, spn));
-        when(diagnosticMessageModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
+        when(communicationsModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
-        when(diagnosticMessageModule.requestDM25(any(), eq(1))).thenReturn(new BusResult<>(true));
+        when(communicationsModule.requestDM25(any(), eq(1))).thenReturn(new BusResult<>(true));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM25(any(), eq(1));
+        verify(communicationsModule).requestDM25(any(), eq(0));
+        verify(communicationsModule).requestDM25(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -234,11 +234,11 @@ public class Part04Step10ControllerTest extends AbstractControllerTest {
         var dtc2 = DiagnosticTroubleCode.create(456, 12, 0, 1);
 
         var dm25 = DM25ExpandedFreezeFrame.create(0, new FreezeFrame(dtc2, spn));
-        when(diagnosticMessageModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
+        when(communicationsModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(0));
+        verify(communicationsModule).requestDM25(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part04/Part04Step11ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part04/Part04Step11ControllerTest.java
@@ -25,7 +25,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -47,7 +47,7 @@ public class Part04Step11ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -84,7 +84,7 @@ public class Part04Step11ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -93,7 +93,7 @@ public class Part04Step11ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -103,7 +103,7 @@ public class Part04Step11ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -138,11 +138,11 @@ public class Part04Step11ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1)); // no query expected
 
         var dm20 = DM20MonitorPerformanceRatioPacket.create(0, 101, 10, ratio);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(new BusResult<>(false, dm20));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(new BusResult<>(false, dm20));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -158,11 +158,11 @@ public class Part04Step11ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm20 = DM20MonitorPerformanceRatioPacket.create(0, 100, 10, ratio);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(new BusResult<>(false, dm20));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(new BusResult<>(false, dm20));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -183,11 +183,11 @@ public class Part04Step11ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm20 = DM20MonitorPerformanceRatioPacket.create(0, 103, 10, ratio);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(new BusResult<>(false, dm20));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(new BusResult<>(false, dm20));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part04/Part04Step12ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part04/Part04Step12ControllerTest.java
@@ -25,7 +25,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -47,7 +47,7 @@ public class Part04Step12ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -84,7 +84,7 @@ public class Part04Step12ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -93,7 +93,7 @@ public class Part04Step12ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -103,7 +103,7 @@ public class Part04Step12ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -137,7 +137,7 @@ public class Part04Step12ControllerTest extends AbstractControllerTest {
         obdModuleInformation0.setSupportedSPNs(List.of(supportedSPN0));
         dataRepository.putObdModule(obdModuleInformation0);
         var dm30_0 = DM30ScaledTestResultsPacket.create(0, 0, str0);
-        when(diagnosticMessageModule.requestTestResults(any(), eq(0), eq(246), eq(5846), eq(31))).thenReturn(List.of(
+        when(communicationsModule.requestTestResults(any(), eq(0), eq(246), eq(5846), eq(31))).thenReturn(List.of(
                                                                                                                      dm30_0));
 
         // Module 1 doesn't support TID 246 - requires another request
@@ -148,22 +148,22 @@ public class Part04Step12ControllerTest extends AbstractControllerTest {
         obdModuleInformation1.setSupportedSPNs(List.of(supportedSPN1));
         dataRepository.putObdModule(obdModuleInformation1);
 
-        when(diagnosticMessageModule.requestTestResults(any(), eq(1), eq(246), eq(5846), eq(31))).thenReturn(List.of());
+        when(communicationsModule.requestTestResults(any(), eq(1), eq(246), eq(5846), eq(31))).thenReturn(List.of());
         var dm30_1 = DM30ScaledTestResultsPacket.create(1, 0, str1);
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(1),
-                                                        eq(247),
-                                                        eq(supportedSPN1.getSpn()),
-                                                        eq(31))).thenReturn(List.of(dm30_1));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(1),
+                                                     eq(247),
+                                                     eq(supportedSPN1.getSpn()),
+                                                     eq(31))).thenReturn(List.of(dm30_1));
 
         // Module 2 doesn't have Scaled Test Results
         dataRepository.putObdModule(new OBDModuleInformation(2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(246), eq(5846), eq(31));
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(1), eq(246), eq(5846), eq(31));
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(1), eq(247), eq(supportedSPN1.getSpn()), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(246), eq(5846), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(1), eq(246), eq(5846), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(1), eq(247), eq(supportedSPN1.getSpn()), eq(31));
 
         // Verify non-initialized tests are stored
         List<ScaledTestResult> nonInitializedTests = dataRepository.getObdModule(0).getNonInitializedTests();
@@ -189,7 +189,7 @@ public class Part04Step12ControllerTest extends AbstractControllerTest {
 
         ScaledTestResult str1 = ScaledTestResult.create(247, 159, 8, 129, 0, 0, 0);
         var dm30_0 = DM30ScaledTestResultsPacket.create(0, 0, str0, str1);
-        when(diagnosticMessageModule.requestTestResults(any(), eq(0), eq(246), eq(5846), eq(31))).thenReturn(List.of(
+        when(communicationsModule.requestTestResults(any(), eq(0), eq(246), eq(5846), eq(31))).thenReturn(List.of(
                                                                                                                      dm30_0));
 
         // Module 1 doesn't support TID 246 - requires another request
@@ -200,21 +200,21 @@ public class Part04Step12ControllerTest extends AbstractControllerTest {
         obdModuleInformation1.setSupportedSPNs(List.of(supportedSPN1));
         dataRepository.putObdModule(obdModuleInformation1);
 
-        when(diagnosticMessageModule.requestTestResults(any(), eq(1), eq(246), eq(5846), eq(31))).thenReturn(List.of());
+        when(communicationsModule.requestTestResults(any(), eq(1), eq(246), eq(5846), eq(31))).thenReturn(List.of());
         ScaledTestResult str12 = ScaledTestResult.create(247, 200, 8, 129, 0, 0, 0);
         var dm30_1 = DM30ScaledTestResultsPacket.create(1, 0, str11, str12);
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(1),
-                                                        eq(247),
-                                                        eq(supportedSPN1.getSpn()),
-                                                        eq(31)))
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(1),
+                                                     eq(247),
+                                                     eq(supportedSPN1.getSpn()),
+                                                     eq(31)))
                                                                 .thenReturn(List.of(dm30_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(246), eq(5846), eq(31));
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(1), eq(246), eq(5846), eq(31));
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(1), eq(247), eq(supportedSPN1.getSpn()), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(246), eq(5846), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(1), eq(246), eq(5846), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(1), eq(247), eq(supportedSPN1.getSpn()), eq(31));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part04/Part04Step13ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part04/Part04Step13ControllerTest.java
@@ -30,7 +30,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -52,7 +52,7 @@ public class Part04Step13ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -92,7 +92,7 @@ public class Part04Step13ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               verifier);
 
         setup(instance,
@@ -102,7 +102,7 @@ public class Part04Step13ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -112,7 +112,7 @@ public class Part04Step13ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener,
                                  verifier);
     }
@@ -144,21 +144,21 @@ public class Part04Step13ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
         dataRepository.putObdModule(new OBDModuleInformation(2));
 
-        when(diagnosticMessageModule.requestDM3(any(), eq(0)))
+        when(communicationsModule.requestDM3(any(), eq(0)))
                                                               .thenReturn(List.of(AcknowledgmentPacket.create(0,
                                                                                                               NACK)));
-        when(diagnosticMessageModule.requestDM3(any(), eq(1)))
+        when(communicationsModule.requestDM3(any(), eq(1)))
                                                               .thenReturn(List.of(AcknowledgmentPacket.create(1,
                                                                                                               DENIED)));
-        when(diagnosticMessageModule.requestDM3(any(), eq(2)))
+        when(communicationsModule.requestDM3(any(), eq(2)))
                                                               .thenReturn(List.of());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM3(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM3(any(), eq(1));
-        verify(diagnosticMessageModule).requestDM3(any(), eq(2));
-        verify(diagnosticMessageModule).requestDM3(any());
+        verify(communicationsModule).requestDM3(any(), eq(0));
+        verify(communicationsModule).requestDM3(any(), eq(1));
+        verify(communicationsModule).requestDM3(any(), eq(2));
+        verify(communicationsModule).requestDM3(any());
 
         verify(verifier).setJ1939(any());
         verify(verifier).verifyDataNotErased(any(), eq("6.4.13.2.a"));
@@ -184,14 +184,14 @@ public class Part04Step13ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
-        when(diagnosticMessageModule.requestDM3(any(), eq(0)))
+        when(communicationsModule.requestDM3(any(), eq(0)))
                                                               .thenReturn(List.of(AcknowledgmentPacket.create(0,
                                                                                                               ACK)));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM3(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM3(any());
+        verify(communicationsModule).requestDM3(any(), eq(0));
+        verify(communicationsModule).requestDM3(any());
 
         verify(verifier).setJ1939(any());
         verify(verifier).verifyDataNotErased(any(), eq("6.4.13.2.a"));
@@ -222,14 +222,14 @@ public class Part04Step13ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
-        when(diagnosticMessageModule.requestDM3(any(), eq(0)))
+        when(communicationsModule.requestDM3(any(), eq(0)))
                                                               .thenReturn(List.of(AcknowledgmentPacket.create(0,
                                                                                                               BUSY)));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM3(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM3(any());
+        verify(communicationsModule).requestDM3(any(), eq(0));
+        verify(communicationsModule).requestDM3(any());
 
         verify(verifier).setJ1939(any());
         verify(verifier).verifyDataNotErased(any(), eq("6.4.13.2.a"));

--- a/src-test/org/etools/j1939_84/controllers/part04/Part04Step14ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part04/Part04Step14ControllerTest.java
@@ -24,7 +24,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.Outcome;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -46,7 +46,7 @@ public class Part04Step14ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -83,7 +83,7 @@ public class Part04Step14ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -92,7 +92,7 @@ public class Part04Step14ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -102,7 +102,7 @@ public class Part04Step14ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -136,17 +136,17 @@ public class Part04Step14ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm30_123_12 = DM30ScaledTestResultsPacket.create(0, 0, str1);
-        when(diagnosticMessageModule.requestTestResults(any(), eq(0), eq(250), eq(123), eq(12)))
+        when(communicationsModule.requestTestResults(any(), eq(0), eq(250), eq(123), eq(12)))
                                                                                                 .thenReturn(List.of(dm30_123_12));
 
         var dm30_456_9 = DM30ScaledTestResultsPacket.create(0, 0, str2);
-        when(diagnosticMessageModule.requestTestResults(any(), eq(0), eq(250), eq(456), eq(9)))
+        when(communicationsModule.requestTestResults(any(), eq(0), eq(250), eq(456), eq(9)))
                                                                                                .thenReturn(List.of(dm30_456_9));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(250), eq(123), eq(12));
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(250), eq(456), eq(9));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(250), eq(123), eq(12));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(250), eq(456), eq(9));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -163,18 +163,18 @@ public class Part04Step14ControllerTest extends AbstractControllerTest {
 
         var str_123_12 = ScaledTestResult.create(247, 123, 12, 6, 0, 0, 0);
         var dm30_123_12 = DM30ScaledTestResultsPacket.create(0, 0, str_123_12);
-        when(diagnosticMessageModule.requestTestResults(any(), eq(0), eq(250), eq(123), eq(12)))
+        when(communicationsModule.requestTestResults(any(), eq(0), eq(250), eq(123), eq(12)))
                                                                                                 .thenReturn(List.of(dm30_123_12));
 
         var str_456_9 = ScaledTestResult.create(247, 456, 9, 4, 0xFB00, 0xFFFF, 0xFFFF);
         var dm30_456_9 = DM30ScaledTestResultsPacket.create(0, 0, str_456_9);
-        when(diagnosticMessageModule.requestTestResults(any(), eq(0), eq(250), eq(456), eq(9)))
+        when(communicationsModule.requestTestResults(any(), eq(0), eq(250), eq(456), eq(9)))
                                                                                                .thenReturn(List.of(dm30_456_9));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(250), eq(123), eq(12));
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(250), eq(456), eq(9));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(250), eq(123), eq(12));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(250), eq(456), eq(9));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part04/Part04Step15ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part04/Part04Step15ControllerTest.java
@@ -26,7 +26,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -49,7 +49,7 @@ public class Part04Step15ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -83,7 +83,7 @@ public class Part04Step15ControllerTest extends AbstractControllerTest {
                                               DataRepository.newInstance(),
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -92,7 +92,7 @@ public class Part04Step15ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -102,7 +102,7 @@ public class Part04Step15ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part05/Part05ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part05/Part05ControllerTest.java
@@ -24,7 +24,7 @@ public class Part05ControllerTest extends AbstractPartControllerTest {
                                         DataRepository.newInstance(),
                                         engineSpeedModule,
                                         vehicleInformationModule,
-                                        diagnosticMessageModule,
+                                        communicationsModule,
                                         step01Controller,
                                         step02Controller,
                                         step03Controller,

--- a/src-test/org/etools/j1939_84/controllers/part05/Part05Step01ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part05/Part05Step01ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -50,7 +50,7 @@ public class Part05Step01ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -87,7 +87,7 @@ public class Part05Step01ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -96,7 +96,7 @@ public class Part05Step01ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -106,7 +106,7 @@ public class Part05Step01ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part05/Part05Step02ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part05/Part05Step02ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -50,7 +50,7 @@ public class Part05Step02ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -87,7 +87,7 @@ public class Part05Step02ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -96,7 +96,7 @@ public class Part05Step02ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -106,7 +106,7 @@ public class Part05Step02ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -144,11 +144,11 @@ public class Part05Step02ControllerTest extends AbstractControllerTest {
         obdModule1.set(DM6PendingEmissionDTCPacket.create(1, ON, OFF, OFF, OFF, dtc_1), 3);
         dataRepository.putObdModule(obdModule1);
 
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(RequestResult.of(dm12, dm12_1));
+        when(communicationsModule.requestDM12(any())).thenReturn(RequestResult.of(dm12, dm12_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -160,7 +160,7 @@ public class Part05Step02ControllerTest extends AbstractControllerTest {
         var dtc_1 = DiagnosticTroubleCode.create(609, 19, 1, 1);
         var dtc_2 = DiagnosticTroubleCode.create(4334, 4, 0, 0);
         var dm12_1 = DM12MILOnEmissionDTCPacket.create(1, SLOW_FLASH, OFF, OFF, OFF, dtc_1, dtc_2);
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(RequestResult.of(dm12, dm12_1));
+        when(communicationsModule.requestDM12(any())).thenReturn(RequestResult.of(dm12, dm12_1));
 
         var obdModule0 = new OBDModuleInformation(0);
         obdModule0.set(DM6PendingEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF), 3);
@@ -172,7 +172,7 @@ public class Part05Step02ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any());
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -204,11 +204,11 @@ public class Part05Step02ControllerTest extends AbstractControllerTest {
         obdModule1.set(DM6PendingEmissionDTCPacket.create(1, SLOW_FLASH, OFF, OFF, OFF), 4);
         dataRepository.putObdModule(obdModule1);
 
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(RequestResult.of(dm12, dm12_1));
+        when(communicationsModule.requestDM12(any())).thenReturn(RequestResult.of(dm12, dm12_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any());
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -238,11 +238,11 @@ public class Part05Step02ControllerTest extends AbstractControllerTest {
         obdModule1.set(DM6PendingEmissionDTCPacket.create(1, OFF, OFF, OFF, OFF, dtc_1, dtc_2), 3);
         dataRepository.putObdModule(obdModule1);
 
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(RequestResult.of(dm12, dm12_1));
+        when(communicationsModule.requestDM12(any())).thenReturn(RequestResult.of(dm12, dm12_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any());
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,

--- a/src-test/org/etools/j1939_84/controllers/part05/Part05Step03ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part05/Part05Step03ControllerTest.java
@@ -27,7 +27,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -49,7 +49,7 @@ public class Part05Step03ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -86,7 +86,7 @@ public class Part05Step03ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -95,7 +95,7 @@ public class Part05Step03ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -105,7 +105,7 @@ public class Part05Step03ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -146,11 +146,11 @@ public class Part05Step03ControllerTest extends AbstractControllerTest {
         // Module 2 is a non-OBD Module
         var dm1_2 = DM1ActiveDTCsPacket.create(2, OFF, OFF, OFF, OFF);
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_1, dm1_2));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_1, dm1_2));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -166,11 +166,11 @@ public class Part05Step03ControllerTest extends AbstractControllerTest {
         var dtc1 = DiagnosticTroubleCode.create(456, 14, 1, 1);
         var dm1_0 = DM1ActiveDTCsPacket.create(0, ON, OFF, OFF, OFF, dtc1);
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -189,11 +189,11 @@ public class Part05Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
         var dm1_0 = DM1ActiveDTCsPacket.create(0, FAST_FLASH, OFF, OFF, OFF, dtc0);
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part05/Part05Step04ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part05/Part05Step04ControllerTest.java
@@ -30,7 +30,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -52,7 +52,7 @@ public class Part05Step04ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -89,7 +89,7 @@ public class Part05Step04ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -98,7 +98,7 @@ public class Part05Step04ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -108,7 +108,7 @@ public class Part05Step04ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -141,17 +141,17 @@ public class Part05Step04ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc), 5);
         dataRepository.putObdModule(obdModuleInformation);
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         // Module 1 will NACK
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM28(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM28(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM28(any(), eq(1));
+        verify(communicationsModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -165,11 +165,11 @@ public class Part05Step04ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc), 5);
         dataRepository.putObdModule(obdModuleInformation);
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, FAST_FLASH, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -190,11 +190,11 @@ public class Part05Step04ControllerTest extends AbstractControllerTest {
 
         var dtc2 = DiagnosticTroubleCode.create(456, 9, 0, 14);
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc2);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -210,11 +210,11 @@ public class Part05Step04ControllerTest extends AbstractControllerTest {
         OBDModuleInformation obdModuleInformation = new OBDModuleInformation(0);
         dataRepository.putObdModule(obdModuleInformation);
 
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(new BusResult<>(true));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(new BusResult<>(true));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part05/Part05Step05ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part05/Part05Step05ControllerTest.java
@@ -30,7 +30,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -52,7 +52,7 @@ public class Part05Step05ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -89,7 +89,7 @@ public class Part05Step05ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -98,7 +98,7 @@ public class Part05Step05ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -108,7 +108,7 @@ public class Part05Step05ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -143,11 +143,11 @@ public class Part05Step05ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 0, 1, 0, 1);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(new RequestResult<>(false, dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(new RequestResult<>(false, dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -165,11 +165,11 @@ public class Part05Step05ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm29 = DM29DtcCounts.create(0, 0, 1, 0, 1, 0, 1);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(new RequestResult<>(false, dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(new RequestResult<>(false, dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -191,11 +191,11 @@ public class Part05Step05ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 0, 1, 1, 1);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(new RequestResult<>(false, dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(new RequestResult<>(false, dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -215,11 +215,11 @@ public class Part05Step05ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(new RequestResult<>(false, dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(new RequestResult<>(false, dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -242,11 +242,11 @@ public class Part05Step05ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 0, 1, 0, 1);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(new RequestResult<>(false, dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(new RequestResult<>(false, dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -269,11 +269,11 @@ public class Part05Step05ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 0, 1, 0, 1);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(new RequestResult<>(false, dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(new RequestResult<>(false, dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -295,11 +295,11 @@ public class Part05Step05ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 1, 1, 0, 1);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(new RequestResult<>(false, dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(new RequestResult<>(false, dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -321,11 +321,11 @@ public class Part05Step05ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 0xFF, 1, 0, 1);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(new RequestResult<>(false, dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(new RequestResult<>(false, dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -346,11 +346,11 @@ public class Part05Step05ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 0, 1, 0, 1);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(new RequestResult<>(false, dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(new RequestResult<>(false, dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -373,11 +373,11 @@ public class Part05Step05ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 0, 2, 0, 1);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(new RequestResult<>(false, dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(new RequestResult<>(false, dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -400,11 +400,11 @@ public class Part05Step05ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 0, 1, 0, 2);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(new RequestResult<>(false, dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(new RequestResult<>(false, dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -434,11 +434,11 @@ public class Part05Step05ControllerTest extends AbstractControllerTest {
 
         var dm29_1 = DM29DtcCounts.create(1, 0, 0, 0, 1, 0, 0);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(new RequestResult<>(false, dm29_0, dm29_1));
+        when(communicationsModule.requestDM29(any())).thenReturn(new RequestResult<>(false, dm29_0, dm29_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -466,11 +466,11 @@ public class Part05Step05ControllerTest extends AbstractControllerTest {
 
         var dm29_1 = DM29DtcCounts.create(1, 0, 0, 0, 0, 0, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(new RequestResult<>(false, dm29_0, dm29_1));
+        when(communicationsModule.requestDM29(any())).thenReturn(new RequestResult<>(false, dm29_0, dm29_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part05/Part05Step06ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part05/Part05Step06ControllerTest.java
@@ -26,7 +26,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -48,7 +48,7 @@ public class Part05Step06ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -85,7 +85,7 @@ public class Part05Step06ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -94,7 +94,7 @@ public class Part05Step06ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -104,7 +104,7 @@ public class Part05Step06ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -146,7 +146,7 @@ public class Part05Step06ControllerTest extends AbstractControllerTest {
                 0xBB, // Applicable System Monitor Denominator
         };
         var dm20Packet = new DM20MonitorPerformanceRatioPacket(Packet.create(PGN, 0x00, data));
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20Packet));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20Packet));
 
         OBDModuleInformation obdModuleInformation = new OBDModuleInformation(0);
         obdModuleInformation.set(dm20Packet, 1);
@@ -159,13 +159,13 @@ public class Part05Step06ControllerTest extends AbstractControllerTest {
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(0));
     }
 
     @Test
     public void testEmptyPackets() {
 
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.empty());
 
         int[] data = {
                 0x04, // Ignition Cycle Counter
@@ -193,7 +193,7 @@ public class Part05Step06ControllerTest extends AbstractControllerTest {
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(0));
     }
 
 }

--- a/src-test/org/etools/j1939_84/controllers/part05/Part05Step07ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part05/Part05Step07ControllerTest.java
@@ -25,7 +25,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -47,7 +47,7 @@ public class Part05Step07ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -81,7 +81,7 @@ public class Part05Step07ControllerTest extends AbstractControllerTest {
                                               DataRepository.newInstance(),
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -90,7 +90,7 @@ public class Part05Step07ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -100,7 +100,7 @@ public class Part05Step07ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part06/Part06ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part06/Part06ControllerTest.java
@@ -24,7 +24,7 @@ public class Part06ControllerTest extends AbstractPartControllerTest {
                                         DataRepository.newInstance(),
                                         engineSpeedModule,
                                         vehicleInformationModule,
-                                        diagnosticMessageModule,
+                                        communicationsModule,
                                         step01Controller,
                                         step02Controller,
                                         step03Controller,

--- a/src-test/org/etools/j1939_84/controllers/part06/Part06Step01ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part06/Part06Step01ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -50,7 +50,7 @@ public class Part06Step01ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -85,7 +85,7 @@ public class Part06Step01ControllerTest extends AbstractControllerTest {
                                               DataRepository.newInstance(),
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -94,7 +94,7 @@ public class Part06Step01ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -104,7 +104,7 @@ public class Part06Step01ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part06/Part06Step02ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part06/Part06Step02ControllerTest.java
@@ -27,7 +27,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -50,7 +50,7 @@ public class Part06Step02ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -87,7 +87,7 @@ public class Part06Step02ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -96,7 +96,7 @@ public class Part06Step02ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -106,7 +106,7 @@ public class Part06Step02ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -135,12 +135,12 @@ public class Part06Step02ControllerTest extends AbstractControllerTest {
         RequestResult<DM5DiagnosticReadinessPacket> globalRequestResponse = new RequestResult<>(false,
                                                                                                 Collections.emptyList(),
                                                                                                 Collections.emptyList());
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(globalRequestResponse);
+        when(communicationsModule.requestDM5(any())).thenReturn(globalRequestResponse);
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM5(any());
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM5(any());
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -169,12 +169,12 @@ public class Part06Step02ControllerTest extends AbstractControllerTest {
                                                                                                 Collections.emptyList(),
                                                                                                 Collections.singletonList(
                                                                                                                           packet44));
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(globalRequestResponse);
+        when(communicationsModule.requestDM5(any())).thenReturn(globalRequestResponse);
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM5(any());
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM5(any());
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -228,7 +228,7 @@ public class Part06Step02ControllerTest extends AbstractControllerTest {
                                                                                                         packet0,
                                                                                                         packet21),
                                                                                                 List.of(packet44));
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(globalRequestResponse);
+        when(communicationsModule.requestDM5(any())).thenReturn(globalRequestResponse);
 
         OBDModuleInformation obdModule = new OBDModuleInformation(0x03);
         dataRepository.putObdModule(obdModule);
@@ -239,8 +239,8 @@ public class Part06Step02ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM5(any());
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM5(any());
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -266,11 +266,11 @@ public class Part06Step02ControllerTest extends AbstractControllerTest {
         var dm5 = DM5DiagnosticReadinessPacket.create(0, 1, 0, 0x22);
         var dm5_1 = DM5DiagnosticReadinessPacket.create(1, 0, 0, 0x22);
 
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(RequestResult.of(dm5, dm5_1));
+        when(communicationsModule.requestDM5(any())).thenReturn(RequestResult.of(dm5, dm5_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part06/Part06Step03ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part06/Part06Step03ControllerTest.java
@@ -26,7 +26,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -48,7 +48,7 @@ public class Part06Step03ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -85,7 +85,7 @@ public class Part06Step03ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -94,7 +94,7 @@ public class Part06Step03ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -104,7 +104,7 @@ public class Part06Step03ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -133,11 +133,11 @@ public class Part06Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0x01));
         DiagnosticTroubleCode dtc = DiagnosticTroubleCode.create(1569, 31, 0, 0);
         var packet1 = DM12MILOnEmissionDTCPacket.create(0x01, ON, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM12(any(), eq(0x01))).thenReturn(BusResult.of(packet1));
+        when(communicationsModule.requestDM12(any(), eq(0x01))).thenReturn(BusResult.of(packet1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0x01));
+        verify(communicationsModule).requestDM12(any(), eq(0x01));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -148,11 +148,11 @@ public class Part06Step03ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
-        when(diagnosticMessageModule.requestDM12(any(), eq(0x01))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM12(any(), eq(0x01))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0x01));
+        verify(communicationsModule).requestDM12(any(), eq(0x01));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -175,11 +175,11 @@ public class Part06Step03ControllerTest extends AbstractControllerTest {
     public void testFailureForNoDTC() {
         dataRepository.putObdModule(new OBDModuleInformation(0x01));
         var packet1 = DM12MILOnEmissionDTCPacket.create(0x01, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM12(any(), eq(0x01))).thenReturn(BusResult.of(packet1));
+        when(communicationsModule.requestDM12(any(), eq(0x01))).thenReturn(BusResult.of(packet1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0x01));
+        verify(communicationsModule).requestDM12(any(), eq(0x01));
 
         assertEquals("", listener.getResults());
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -193,11 +193,11 @@ public class Part06Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0x01));
         DiagnosticTroubleCode dtc = DiagnosticTroubleCode.create(1569, 31, 0, 0);
         var packet1 = DM12MILOnEmissionDTCPacket.create(0x01, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM12(any(), eq(0x01))).thenReturn(BusResult.of(packet1));
+        when(communicationsModule.requestDM12(any(), eq(0x01))).thenReturn(BusResult.of(packet1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0x01));
+        verify(communicationsModule).requestDM12(any(), eq(0x01));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());

--- a/src-test/org/etools/j1939_84/controllers/part06/Part06Step04ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part06/Part06Step04ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -50,7 +50,7 @@ public class Part06Step04ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -87,7 +87,7 @@ public class Part06Step04ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -96,7 +96,7 @@ public class Part06Step04ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -106,7 +106,7 @@ public class Part06Step04ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -141,11 +141,11 @@ public class Part06Step04ControllerTest extends AbstractControllerTest {
 
         var dm1_0 = DM1ActiveDTCsPacket.create(0, ON, OFF, OFF, OFF, dtc);
         var dm1_1 = DM1ActiveDTCsPacket.create(1, NOT_SUPPORTED, NOT_SUPPORTED, NOT_SUPPORTED, NOT_SUPPORTED);
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_1));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -163,11 +163,11 @@ public class Part06Step04ControllerTest extends AbstractControllerTest {
 
         var dm1_0 = DM1ActiveDTCsPacket.create(0, OFF, OFF, OFF, OFF, dtc);
         var dm1_1 = DM1ActiveDTCsPacket.create(1, ON, ON, ON, ON);
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_1));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -187,11 +187,11 @@ public class Part06Step04ControllerTest extends AbstractControllerTest {
 
         var dm1_0 = DM1ActiveDTCsPacket.create(0, ON, OFF, OFF, OFF, dtc2);
         var dm1_1 = DM1ActiveDTCsPacket.create(1, ON, ON, ON, ON);
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_1));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -213,11 +213,11 @@ public class Part06Step04ControllerTest extends AbstractControllerTest {
 
         var dm1_0 = DM1ActiveDTCsPacket.create(0, ON, OFF, OFF, OFF, dtc);
         var dm1_1 = DM1ActiveDTCsPacket.create(1, ON, ON, ON, ON);
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_1));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part06/Part06Step05ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part06/Part06Step05ControllerTest.java
@@ -25,7 +25,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -47,7 +47,7 @@ public class Part06Step05ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -84,7 +84,7 @@ public class Part06Step05ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -93,7 +93,7 @@ public class Part06Step05ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -103,7 +103,7 @@ public class Part06Step05ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -140,15 +140,15 @@ public class Part06Step05ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(2));
 
         var dm20 = DM20MonitorPerformanceRatioPacket.create(0, 5, 7);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
 
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM20(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM20(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM20(any(), eq(1));
+        verify(communicationsModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -161,11 +161,11 @@ public class Part06Step05ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm20 = DM20MonitorPerformanceRatioPacket.create(0, 4, 7);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -183,11 +183,11 @@ public class Part06Step05ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm20 = DM20MonitorPerformanceRatioPacket.create(0, 6, 7);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part06/Part06Step06ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part06/Part06Step06ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -50,7 +50,7 @@ public class Part06Step06ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -87,7 +87,7 @@ public class Part06Step06ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -96,7 +96,7 @@ public class Part06Step06ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -106,7 +106,7 @@ public class Part06Step06ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -134,16 +134,16 @@ public class Part06Step06ControllerTest extends AbstractControllerTest {
     public void testHappyPathNoFailures() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm23 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm23));
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm23));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM23(any(), eq(1))).thenReturn(new BusResult<>(false, nack));
+        when(communicationsModule.requestDM23(any(), eq(1))).thenReturn(new BusResult<>(false, nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM23(any(), eq(1));
+        verify(communicationsModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -154,11 +154,11 @@ public class Part06Step06ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dtc = DiagnosticTroubleCode.create(123, 12, 0, 4);
         var dm23 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm23));
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm23));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -173,11 +173,11 @@ public class Part06Step06ControllerTest extends AbstractControllerTest {
     public void testFailureForNoMIL() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm23 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm23));
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm23));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -189,15 +189,15 @@ public class Part06Step06ControllerTest extends AbstractControllerTest {
     public void testFailureForNoNACK() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm23 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm23));
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(new BusResult<>(false, dm23));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
-        when(diagnosticMessageModule.requestDM23(any(), eq(1))).thenReturn(new BusResult<>(true));
+        when(communicationsModule.requestDM23(any(), eq(1))).thenReturn(new BusResult<>(true));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM23(any(), eq(1));
+        verify(communicationsModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part06/Part06Step07ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part06/Part06Step07ControllerTest.java
@@ -30,7 +30,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -52,7 +52,7 @@ public class Part06Step07ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -89,7 +89,7 @@ public class Part06Step07ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -98,7 +98,7 @@ public class Part06Step07ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -108,7 +108,7 @@ public class Part06Step07ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -140,16 +140,16 @@ public class Part06Step07ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc), 6);
         dataRepository.putObdModule(obdModuleInformation);
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM28(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM28(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM28(any(), eq(1));
+        verify(communicationsModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -162,11 +162,11 @@ public class Part06Step07ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF), 6);
         dataRepository.putObdModule(obdModuleInformation);
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -183,11 +183,11 @@ public class Part06Step07ControllerTest extends AbstractControllerTest {
 
         var dtc2 = DiagnosticTroubleCode.create(234, 14, 0, 1);
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc2);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -205,11 +205,11 @@ public class Part06Step07ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(DM12MILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc), 6);
         dataRepository.putObdModule(obdModuleInformation);
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -224,15 +224,15 @@ public class Part06Step07ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc), 6);
         dataRepository.putObdModule(obdModuleInformation);
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
-        when(diagnosticMessageModule.requestDM28(any(), eq(1))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM28(any(), eq(1))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM28(any(), eq(1));
+        verify(communicationsModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part06/Part06Step08ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part06/Part06Step08ControllerTest.java
@@ -34,7 +34,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -56,7 +56,7 @@ public class Part06Step08ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -93,7 +93,7 @@ public class Part06Step08ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -102,7 +102,7 @@ public class Part06Step08ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -112,7 +112,7 @@ public class Part06Step08ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -148,16 +148,16 @@ public class Part06Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 1, 1, 0, 1);
-        when(diagnosticMessageModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
+        when(communicationsModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM29(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM29(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM29(any(), eq(1));
+        verify(communicationsModule).requestDM29(any(), eq(0));
+        verify(communicationsModule).requestDM29(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -176,11 +176,11 @@ public class Part06Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm29 = DM29DtcCounts.create(0, 0, 1, 1, 1, 0, 1);
-        when(diagnosticMessageModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
+        when(communicationsModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any(), eq(0));
+        verify(communicationsModule).requestDM29(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -202,11 +202,11 @@ public class Part06Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 1, 1, 1, 1);
-        when(diagnosticMessageModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
+        when(communicationsModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any(), eq(0));
+        verify(communicationsModule).requestDM29(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -228,11 +228,11 @@ public class Part06Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 1, 0, 0, 1);
-        when(diagnosticMessageModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
+        when(communicationsModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any(), eq(0));
+        verify(communicationsModule).requestDM29(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -252,11 +252,11 @@ public class Part06Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 1, 1, 0, 1);
-        when(diagnosticMessageModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
+        when(communicationsModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any(), eq(0));
+        verify(communicationsModule).requestDM29(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -278,11 +278,11 @@ public class Part06Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 1, 1, 0, 0);
-        when(diagnosticMessageModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
+        when(communicationsModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any(), eq(0));
+        verify(communicationsModule).requestDM29(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -305,11 +305,11 @@ public class Part06Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 1, 1, 0, 1);
-        when(diagnosticMessageModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
+        when(communicationsModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any(), eq(0));
+        verify(communicationsModule).requestDM29(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -332,11 +332,11 @@ public class Part06Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 1, 1, 0, 1);
-        when(diagnosticMessageModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
+        when(communicationsModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any(), eq(0));
+        verify(communicationsModule).requestDM29(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -357,11 +357,11 @@ public class Part06Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 1, 1, 0, 1);
-        when(diagnosticMessageModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
+        when(communicationsModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any(), eq(0));
+        verify(communicationsModule).requestDM29(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -383,15 +383,15 @@ public class Part06Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 1, 1, 0, 1);
-        when(diagnosticMessageModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
+        when(communicationsModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
-        when(diagnosticMessageModule.requestDM29(any(), eq(1))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM29(any(), eq(1))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM29(any(), eq(1));
+        verify(communicationsModule).requestDM29(any(), eq(0));
+        verify(communicationsModule).requestDM29(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -414,11 +414,11 @@ public class Part06Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 1, 2, 0, 1);
-        when(diagnosticMessageModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
+        when(communicationsModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any(), eq(0));
+        verify(communicationsModule).requestDM29(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -440,7 +440,7 @@ public class Part06Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 1, 1, 0, 1);
-        when(diagnosticMessageModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
+        when(communicationsModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
 
         OBDModuleInformation obdModuleInformation1 = new OBDModuleInformation(1);
         obdModuleInformation1.set(DM12MILOnEmissionDTCPacket.create(1, ON, OFF, OFF, OFF, dtc), 6);
@@ -449,12 +449,12 @@ public class Part06Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation1);
 
         var dm29_1 = DM29DtcCounts.create(1, 0, 0, 1, 1, 0, 0);
-        when(diagnosticMessageModule.requestDM29(any(), eq(1))).thenReturn(BusResult.of(dm29_1));
+        when(communicationsModule.requestDM29(any(), eq(1))).thenReturn(BusResult.of(dm29_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM29(any(), eq(1));
+        verify(communicationsModule).requestDM29(any(), eq(0));
+        verify(communicationsModule).requestDM29(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -477,11 +477,11 @@ public class Part06Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 1, 1, 0, 2);
-        when(diagnosticMessageModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
+        when(communicationsModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any(), eq(0));
+        verify(communicationsModule).requestDM29(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -503,7 +503,7 @@ public class Part06Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 1, 1, 0, 1);
-        when(diagnosticMessageModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
+        when(communicationsModule.requestDM29(any(), eq(0))).thenReturn(BusResult.of(dm29));
 
         OBDModuleInformation obdModuleInformation1 = new OBDModuleInformation(1);
         obdModuleInformation1.set(DM27AllPendingDTCsPacket.create(1, ON, OFF, OFF, OFF, dtc), 6);
@@ -512,12 +512,12 @@ public class Part06Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation1);
 
         var dm29_1 = DM29DtcCounts.create(1, 0, 0, 1, 0, 0, 1);
-        when(diagnosticMessageModule.requestDM29(any(), eq(1))).thenReturn(BusResult.of(dm29_1));
+        when(communicationsModule.requestDM29(any(), eq(1))).thenReturn(BusResult.of(dm29_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM29(any(), eq(1));
+        verify(communicationsModule).requestDM29(any(), eq(0));
+        verify(communicationsModule).requestDM29(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part06/Part06Step09ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part06/Part06Step09ControllerTest.java
@@ -31,7 +31,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -53,7 +53,7 @@ public class Part06Step09ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -90,7 +90,7 @@ public class Part06Step09ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -99,7 +99,7 @@ public class Part06Step09ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -109,7 +109,7 @@ public class Part06Step09ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -141,16 +141,16 @@ public class Part06Step09ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc), 6);
         dataRepository.putObdModule(obdModuleInformation);
         var dm31 = DM31DtcToLampAssociation.create(0, 0, DTCLampStatus.create(dtc, OFF, ON, OFF, OFF));
-        when(diagnosticMessageModule.requestDM31(any(), eq(0))).thenReturn(RequestResult.of(dm31));
+        when(communicationsModule.requestDM31(any(), eq(0))).thenReturn(RequestResult.of(dm31));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM31(any(), eq(1))).thenReturn(new RequestResult<>(true, nack));
+        when(communicationsModule.requestDM31(any(), eq(1))).thenReturn(new RequestResult<>(true, nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM31(any(), eq(1));
+        verify(communicationsModule).requestDM31(any(), eq(0));
+        verify(communicationsModule).requestDM31(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -167,11 +167,11 @@ public class Part06Step09ControllerTest extends AbstractControllerTest {
 
         var dtc1 = DiagnosticTroubleCode.create(456, 12, 0, 1);
         var dm31 = DM31DtcToLampAssociation.create(0, 0, DTCLampStatus.create(dtc1, OFF, ON, OFF, OFF));
-        when(diagnosticMessageModule.requestDM31(any(), eq(0))).thenReturn(RequestResult.of(dm31));
+        when(communicationsModule.requestDM31(any(), eq(0))).thenReturn(RequestResult.of(dm31));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any(), eq(0));
+        verify(communicationsModule).requestDM31(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -189,11 +189,11 @@ public class Part06Step09ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc), 6);
         dataRepository.putObdModule(obdModuleInformation);
         var dm31 = DM31DtcToLampAssociation.create(0, 0, DTCLampStatus.create(dtc, OFF, OFF, OFF, OFF));
-        when(diagnosticMessageModule.requestDM31(any(), eq(0))).thenReturn(RequestResult.of(dm31));
+        when(communicationsModule.requestDM31(any(), eq(0))).thenReturn(RequestResult.of(dm31));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any(), eq(0));
+        verify(communicationsModule).requestDM31(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -211,15 +211,15 @@ public class Part06Step09ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc), 6);
         dataRepository.putObdModule(obdModuleInformation);
         var dm31 = DM31DtcToLampAssociation.create(0, 0, DTCLampStatus.create(dtc, OFF, ON, OFF, OFF));
-        when(diagnosticMessageModule.requestDM31(any(), eq(0))).thenReturn(RequestResult.of(dm31));
+        when(communicationsModule.requestDM31(any(), eq(0))).thenReturn(RequestResult.of(dm31));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
-        when(diagnosticMessageModule.requestDM31(any(), eq(1))).thenReturn(new RequestResult<>(true));
+        when(communicationsModule.requestDM31(any(), eq(1))).thenReturn(new RequestResult<>(true));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM31(any(), eq(1));
+        verify(communicationsModule).requestDM31(any(), eq(0));
+        verify(communicationsModule).requestDM31(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part06/Part06Step10ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part06/Part06Step10ControllerTest.java
@@ -31,7 +31,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -53,7 +53,7 @@ public class Part06Step10ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -90,7 +90,7 @@ public class Part06Step10ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -99,7 +99,7 @@ public class Part06Step10ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -109,7 +109,7 @@ public class Part06Step10ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -142,16 +142,16 @@ public class Part06Step10ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm21 = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 1, 0);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM21(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM21(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(1));
+        verify(communicationsModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -167,11 +167,11 @@ public class Part06Step10ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm21 = DM21DiagnosticReadinessPacket.create(0, 0, 1, 0, 1, 0);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -190,11 +190,11 @@ public class Part06Step10ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm21 = DM21DiagnosticReadinessPacket.create(0, 0, 0xFFFF, 0, 1, 0);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -209,11 +209,11 @@ public class Part06Step10ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
         var dm21 = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 1, 0);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -228,11 +228,11 @@ public class Part06Step10ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
         var nack = AcknowledgmentPacket.create(0, NACK);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -252,15 +252,15 @@ public class Part06Step10ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm21 = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 1, 0);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
-        when(diagnosticMessageModule.requestDM21(any(), eq(1))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM21(any(), eq(1))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(1));
+        verify(communicationsModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -279,11 +279,11 @@ public class Part06Step10ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm21 = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -302,7 +302,7 @@ public class Part06Step10ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm21 = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 1, 0);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
 
         var dtc_1 = DiagnosticTroubleCode.create(234, 12, 0, 1);
 
@@ -311,12 +311,12 @@ public class Part06Step10ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation1);
 
         var dm21_1 = DM21DiagnosticReadinessPacket.create(1, 0, 0, 0, 3, 0);
-        when(diagnosticMessageModule.requestDM21(any(), eq(1))).thenReturn(BusResult.of(dm21_1));
+        when(communicationsModule.requestDM21(any(), eq(1))).thenReturn(BusResult.of(dm21_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(1));
+        verify(communicationsModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part06/Part06Step11ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part06/Part06Step11ControllerTest.java
@@ -27,7 +27,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -49,7 +49,7 @@ public class Part06Step11ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -83,7 +83,7 @@ public class Part06Step11ControllerTest extends AbstractControllerTest {
                                               DataRepository.newInstance(),
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -92,7 +92,7 @@ public class Part06Step11ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -102,7 +102,7 @@ public class Part06Step11ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part07/Part07ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part07/Part07ControllerTest.java
@@ -24,7 +24,7 @@ public class Part07ControllerTest extends AbstractPartControllerTest {
                                         DataRepository.newInstance(),
                                         engineSpeedModule,
                                         vehicleInformationModule,
-                                        diagnosticMessageModule,
+                                        communicationsModule,
                                         step01Controller,
                                         step02Controller,
                                         step03Controller,

--- a/src-test/org/etools/j1939_84/controllers/part07/Part07Step01ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part07/Part07Step01ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -51,7 +51,7 @@ public class Part07Step01ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -85,7 +85,7 @@ public class Part07Step01ControllerTest extends AbstractControllerTest {
                                               DataRepository.newInstance(),
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -94,7 +94,7 @@ public class Part07Step01ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -104,7 +104,7 @@ public class Part07Step01ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part07/Part07Step02ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part07/Part07Step02ControllerTest.java
@@ -30,7 +30,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -52,7 +52,7 @@ public class Part07Step02ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -89,7 +89,7 @@ public class Part07Step02ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -98,7 +98,7 @@ public class Part07Step02ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -108,7 +108,7 @@ public class Part07Step02ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -141,16 +141,16 @@ public class Part07Step02ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModule);
 
         var dm23 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(BusResult.of(dm23));
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(BusResult.of(dm23));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM23(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM23(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM23(any(), eq(1));
+        verify(communicationsModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -166,11 +166,11 @@ public class Part07Step02ControllerTest extends AbstractControllerTest {
 
         var dtc23 = DiagnosticTroubleCode.create(123, 12, 0, 4);
         var dm23 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc23);
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(BusResult.of(dm23));
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(BusResult.of(dm23));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -195,11 +195,11 @@ public class Part07Step02ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModule);
 
         var dm23 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc, dtc1);
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(BusResult.of(dm23));
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(BusResult.of(dm23));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -225,15 +225,15 @@ public class Part07Step02ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModule1);
 
         var dm23 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(BusResult.of(dm23));
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(BusResult.of(dm23));
 
         var dm23_1 = DM23PreviouslyMILOnEmissionDTCPacket.create(1, OFF, OFF, OFF, OFF, dtc1);
-        when(diagnosticMessageModule.requestDM23(any(), eq(1))).thenReturn(BusResult.of(dm23_1));
+        when(communicationsModule.requestDM23(any(), eq(1))).thenReturn(BusResult.of(dm23_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM23(any(), eq(1));
+        verify(communicationsModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -252,11 +252,11 @@ public class Part07Step02ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModule);
 
         var dm23 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(BusResult.of(dm23));
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(BusResult.of(dm23));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -276,19 +276,19 @@ public class Part07Step02ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModule);
 
         var dm23 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(BusResult.of(dm23));
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(BusResult.of(dm23));
 
         OBDModuleInformation obdModule1 = new OBDModuleInformation(1);
         var dtc1 = DiagnosticTroubleCode.create(1569, 31, 0, 0);
         var dm6_1 = DM12MILOnEmissionDTCPacket.create(1, OFF, OFF, OFF, OFF, dtc1);
         obdModule.set(dm6_1, 6);
         dataRepository.putObdModule(obdModule1);
-        when(diagnosticMessageModule.requestDM23(any(), eq(1))).thenReturn(new BusResult<>(true));
+        when(communicationsModule.requestDM23(any(), eq(1))).thenReturn(new BusResult<>(true));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM23(any(), eq(1));
+        verify(communicationsModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part07/Part07Step03ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part07/Part07Step03ControllerTest.java
@@ -33,7 +33,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -55,7 +55,7 @@ public class Part07Step03ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -92,7 +92,7 @@ public class Part07Step03ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -101,7 +101,7 @@ public class Part07Step03ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -111,7 +111,7 @@ public class Part07Step03ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -145,21 +145,21 @@ public class Part07Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm2_0 = DM2PreviouslyActiveDTC.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dm2_0));
+        when(communicationsModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dm2_0));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM2(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM2(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         var dm2_2 = DM2PreviouslyActiveDTC.create(2, NOT_SUPPORTED, NOT_SUPPORTED, NOT_SUPPORTED, NOT_SUPPORTED);
 
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(RequestResult.of(dm2_0, dm2_2));
+        when(communicationsModule.requestDM2(any())).thenReturn(RequestResult.of(dm2_0, dm2_2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
-        verify(diagnosticMessageModule).requestDM2(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM2(any(), eq(1));
+        verify(communicationsModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any(), eq(0));
+        verify(communicationsModule).requestDM2(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -168,11 +168,11 @@ public class Part07Step03ControllerTest extends AbstractControllerTest {
 
     @Test
     public void testNoPackets() {
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM2(any())).thenReturn(RequestResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -186,16 +186,16 @@ public class Part07Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm2_0 = DM2PreviouslyActiveDTC.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dm2_0));
+        when(communicationsModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dm2_0));
 
         var dm2_2 = DM2PreviouslyActiveDTC.create(2, OFF, OFF, OFF, OFF, dtc);
 
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(RequestResult.of(dm2_0, dm2_2));
+        when(communicationsModule.requestDM2(any())).thenReturn(RequestResult.of(dm2_0, dm2_2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
-        verify(diagnosticMessageModule).requestDM2(any(), eq(0));
+        verify(communicationsModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -216,14 +216,14 @@ public class Part07Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm2_0 = DM2PreviouslyActiveDTC.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dm2_0));
+        when(communicationsModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dm2_0));
 
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(RequestResult.of(dm2_0));
+        when(communicationsModule.requestDM2(any())).thenReturn(RequestResult.of(dm2_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
-        verify(diagnosticMessageModule).requestDM2(any(), eq(0));
+        verify(communicationsModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -244,14 +244,14 @@ public class Part07Step03ControllerTest extends AbstractControllerTest {
 
         var dtc2 = DiagnosticTroubleCode.create(423, 11, 1, 19);
         var dm2_0 = DM2PreviouslyActiveDTC.create(0, OFF, OFF, OFF, OFF, dtc2);
-        when(diagnosticMessageModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dm2_0));
+        when(communicationsModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dm2_0));
 
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(RequestResult.of(dm2_0));
+        when(communicationsModule.requestDM2(any())).thenReturn(RequestResult.of(dm2_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
-        verify(diagnosticMessageModule).requestDM2(any(), eq(0));
+        verify(communicationsModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -271,14 +271,14 @@ public class Part07Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm2_0 = DM2PreviouslyActiveDTC.create(0, ON, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dm2_0));
+        when(communicationsModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dm2_0));
 
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(RequestResult.of(dm2_0));
+        when(communicationsModule.requestDM2(any())).thenReturn(RequestResult.of(dm2_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
-        verify(diagnosticMessageModule).requestDM2(any(), eq(0));
+        verify(communicationsModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -299,16 +299,16 @@ public class Part07Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm2_0 = DM2PreviouslyActiveDTC.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dm2_0));
+        when(communicationsModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dm2_0));
 
         var dm2_2 = DM2PreviouslyActiveDTC.create(2, ON, OFF, OFF, OFF);
 
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(RequestResult.of(dm2_0, dm2_2));
+        when(communicationsModule.requestDM2(any())).thenReturn(RequestResult.of(dm2_0, dm2_2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
-        verify(diagnosticMessageModule).requestDM2(any(), eq(0));
+        verify(communicationsModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -329,15 +329,15 @@ public class Part07Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm2_0 = DM2PreviouslyActiveDTC.create(0, ON, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dm2_0));
+        when(communicationsModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dm2_0));
 
         var dm2_0_2 = DM2PreviouslyActiveDTC.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(RequestResult.of(dm2_0_2));
+        when(communicationsModule.requestDM2(any())).thenReturn(RequestResult.of(dm2_0_2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
-        verify(diagnosticMessageModule).requestDM2(any(), eq(0));
+        verify(communicationsModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -356,18 +356,18 @@ public class Part07Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm2_0 = DM2PreviouslyActiveDTC.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dm2_0));
+        when(communicationsModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dm2_0));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
-        when(diagnosticMessageModule.requestDM2(any(), eq(1))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM2(any(), eq(1))).thenReturn(BusResult.empty());
 
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(RequestResult.of(dm2_0));
+        when(communicationsModule.requestDM2(any())).thenReturn(RequestResult.of(dm2_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
-        verify(diagnosticMessageModule).requestDM2(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM2(any(), eq(1));
+        verify(communicationsModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any(), eq(0));
+        verify(communicationsModule).requestDM2(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part07/Part07Step04ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part07/Part07Step04ControllerTest.java
@@ -29,7 +29,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -51,7 +51,7 @@ public class Part07Step04ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -88,7 +88,7 @@ public class Part07Step04ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -97,7 +97,7 @@ public class Part07Step04ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -107,7 +107,7 @@ public class Part07Step04ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -135,16 +135,16 @@ public class Part07Step04ControllerTest extends AbstractControllerTest {
     public void testHappyPathNoFailures() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm12 = DM12MILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM12(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM12(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM12(any(), eq(1));
+        verify(communicationsModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -156,11 +156,11 @@ public class Part07Step04ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dtc = DiagnosticTroubleCode.create(1223, 12, 0, 1);
         var dm12 = DM12MILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -174,11 +174,11 @@ public class Part07Step04ControllerTest extends AbstractControllerTest {
     public void testFailureForMILNotOff() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm12 = DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -192,11 +192,11 @@ public class Part07Step04ControllerTest extends AbstractControllerTest {
     public void testFailureForNoSupport() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var nack = AcknowledgmentPacket.create(0, NACK);
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -206,11 +206,11 @@ public class Part07Step04ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForNoNACKAndNoSupport() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part07/Part07Step05ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part07/Part07Step05ControllerTest.java
@@ -25,7 +25,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -47,7 +47,7 @@ public class Part07Step05ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -84,7 +84,7 @@ public class Part07Step05ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -93,7 +93,7 @@ public class Part07Step05ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -103,7 +103,7 @@ public class Part07Step05ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -135,11 +135,11 @@ public class Part07Step05ControllerTest extends AbstractControllerTest {
         // Non-OBD Module
         var dtc = DiagnosticTroubleCode.create(122, 12, 1, 12);
         var dm1_1 = DM1ActiveDTCsPacket.create(1, ON, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_1));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -152,11 +152,11 @@ public class Part07Step05ControllerTest extends AbstractControllerTest {
         var dtc = DiagnosticTroubleCode.create(122, 12, 1, 12);
         var dm1 = DM1ActiveDTCsPacket.create(0, OFF, OFF, OFF, OFF, dtc);
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -171,11 +171,11 @@ public class Part07Step05ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm1 = DM1ActiveDTCsPacket.create(0, ON, OFF, OFF, OFF);
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -192,11 +192,11 @@ public class Part07Step05ControllerTest extends AbstractControllerTest {
         // Non-OBD Module
         var dtc = DiagnosticTroubleCode.create(122, 12, 1, 12);
         var dm1 = DM1ActiveDTCsPacket.create(1, ON, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part07/Part07Step06ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part07/Part07Step06ControllerTest.java
@@ -26,7 +26,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -48,7 +48,7 @@ public class Part07Step06ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -85,7 +85,7 @@ public class Part07Step06ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -94,7 +94,7 @@ public class Part07Step06ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -104,7 +104,7 @@ public class Part07Step06ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -141,11 +141,11 @@ public class Part07Step06ControllerTest extends AbstractControllerTest {
         var dm5_1 = DM5DiagnosticReadinessPacket.create(1, 0xFF, 0, 0x22);
 
         var dm5_2 = DM5DiagnosticReadinessPacket.create(2, 1, 0, 0x05);
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(RequestResult.of(dm5_0, dm5_1, dm5_2));
+        when(communicationsModule.requestDM5(any())).thenReturn(RequestResult.of(dm5_0, dm5_1, dm5_2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -161,11 +161,11 @@ public class Part07Step06ControllerTest extends AbstractControllerTest {
 
         var dm5_0 = DM5DiagnosticReadinessPacket.create(0, 1, 1, 0x22);
 
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(RequestResult.of(dm5_0));
+        when(communicationsModule.requestDM5(any())).thenReturn(RequestResult.of(dm5_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -183,11 +183,11 @@ public class Part07Step06ControllerTest extends AbstractControllerTest {
 
         var dm5_0 = DM5DiagnosticReadinessPacket.create(0, 0, 0, 0x22);
 
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(RequestResult.of(dm5_0));
+        when(communicationsModule.requestDM5(any())).thenReturn(RequestResult.of(dm5_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -206,11 +206,11 @@ public class Part07Step06ControllerTest extends AbstractControllerTest {
 
         var dm5_0 = DM5DiagnosticReadinessPacket.create(0, 0, 2, 0x22);
 
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(RequestResult.of(dm5_0));
+        when(communicationsModule.requestDM5(any())).thenReturn(RequestResult.of(dm5_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part07/Part07Step07ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part07/Part07Step07ControllerTest.java
@@ -30,7 +30,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -52,7 +52,7 @@ public class Part07Step07ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -89,7 +89,7 @@ public class Part07Step07ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -98,7 +98,7 @@ public class Part07Step07ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -108,7 +108,7 @@ public class Part07Step07ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -136,19 +136,19 @@ public class Part07Step07ControllerTest extends AbstractControllerTest {
     public void testHappyPathNoFailures() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm6 = DM6PendingEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.of(dm6));
+        when(communicationsModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.of(dm6));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM6(any(), eq(1))).thenReturn(new RequestResult<>(false, nack));
+        when(communicationsModule.requestDM6(any(), eq(1))).thenReturn(new RequestResult<>(false, nack));
 
-        when(diagnosticMessageModule.requestDM6(any())).thenReturn(RequestResult.of(dm6));
+        when(communicationsModule.requestDM6(any())).thenReturn(RequestResult.of(dm6));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM6(any());
-        verify(diagnosticMessageModule).requestDM6(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM6(any(), eq(1));
+        verify(communicationsModule).requestDM6(any());
+        verify(communicationsModule).requestDM6(any(), eq(0));
+        verify(communicationsModule).requestDM6(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -160,13 +160,13 @@ public class Part07Step07ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dtc = DiagnosticTroubleCode.create(123, 1, 0, 3);
         var dm6 = DM6PendingEmissionDTCPacket.create(0, ALTERNATE_OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.of(dm6));
-        when(diagnosticMessageModule.requestDM6(any())).thenReturn(RequestResult.of(dm6));
+        when(communicationsModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.of(dm6));
+        when(communicationsModule.requestDM6(any())).thenReturn(RequestResult.of(dm6));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM6(any());
-        verify(diagnosticMessageModule).requestDM6(any(), eq(0));
+        verify(communicationsModule).requestDM6(any());
+        verify(communicationsModule).requestDM6(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -180,13 +180,13 @@ public class Part07Step07ControllerTest extends AbstractControllerTest {
     public void testFailureForMILNotOff() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm6 = DM6PendingEmissionDTCPacket.create(0, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.of(dm6));
-        when(diagnosticMessageModule.requestDM6(any())).thenReturn(RequestResult.of(dm6));
+        when(communicationsModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.of(dm6));
+        when(communicationsModule.requestDM6(any())).thenReturn(RequestResult.of(dm6));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM6(any());
-        verify(diagnosticMessageModule).requestDM6(any(), eq(0));
+        verify(communicationsModule).requestDM6(any());
+        verify(communicationsModule).requestDM6(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -200,15 +200,15 @@ public class Part07Step07ControllerTest extends AbstractControllerTest {
     public void testFailureForDifference() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm6_0 = DM6PendingEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM6(any())).thenReturn(RequestResult.of(dm6_0));
+        when(communicationsModule.requestDM6(any())).thenReturn(RequestResult.of(dm6_0));
 
         var dm6_1 = DM6PendingEmissionDTCPacket.create(0, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.of(dm6_1));
+        when(communicationsModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.of(dm6_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM6(any());
-        verify(diagnosticMessageModule).requestDM6(any(), eq(0));
+        verify(communicationsModule).requestDM6(any());
+        verify(communicationsModule).requestDM6(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -221,13 +221,13 @@ public class Part07Step07ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForNoNACK() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
-        when(diagnosticMessageModule.requestDM6(any())).thenReturn(RequestResult.empty());
-        when(diagnosticMessageModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM6(any())).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM6(any());
-        verify(diagnosticMessageModule).requestDM6(any(), eq(0));
+        verify(communicationsModule).requestDM6(any());
+        verify(communicationsModule).requestDM6(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part07/Part07Step08ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part07/Part07Step08ControllerTest.java
@@ -30,7 +30,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -52,7 +52,7 @@ public class Part07Step08ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -89,7 +89,7 @@ public class Part07Step08ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -98,7 +98,7 @@ public class Part07Step08ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -108,7 +108,7 @@ public class Part07Step08ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -136,19 +136,19 @@ public class Part07Step08ControllerTest extends AbstractControllerTest {
     public void testHappyPathNoFailures() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm27 = DM27AllPendingDTCsPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM27(any(), eq(0))).thenReturn(BusResult.of(dm27));
+        when(communicationsModule.requestDM27(any(), eq(0))).thenReturn(BusResult.of(dm27));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM27(any(), eq(1))).thenReturn(new BusResult<>(false, nack));
+        when(communicationsModule.requestDM27(any(), eq(1))).thenReturn(new BusResult<>(false, nack));
 
-        when(diagnosticMessageModule.requestDM27(any())).thenReturn(RequestResult.of(dm27));
+        when(communicationsModule.requestDM27(any())).thenReturn(RequestResult.of(dm27));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM27(any(), eq(1));
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0));
+        verify(communicationsModule).requestDM27(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -160,13 +160,13 @@ public class Part07Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dtc = DiagnosticTroubleCode.create(123, 1, 0, 3);
         var dm27 = DM27AllPendingDTCsPacket.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM27(any(), eq(0))).thenReturn(BusResult.of(dm27));
-        when(diagnosticMessageModule.requestDM27(any())).thenReturn(RequestResult.of(dm27));
+        when(communicationsModule.requestDM27(any(), eq(0))).thenReturn(BusResult.of(dm27));
+        when(communicationsModule.requestDM27(any())).thenReturn(RequestResult.of(dm27));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0));
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -180,13 +180,13 @@ public class Part07Step08ControllerTest extends AbstractControllerTest {
     public void testFailureForMILNotOff() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm27 = DM27AllPendingDTCsPacket.create(0, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM27(any(), eq(0))).thenReturn(BusResult.of(dm27));
-        when(diagnosticMessageModule.requestDM27(any())).thenReturn(RequestResult.of(dm27));
+        when(communicationsModule.requestDM27(any(), eq(0))).thenReturn(BusResult.of(dm27));
+        when(communicationsModule.requestDM27(any())).thenReturn(RequestResult.of(dm27));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0));
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -200,15 +200,15 @@ public class Part07Step08ControllerTest extends AbstractControllerTest {
     public void testFailureForDifference() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm27_0 = DM27AllPendingDTCsPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM27(any())).thenReturn(RequestResult.of(dm27_0));
+        when(communicationsModule.requestDM27(any())).thenReturn(RequestResult.of(dm27_0));
 
         var dm27_1 = DM27AllPendingDTCsPacket.create(0, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM27(any(), eq(0))).thenReturn(BusResult.of(dm27_1));
+        when(communicationsModule.requestDM27(any(), eq(0))).thenReturn(BusResult.of(dm27_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0));
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -221,13 +221,13 @@ public class Part07Step08ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForNoNACK() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
-        when(diagnosticMessageModule.requestDM27(any())).thenReturn(RequestResult.empty());
-        when(diagnosticMessageModule.requestDM27(any(), eq(0))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM27(any())).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM27(any(), eq(0))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0));
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part07/Part07Step09ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part07/Part07Step09ControllerTest.java
@@ -29,7 +29,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -51,7 +51,7 @@ public class Part07Step09ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -88,7 +88,7 @@ public class Part07Step09ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -97,7 +97,7 @@ public class Part07Step09ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -107,7 +107,7 @@ public class Part07Step09ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -135,16 +135,16 @@ public class Part07Step09ControllerTest extends AbstractControllerTest {
     public void testHappyPathNoFailures() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM28(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM28(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM28(any(), eq(1));
+        verify(communicationsModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -156,11 +156,11 @@ public class Part07Step09ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dtc = DiagnosticTroubleCode.create(123, 1, 1, 1);
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -174,11 +174,11 @@ public class Part07Step09ControllerTest extends AbstractControllerTest {
     public void testFailureForMILNotOff() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -191,11 +191,11 @@ public class Part07Step09ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForNoNACK() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part07/Part07Step10ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part07/Part07Step10ControllerTest.java
@@ -27,7 +27,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -49,7 +49,7 @@ public class Part07Step10ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -86,7 +86,7 @@ public class Part07Step10ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -95,7 +95,7 @@ public class Part07Step10ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -105,7 +105,7 @@ public class Part07Step10ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -137,11 +137,11 @@ public class Part07Step10ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 0, 0, 1, 0);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -150,11 +150,11 @@ public class Part07Step10ControllerTest extends AbstractControllerTest {
 
     @Test
     public void testNoPacket() {
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of());
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -172,11 +172,11 @@ public class Part07Step10ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm29 = DM29DtcCounts.create(0, 0, 1, 0, 0, 1, 0);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -194,11 +194,11 @@ public class Part07Step10ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 1, 0, 1, 0);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -216,11 +216,11 @@ public class Part07Step10ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 0, 1, 1, 0);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -238,11 +238,11 @@ public class Part07Step10ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 0, 0, 1, 1);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -258,11 +258,11 @@ public class Part07Step10ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -281,11 +281,11 @@ public class Part07Step10ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm29 = DM29DtcCounts.create(0, 0, 0, 0, 0, 2, 0);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -309,11 +309,11 @@ public class Part07Step10ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation1);
         var dm29_1 = DM29DtcCounts.create(1, 0, 0, 0, 0, 1, 0);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0, dm29_1));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0, dm29_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part07/Part07Step11ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part07/Part07Step11ControllerTest.java
@@ -32,7 +32,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -54,7 +54,7 @@ public class Part07Step11ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -91,7 +91,7 @@ public class Part07Step11ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -100,7 +100,7 @@ public class Part07Step11ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -110,7 +110,7 @@ public class Part07Step11ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -143,16 +143,16 @@ public class Part07Step11ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(DM12MILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc), 7);
         dataRepository.putObdModule(obdModuleInformation);
         var dm31 = DM31DtcToLampAssociation.create(0, 0, DTCLampStatus.create(dtc, OFF, OFF, OFF, OFF));
-        when(diagnosticMessageModule.requestDM31(any(), eq(0))).thenReturn(RequestResult.of(dm31));
+        when(communicationsModule.requestDM31(any(), eq(0))).thenReturn(RequestResult.of(dm31));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM31(any(), eq(1))).thenReturn(new RequestResult<>(true, nack));
+        when(communicationsModule.requestDM31(any(), eq(1))).thenReturn(new RequestResult<>(true, nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM31(any(), eq(1));
+        verify(communicationsModule).requestDM31(any(), eq(0));
+        verify(communicationsModule).requestDM31(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -169,11 +169,11 @@ public class Part07Step11ControllerTest extends AbstractControllerTest {
 
         var dtc1 = DiagnosticTroubleCode.create(456, 12, 0, 1);
         var dm31 = DM31DtcToLampAssociation.create(0, 0, DTCLampStatus.create(dtc1, ON, ON, OFF, OFF));
-        when(diagnosticMessageModule.requestDM31(any(), eq(0))).thenReturn(RequestResult.of(dm31));
+        when(communicationsModule.requestDM31(any(), eq(0))).thenReturn(RequestResult.of(dm31));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any(), eq(0));
+        verify(communicationsModule).requestDM31(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -192,11 +192,11 @@ public class Part07Step11ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm31 = DM31DtcToLampAssociation.create(0, 0, DTCLampStatus.create(dtc, OFF, OFF, OFF, OFF));
-        when(diagnosticMessageModule.requestDM31(any(), eq(0))).thenReturn(RequestResult.of(dm31));
+        when(communicationsModule.requestDM31(any(), eq(0))).thenReturn(RequestResult.of(dm31));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any(), eq(0));
+        verify(communicationsModule).requestDM31(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -214,15 +214,15 @@ public class Part07Step11ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(DM12MILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc), 7);
         dataRepository.putObdModule(obdModuleInformation);
         var dm31 = DM31DtcToLampAssociation.create(0, 0, DTCLampStatus.create(dtc, OFF, OFF, OFF, OFF));
-        when(diagnosticMessageModule.requestDM31(any(), eq(0))).thenReturn(RequestResult.of(dm31));
+        when(communicationsModule.requestDM31(any(), eq(0))).thenReturn(RequestResult.of(dm31));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
-        when(diagnosticMessageModule.requestDM31(any(), eq(1))).thenReturn(new RequestResult<>(true));
+        when(communicationsModule.requestDM31(any(), eq(1))).thenReturn(new RequestResult<>(true));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM31(any(), eq(1));
+        verify(communicationsModule).requestDM31(any(), eq(0));
+        verify(communicationsModule).requestDM31(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part07/Part07Step12ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part07/Part07Step12ControllerTest.java
@@ -31,7 +31,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -53,7 +53,7 @@ public class Part07Step12ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -90,7 +90,7 @@ public class Part07Step12ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -99,7 +99,7 @@ public class Part07Step12ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -109,7 +109,7 @@ public class Part07Step12ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -141,16 +141,16 @@ public class Part07Step12ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
         var freezeFrame = new FreezeFrame(dtc, new int[0]);
         var dm25 = DM25ExpandedFreezeFrame.create(0, freezeFrame);
-        when(diagnosticMessageModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
+        when(communicationsModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM25(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM25(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM25(any(), eq(1));
+        verify(communicationsModule).requestDM25(any(), eq(0));
+        verify(communicationsModule).requestDM25(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -161,11 +161,11 @@ public class Part07Step12ControllerTest extends AbstractControllerTest {
     public void testFailureForNoFreezeFrames() {
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM25(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM25(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(1));
+        verify(communicationsModule).requestDM25(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -184,11 +184,11 @@ public class Part07Step12ControllerTest extends AbstractControllerTest {
         var dtc2 = DiagnosticTroubleCode.create(234, 3, 1, 1);
         var freezeFrame = new FreezeFrame(dtc2, new int[0]);
         var dm25 = DM25ExpandedFreezeFrame.create(0, freezeFrame);
-        when(diagnosticMessageModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
+        when(communicationsModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(0));
+        verify(communicationsModule).requestDM25(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -206,15 +206,15 @@ public class Part07Step12ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
         var freezeFrame = new FreezeFrame(dtc, new int[0]);
         var dm25 = DM25ExpandedFreezeFrame.create(0, freezeFrame);
-        when(diagnosticMessageModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
+        when(communicationsModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
-        when(diagnosticMessageModule.requestDM25(any(), eq(1))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM25(any(), eq(1))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM25(any(), eq(1));
+        verify(communicationsModule).requestDM25(any(), eq(0));
+        verify(communicationsModule).requestDM25(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -235,11 +235,11 @@ public class Part07Step12ControllerTest extends AbstractControllerTest {
         var dtc2 = DiagnosticTroubleCode.create(234, 3, 1, 1);
         var freezeFrame2 = new FreezeFrame(dtc2, new int[0]);
         var dm25 = DM25ExpandedFreezeFrame.create(0, freezeFrame1, freezeFrame2);
-        when(diagnosticMessageModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
+        when(communicationsModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(0));
+        verify(communicationsModule).requestDM25(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part07/Part07Step13ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part07/Part07Step13ControllerTest.java
@@ -24,7 +24,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -46,7 +46,7 @@ public class Part07Step13ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -83,7 +83,7 @@ public class Part07Step13ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -92,7 +92,7 @@ public class Part07Step13ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -102,7 +102,7 @@ public class Part07Step13ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -132,14 +132,14 @@ public class Part07Step13ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(DM20MonitorPerformanceRatioPacket.create(0, 9, 5), 5);
         dataRepository.putObdModule(obdModuleInformation);
         var dm20 = DM20MonitorPerformanceRatioPacket.create(0, 12, 5);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
 
         // Won't be asked for DM20
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -152,11 +152,11 @@ public class Part07Step13ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(DM20MonitorPerformanceRatioPacket.create(0, 9, 5), 5);
         dataRepository.putObdModule(obdModuleInformation);
         var dm20 = DM20MonitorPerformanceRatioPacket.create(0, 14, 5);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -172,11 +172,11 @@ public class Part07Step13ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(DM20MonitorPerformanceRatioPacket.create(0, 9, 5), 5);
         dataRepository.putObdModule(obdModuleInformation);
         var dm20 = DM20MonitorPerformanceRatioPacket.create(0, 9, 5);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part07/Part07Step14ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part07/Part07Step14ControllerTest.java
@@ -26,7 +26,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -48,7 +48,7 @@ public class Part07Step14ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -85,7 +85,7 @@ public class Part07Step14ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -94,7 +94,7 @@ public class Part07Step14ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -104,7 +104,7 @@ public class Part07Step14ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -133,16 +133,16 @@ public class Part07Step14ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm21 = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 1, 0);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM21(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM21(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(1));
+        verify(communicationsModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -155,11 +155,11 @@ public class Part07Step14ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm21 = DM21DiagnosticReadinessPacket.create(0, 0, 1, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -175,15 +175,15 @@ public class Part07Step14ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm21 = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 1, 0);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
-        when(diagnosticMessageModule.requestDM21(any(), eq(1))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM21(any(), eq(1))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(1));
+        verify(communicationsModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part07/Part07Step15ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part07/Part07Step15ControllerTest.java
@@ -29,7 +29,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -51,7 +51,7 @@ public class Part07Step15ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -88,7 +88,7 @@ public class Part07Step15ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -97,7 +97,7 @@ public class Part07Step15ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -107,7 +107,7 @@ public class Part07Step15ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -147,15 +147,15 @@ public class Part07Step15ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm30 = DM30ScaledTestResultsPacket.create(0, 0, scaledTestResult1, scaledTestResult2);
-        when(diagnosticMessageModule.requestTestResult(any(),
-                                                       eq(0),
-                                                       eq(246),
-                                                       eq(5846),
-                                                       eq(31))).thenReturn(BusResult.of(dm30));
+        when(communicationsModule.requestTestResult(any(),
+                                                    eq(0),
+                                                    eq(246),
+                                                    eq(5846),
+                                                    eq(31))).thenReturn(BusResult.of(dm30));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResult(any(), eq(0), eq(246), eq(5846), eq(31));
+        verify(communicationsModule).requestTestResult(any(), eq(0), eq(246), eq(5846), eq(31));
 
         List<ScaledTestResult> nonInitializedTests = dataRepository.getObdModule(0).getNonInitializedTests();
         assertEquals(1, nonInitializedTests.size());
@@ -181,22 +181,22 @@ public class Part07Step15ControllerTest extends AbstractControllerTest {
         obdModuleInformation.setScaledTestResults(List.of(scaledTestResult1, scaledTestResult2));
         dataRepository.putObdModule(obdModuleInformation);
 
-        when(diagnosticMessageModule.requestTestResult(any(), eq(0), eq(246), eq(5846), eq(31)))
+        when(communicationsModule.requestTestResult(any(), eq(0), eq(246), eq(5846), eq(31)))
                                                                                                 .thenReturn(BusResult.empty());
 
         var dm30_123 = DM30ScaledTestResultsPacket.create(0, 0, scaledTestResult1);
-        when(diagnosticMessageModule.requestTestResult(any(), eq(0), eq(247), eq(123), eq(31)))
+        when(communicationsModule.requestTestResult(any(), eq(0), eq(247), eq(123), eq(31)))
                                                                                                .thenReturn(BusResult.of(dm30_123));
 
         var dm30_456 = DM30ScaledTestResultsPacket.create(0, 0, scaledTestResult2);
-        when(diagnosticMessageModule.requestTestResult(any(), eq(0), eq(247), eq(456), eq(31)))
+        when(communicationsModule.requestTestResult(any(), eq(0), eq(247), eq(456), eq(31)))
                                                                                                .thenReturn(BusResult.of(dm30_456));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResult(any(), eq(0), eq(246), eq(5846), eq(31));
-        verify(diagnosticMessageModule).requestTestResult(any(), eq(0), eq(247), eq(123), eq(31));
-        verify(diagnosticMessageModule).requestTestResult(any(), eq(0), eq(247), eq(456), eq(31));
+        verify(communicationsModule).requestTestResult(any(), eq(0), eq(246), eq(5846), eq(31));
+        verify(communicationsModule).requestTestResult(any(), eq(0), eq(247), eq(123), eq(31));
+        verify(communicationsModule).requestTestResult(any(), eq(0), eq(247), eq(456), eq(31));
 
         List<ScaledTestResult> nonInitializedTests = dataRepository.getObdModule(0).getNonInitializedTests();
         assertEquals(1, nonInitializedTests.size());
@@ -217,20 +217,20 @@ public class Part07Step15ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(obdModuleInformation);
 
-        when(diagnosticMessageModule.requestTestResult(any(), eq(0), eq(246), eq(5846), eq(31)))
+        when(communicationsModule.requestTestResult(any(), eq(0), eq(246), eq(5846), eq(31)))
                                                                                                 .thenReturn(BusResult.empty());
 
         var ack = AcknowledgmentPacket.create(0, ACK);
-        when(diagnosticMessageModule.requestTestResult(any(), eq(0), eq(247), eq(123), eq(31)))
+        when(communicationsModule.requestTestResult(any(), eq(0), eq(247), eq(123), eq(31)))
                                                                                                .thenReturn(BusResult.of(ack));
-        when(diagnosticMessageModule.requestTestResult(any(), eq(0), eq(247), eq(456), eq(31)))
+        when(communicationsModule.requestTestResult(any(), eq(0), eq(247), eq(456), eq(31)))
                                                                                                .thenReturn(BusResult.of(ack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResult(any(), eq(0), eq(246), eq(5846), eq(31));
-        verify(diagnosticMessageModule).requestTestResult(any(), eq(0), eq(247), eq(123), eq(31));
-        verify(diagnosticMessageModule).requestTestResult(any(), eq(0), eq(247), eq(456), eq(31));
+        verify(communicationsModule).requestTestResult(any(), eq(0), eq(246), eq(5846), eq(31));
+        verify(communicationsModule).requestTestResult(any(), eq(0), eq(247), eq(123), eq(31));
+        verify(communicationsModule).requestTestResult(any(), eq(0), eq(247), eq(456), eq(31));
 
         List<ScaledTestResult> nonInitializedTests = dataRepository.getObdModule(0).getNonInitializedTests();
         assertEquals(0, nonInitializedTests.size());
@@ -256,15 +256,15 @@ public class Part07Step15ControllerTest extends AbstractControllerTest {
 
         var scaledTestResult3 = ScaledTestResult.create(247, 9634, 31, 4, 0, 0, 0);
         var dm30 = DM30ScaledTestResultsPacket.create(0, 0, scaledTestResult1, scaledTestResult2, scaledTestResult3);
-        when(diagnosticMessageModule.requestTestResult(any(),
-                                                       eq(0),
-                                                       eq(246),
-                                                       eq(5846),
-                                                       eq(31))).thenReturn(BusResult.of(dm30));
+        when(communicationsModule.requestTestResult(any(),
+                                                    eq(0),
+                                                    eq(246),
+                                                    eq(5846),
+                                                    eq(31))).thenReturn(BusResult.of(dm30));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResult(any(), eq(0), eq(246), eq(5846), eq(31));
+        verify(communicationsModule).requestTestResult(any(), eq(0), eq(246), eq(5846), eq(31));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -288,22 +288,22 @@ public class Part07Step15ControllerTest extends AbstractControllerTest {
         obdModuleInformation.setScaledTestResults(List.of(scaledTestResult1, scaledTestResult2));
         dataRepository.putObdModule(obdModuleInformation);
 
-        when(diagnosticMessageModule.requestTestResult(any(), eq(0), eq(246), eq(5846), eq(31)))
+        when(communicationsModule.requestTestResult(any(), eq(0), eq(246), eq(5846), eq(31)))
                                                                                                 .thenReturn(BusResult.empty());
 
         var dm30_123 = DM30ScaledTestResultsPacket.create(0, 0, scaledTestResult1);
-        when(diagnosticMessageModule.requestTestResult(any(), eq(0), eq(247), eq(123), eq(31)))
+        when(communicationsModule.requestTestResult(any(), eq(0), eq(247), eq(123), eq(31)))
                                                                                                .thenReturn(BusResult.of(dm30_123));
 
         var ack = AcknowledgmentPacket.create(0, ACK);
-        when(diagnosticMessageModule.requestTestResult(any(), eq(0), eq(247), eq(456), eq(31)))
+        when(communicationsModule.requestTestResult(any(), eq(0), eq(247), eq(456), eq(31)))
                                                                                                .thenReturn(BusResult.of(ack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResult(any(), eq(0), eq(246), eq(5846), eq(31));
-        verify(diagnosticMessageModule).requestTestResult(any(), eq(0), eq(247), eq(123), eq(31));
-        verify(diagnosticMessageModule).requestTestResult(any(), eq(0), eq(247), eq(456), eq(31));
+        verify(communicationsModule).requestTestResult(any(), eq(0), eq(246), eq(5846), eq(31));
+        verify(communicationsModule).requestTestResult(any(), eq(0), eq(247), eq(123), eq(31));
+        verify(communicationsModule).requestTestResult(any(), eq(0), eq(247), eq(456), eq(31));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -322,16 +322,16 @@ public class Part07Step15ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var nack = AcknowledgmentPacket.create(0, NACK);
-        when(diagnosticMessageModule.requestTestResult(any(), eq(0), eq(246), eq(5846), eq(31)))
+        when(communicationsModule.requestTestResult(any(), eq(0), eq(246), eq(5846), eq(31)))
                                                                                                 .thenReturn(BusResult.of(nack));
 
-        when(diagnosticMessageModule.requestTestResult(any(), eq(0), eq(247), eq(123), eq(31)))
+        when(communicationsModule.requestTestResult(any(), eq(0), eq(247), eq(123), eq(31)))
                                                                                                .thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResult(any(), eq(0), eq(246), eq(5846), eq(31));
-        verify(diagnosticMessageModule).requestTestResult(any(), eq(0), eq(247), eq(123), eq(31));
+        verify(communicationsModule).requestTestResult(any(), eq(0), eq(246), eq(5846), eq(31));
+        verify(communicationsModule).requestTestResult(any(), eq(0), eq(247), eq(123), eq(31));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part07/Part07Step16ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part07/Part07Step16ControllerTest.java
@@ -27,7 +27,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -49,7 +49,7 @@ public class Part07Step16ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -89,7 +89,7 @@ public class Part07Step16ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               verifier);
 
         setup(instance,
@@ -99,7 +99,7 @@ public class Part07Step16ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -109,7 +109,7 @@ public class Part07Step16ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener,
                                  verifier);
     }
@@ -140,14 +140,14 @@ public class Part07Step16ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
         var nackPacket = AcknowledgmentPacket.create(0, NACK);
-        when(diagnosticMessageModule.requestDM3(any())).thenReturn(List.of(nackPacket));
-        when(diagnosticMessageModule.requestDM3(any(), eq(0)))
+        when(communicationsModule.requestDM3(any())).thenReturn(List.of(nackPacket));
+        when(communicationsModule.requestDM3(any(), eq(0)))
                                                               .thenReturn(List.of(nackPacket));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM3(any());
-        verify(diagnosticMessageModule).requestDM3(any(), eq(0));
+        verify(communicationsModule).requestDM3(any());
+        verify(communicationsModule).requestDM3(any(), eq(0));
 
         verify(verifier).setJ1939(any());
         verify(verifier).verifyDataNotErased(any(), eq("6.7.16.2.a"));
@@ -173,14 +173,14 @@ public class Part07Step16ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
-        when(diagnosticMessageModule.requestDM3(any(), eq(0)))
+        when(communicationsModule.requestDM3(any(), eq(0)))
                                                               .thenReturn(List.of(AcknowledgmentPacket.create(0,
                                                                                                               ACK)));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM3(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM3(any());
+        verify(communicationsModule).requestDM3(any(), eq(0));
+        verify(communicationsModule).requestDM3(any());
 
         verify(verifier).setJ1939(any());
         verify(verifier).verifyDataNotErased(any(), eq("6.7.16.2.a"));

--- a/src-test/org/etools/j1939_84/controllers/part07/Part07Step17ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part07/Part07Step17ControllerTest.java
@@ -24,7 +24,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.Outcome;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -46,7 +46,7 @@ public class Part07Step17ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -83,7 +83,7 @@ public class Part07Step17ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -92,7 +92,7 @@ public class Part07Step17ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -102,7 +102,7 @@ public class Part07Step17ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -136,17 +136,17 @@ public class Part07Step17ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm30_123_12 = DM30ScaledTestResultsPacket.create(0, 0, str1);
-        when(diagnosticMessageModule.requestTestResults(any(), eq(0), eq(250), eq(123), eq(12)))
+        when(communicationsModule.requestTestResults(any(), eq(0), eq(250), eq(123), eq(12)))
                                                                                                 .thenReturn(List.of(dm30_123_12));
 
         var dm30_456_9 = DM30ScaledTestResultsPacket.create(0, 0, str2);
-        when(diagnosticMessageModule.requestTestResults(any(), eq(0), eq(250), eq(456), eq(9)))
+        when(communicationsModule.requestTestResults(any(), eq(0), eq(250), eq(456), eq(9)))
                                                                                                .thenReturn(List.of(dm30_456_9));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(250), eq(123), eq(12));
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(250), eq(456), eq(9));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(250), eq(123), eq(12));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(250), eq(456), eq(9));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -163,18 +163,18 @@ public class Part07Step17ControllerTest extends AbstractControllerTest {
 
         var str_123_12 = ScaledTestResult.create(247, 123, 12, 6, 0, 0, 0);
         var dm30_123_12 = DM30ScaledTestResultsPacket.create(0, 0, str_123_12);
-        when(diagnosticMessageModule.requestTestResults(any(), eq(0), eq(250), eq(123), eq(12)))
+        when(communicationsModule.requestTestResults(any(), eq(0), eq(250), eq(123), eq(12)))
                                                                                                 .thenReturn(List.of(dm30_123_12));
 
         var str_456_9 = ScaledTestResult.create(247, 456, 9, 4, 0xFB00, 0xFFFF, 0xFFFF);
         var dm30_456_9 = DM30ScaledTestResultsPacket.create(0, 0, str_456_9);
-        when(diagnosticMessageModule.requestTestResults(any(), eq(0), eq(250), eq(456), eq(9)))
+        when(communicationsModule.requestTestResults(any(), eq(0), eq(250), eq(456), eq(9)))
                                                                                                .thenReturn(List.of(dm30_456_9));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(250), eq(123), eq(12));
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(250), eq(456), eq(9));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(250), eq(123), eq(12));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(250), eq(456), eq(9));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part07/Part07Step18ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part07/Part07Step18ControllerTest.java
@@ -29,7 +29,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -51,7 +51,7 @@ public class Part07Step18ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -88,7 +88,7 @@ public class Part07Step18ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -97,7 +97,7 @@ public class Part07Step18ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -107,7 +107,7 @@ public class Part07Step18ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part08/Part08ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part08/Part08ControllerTest.java
@@ -24,7 +24,7 @@ public class Part08ControllerTest extends AbstractPartControllerTest {
                                         DataRepository.newInstance(),
                                         engineSpeedModule,
                                         vehicleInformationModule,
-                                        diagnosticMessageModule,
+                                        communicationsModule,
                                         step01Controller,
                                         step02Controller,
                                         step03Controller,

--- a/src-test/org/etools/j1939_84/controllers/part08/Part08Step01ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part08/Part08Step01ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -50,7 +50,7 @@ public class Part08Step01ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -85,7 +85,7 @@ public class Part08Step01ControllerTest extends AbstractControllerTest {
                                               DataRepository.newInstance(),
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -94,7 +94,7 @@ public class Part08Step01ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -104,7 +104,7 @@ public class Part08Step01ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part08/Part08Step02ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part08/Part08Step02ControllerTest.java
@@ -36,7 +36,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -58,7 +58,7 @@ public class Part08Step02ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -97,7 +97,7 @@ public class Part08Step02ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -106,7 +106,7 @@ public class Part08Step02ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -116,7 +116,7 @@ public class Part08Step02ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -146,13 +146,13 @@ public class Part08Step02ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var nack = AcknowledgmentPacket.create(0, AcknowledgmentPacket.Response.NACK);
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, nack));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, nack));
 
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
         var dm12_1 = DM12MILOnEmissionDTCPacket.create(1, ON, OFF, OFF, OFF, dtc1);
-        when(diagnosticMessageModule.requestDM12(any(), eq(1))).thenReturn(new BusResult<>(false, dm12_1));
+        when(communicationsModule.requestDM12(any(), eq(1))).thenReturn(new BusResult<>(false, dm12_1));
 
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12_1));
+        when(communicationsModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12_1));
 
         runTest();
 
@@ -163,9 +163,9 @@ public class Part08Step02ControllerTest extends AbstractControllerTest {
         expectedResults += "Attempt 1" + NL;
         assertEquals(expectedResults, listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM12(any());
-        verify(diagnosticMessageModule).requestDM12(any(), eq(1));
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any(), eq(1));
+        verify(communicationsModule).requestDM12(any(), eq(0));
 
         assertEquals(0, dateTimeModule.getTimeAsLong());
 
@@ -175,7 +175,7 @@ public class Part08Step02ControllerTest extends AbstractControllerTest {
     @Test
     public void testNoResponses() {
 
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(new RequestResult<>(true));
+        when(communicationsModule.requestDM12(any())).thenReturn(new RequestResult<>(true));
 
         String promptMsg = "No ECU has reported an active DTC." + NL + "Do you wish to continue?";
         String promptTitle = "No Active DTCs Found";
@@ -204,7 +204,7 @@ public class Part08Step02ControllerTest extends AbstractControllerTest {
         assertEquals(expectedResults.toString(), listener.getResults());
 
         verify(mockListener).onUrgentMessage(eq(promptMsg), eq(promptTitle), eq(QUESTION), any());
-        verify(diagnosticMessageModule, times(300)).requestDM12(any());
+        verify(communicationsModule, times(300)).requestDM12(any());
         verify(mockListener).onUrgentMessage(eq(promptMsg), eq(promptTitle), eq(QUESTION), any());
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -223,7 +223,7 @@ public class Part08Step02ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
         var dm12 = DM12MILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(RequestResult.of(dm12));
+        when(communicationsModule.requestDM12(any())).thenReturn(RequestResult.of(dm12));
 
         String promptMsg = "No ECU has reported an active DTC." + NL + "Do you wish to continue?";
         String promptTitle = "No Active DTCs Found";
@@ -234,7 +234,7 @@ public class Part08Step02ControllerTest extends AbstractControllerTest {
             return null;
         }).when(mockListener).onUrgentMessage(eq(promptMsg), eq(promptTitle), eq(QUESTION), any());
 
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12));
 
         runTest();
 
@@ -254,8 +254,8 @@ public class Part08Step02ControllerTest extends AbstractControllerTest {
         assertEquals(expectedResults.toString(), listener.getResults());
 
         verify(mockListener).onUrgentMessage(eq(promptMsg), eq(promptTitle), eq(QUESTION), any());
-        verify(diagnosticMessageModule, times(300)).requestDM12(any());
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule, times(300)).requestDM12(any());
+        verify(communicationsModule).requestDM12(any(), eq(0));
         verify(mockListener).onUrgentMessage(eq(promptMsg), eq(promptTitle), eq(QUESTION), any());
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -276,8 +276,8 @@ public class Part08Step02ControllerTest extends AbstractControllerTest {
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
         var dtc2 = DiagnosticTroubleCode.create(456, 3, 0, 1);
         var dm12 = DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc1, dtc2);
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(RequestResult.of(dm12));
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12));
+        when(communicationsModule.requestDM12(any())).thenReturn(RequestResult.of(dm12));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12));
 
         runTest();
 
@@ -288,8 +288,8 @@ public class Part08Step02ControllerTest extends AbstractControllerTest {
         expectedResults += "Attempt 1" + NL;
         assertEquals(expectedResults, listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM12(any());
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any(), eq(0));
 
         assertEquals(0, dateTimeModule.getTimeAsLong());
 
@@ -306,8 +306,8 @@ public class Part08Step02ControllerTest extends AbstractControllerTest {
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
         var dm12_0 = DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc1);
         var dm12_1 = DM12MILOnEmissionDTCPacket.create(1, ON, OFF, OFF, OFF, dtc1);
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(RequestResult.of(dm12_0, dm12_1));
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12_0));
+        when(communicationsModule.requestDM12(any())).thenReturn(RequestResult.of(dm12_0, dm12_1));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12_0));
 
         runTest();
 
@@ -318,8 +318,8 @@ public class Part08Step02ControllerTest extends AbstractControllerTest {
         expectedResults += "Attempt 1" + NL;
         assertEquals(expectedResults, listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM12(any());
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any(), eq(0));
 
         assertEquals(0, dateTimeModule.getTimeAsLong());
 
@@ -335,13 +335,13 @@ public class Part08Step02ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var dm12_0 = DM12MILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12_0));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(new BusResult<>(false, dm12_0));
 
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
         var dm12_1 = DM12MILOnEmissionDTCPacket.create(1, ON, OFF, OFF, OFF, dtc1);
-        when(diagnosticMessageModule.requestDM12(any(), eq(1))).thenReturn(new BusResult<>(false, dm12_1));
+        when(communicationsModule.requestDM12(any(), eq(1))).thenReturn(new BusResult<>(false, dm12_1));
 
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12_0, dm12_1));
+        when(communicationsModule.requestDM12(any())).thenReturn(new RequestResult<>(false, dm12_0, dm12_1));
 
         runTest();
 
@@ -352,9 +352,9 @@ public class Part08Step02ControllerTest extends AbstractControllerTest {
         expectedResults += "Attempt 1" + NL;
         assertEquals(expectedResults, listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM12(any());
-        verify(diagnosticMessageModule).requestDM12(any(), eq(1));
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any(), eq(1));
+        verify(communicationsModule).requestDM12(any(), eq(0));
 
         assertEquals(0, dateTimeModule.getTimeAsLong());
 
@@ -367,8 +367,8 @@ public class Part08Step02ControllerTest extends AbstractControllerTest {
 
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
         var dm12 = DM12MILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc1);
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(RequestResult.of(dm12));
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12));
+        when(communicationsModule.requestDM12(any())).thenReturn(RequestResult.of(dm12));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12));
 
         runTest();
 
@@ -379,8 +379,8 @@ public class Part08Step02ControllerTest extends AbstractControllerTest {
         expectedResults += "Attempt 1" + NL;
         assertEquals(expectedResults, listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM12(any());
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any(), eq(0));
 
         assertEquals(0, dateTimeModule.getTimeAsLong());
 
@@ -402,10 +402,10 @@ public class Part08Step02ControllerTest extends AbstractControllerTest {
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
 
         var dm12_1 = DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc1);
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(RequestResult.of(dm12_1));
+        when(communicationsModule.requestDM12(any())).thenReturn(RequestResult.of(dm12_1));
 
         var dm12_2 = DM12MILOnEmissionDTCPacket.create(0, ON, ON, OFF, OFF, dtc1);
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12_2));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12_2));
 
         runTest();
 
@@ -416,8 +416,8 @@ public class Part08Step02ControllerTest extends AbstractControllerTest {
         expectedResults += "Attempt 1" + NL;
         assertEquals(expectedResults, listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM12(any());
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any(), eq(0));
 
         assertEquals(0, dateTimeModule.getTimeAsLong());
 
@@ -432,11 +432,11 @@ public class Part08Step02ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 1);
         var dm12 = DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc1);
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(RequestResult.of(dm12));
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12));
+        when(communicationsModule.requestDM12(any())).thenReturn(RequestResult.of(dm12));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
-        when(diagnosticMessageModule.requestDM12(any(), eq(1))).thenReturn(new BusResult<>(true));
+        when(communicationsModule.requestDM12(any(), eq(1))).thenReturn(new BusResult<>(true));
 
         runTest();
 
@@ -447,9 +447,9 @@ public class Part08Step02ControllerTest extends AbstractControllerTest {
         expectedResults += "Attempt 1" + NL;
         assertEquals(expectedResults, listener.getResults());
 
-        verify(diagnosticMessageModule).requestDM12(any());
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM12(any(), eq(1));
+        verify(communicationsModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any(), eq(1));
 
         assertEquals(0, dateTimeModule.getTimeAsLong());
 

--- a/src-test/org/etools/j1939_84/controllers/part08/Part08Step03ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part08/Part08Step03ControllerTest.java
@@ -26,7 +26,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -48,7 +48,7 @@ public class Part08Step03ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -85,7 +85,7 @@ public class Part08Step03ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -94,7 +94,7 @@ public class Part08Step03ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -104,7 +104,7 @@ public class Part08Step03ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -137,11 +137,11 @@ public class Part08Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(moduleInformation);
 
         var dm1 = DM1ActiveDTCsPacket.create(0, ON, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -150,11 +150,11 @@ public class Part08Step03ControllerTest extends AbstractControllerTest {
 
     @Test
     public void testNoResponses() {
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of());
+        when(communicationsModule.readDM1(any())).thenReturn(List.of());
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -169,11 +169,11 @@ public class Part08Step03ControllerTest extends AbstractControllerTest {
     @Test
     public void testNoActiveDTCFailure() {
         var dm1 = DM1ActiveDTCsPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -201,11 +201,11 @@ public class Part08Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(moduleInfo1);
         var dm1_1 = DM1ActiveDTCsPacket.create(1, ON, OFF, OFF, OFF);
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_1));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -232,11 +232,11 @@ public class Part08Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(moduleInfo0);
         var dm1_0 = DM1ActiveDTCsPacket.create(0, ON, OFF, OFF, OFF, dtc1);
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part08/Part08Step04ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part08/Part08Step04ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -50,7 +50,7 @@ public class Part08Step04ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -87,7 +87,7 @@ public class Part08Step04ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -96,7 +96,7 @@ public class Part08Step04ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -106,7 +106,7 @@ public class Part08Step04ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -140,11 +140,11 @@ public class Part08Step04ControllerTest extends AbstractControllerTest {
 
         var dm23_0 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc);
         var dm23_1 = DM23PreviouslyMILOnEmissionDTCPacket.create(1, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM23(any())).thenReturn(RequestResult.of(dm23_0, dm23_1));
+        when(communicationsModule.requestDM23(any())).thenReturn(RequestResult.of(dm23_0, dm23_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any());
+        verify(communicationsModule).requestDM23(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -158,11 +158,11 @@ public class Part08Step04ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm23 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM23(any())).thenReturn(RequestResult.of(dm23));
+        when(communicationsModule.requestDM23(any())).thenReturn(RequestResult.of(dm23));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any());
+        verify(communicationsModule).requestDM23(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -182,11 +182,11 @@ public class Part08Step04ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm23 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc2);
-        when(diagnosticMessageModule.requestDM23(any())).thenReturn(RequestResult.of(dm23));
+        when(communicationsModule.requestDM23(any())).thenReturn(RequestResult.of(dm23));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any());
+        verify(communicationsModule).requestDM23(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -206,11 +206,11 @@ public class Part08Step04ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm23 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, FAST_FLASH, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM23(any())).thenReturn(RequestResult.of(dm23));
+        when(communicationsModule.requestDM23(any())).thenReturn(RequestResult.of(dm23));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any());
+        verify(communicationsModule).requestDM23(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part08/Part08Step05ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part08/Part08Step05ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -50,7 +50,7 @@ public class Part08Step05ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -87,7 +87,7 @@ public class Part08Step05ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -96,7 +96,7 @@ public class Part08Step05ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -106,7 +106,7 @@ public class Part08Step05ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -146,11 +146,11 @@ public class Part08Step05ControllerTest extends AbstractControllerTest {
         var dtc1 = DiagnosticTroubleCode.create(1289, 3, 0, 1);
         var dm2_2 = DM2PreviouslyActiveDTC.create(2, ON, OFF, OFF, OFF, dtc1);
 
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(RequestResult.of(dm2_0, dm2_1, dm2_2));
+        when(communicationsModule.requestDM2(any())).thenReturn(RequestResult.of(dm2_0, dm2_1, dm2_2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -167,11 +167,11 @@ public class Part08Step05ControllerTest extends AbstractControllerTest {
         var dtc1 = DiagnosticTroubleCode.create(1289, 3, 0, 1);
         var dm2 = DM2PreviouslyActiveDTC.create(0, ON, OFF, OFF, OFF, dtc1);
 
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(RequestResult.of(dm2));
+        when(communicationsModule.requestDM2(any())).thenReturn(RequestResult.of(dm2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -191,11 +191,11 @@ public class Part08Step05ControllerTest extends AbstractControllerTest {
 
         var dm2 = DM2PreviouslyActiveDTC.create(0, FAST_FLASH, OFF, OFF, OFF, dtc);
 
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(RequestResult.of(dm2));
+        when(communicationsModule.requestDM2(any())).thenReturn(RequestResult.of(dm2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part08/Part08Step06ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part08/Part08Step06ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -50,7 +50,7 @@ public class Part08Step06ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -87,7 +87,7 @@ public class Part08Step06ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -96,7 +96,7 @@ public class Part08Step06ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -106,7 +106,7 @@ public class Part08Step06ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -140,19 +140,19 @@ public class Part08Step06ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(DM2PreviouslyActiveDTC.create(0, OFF, OFF, OFF, OFF, dtc3), 8);
         dataRepository.putObdModule(obdModuleInformation);
         var dm5_0 = DM5DiagnosticReadinessPacket.create(0, 2, 1, 0x22);
-        when(diagnosticMessageModule.requestDM5(any(), eq(0))).thenReturn(BusResult.of(dm5_0));
+        when(communicationsModule.requestDM5(any(), eq(0))).thenReturn(BusResult.of(dm5_0));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var dm5_1 = DM5DiagnosticReadinessPacket.create(1, 0xFF, 0, 0x22);
-        when(diagnosticMessageModule.requestDM5(any(), eq(1))).thenReturn(BusResult.of(dm5_1));
+        when(communicationsModule.requestDM5(any(), eq(1))).thenReturn(BusResult.of(dm5_1));
 
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(RequestResult.of(dm5_0, dm5_1));
+        when(communicationsModule.requestDM5(any())).thenReturn(RequestResult.of(dm5_0, dm5_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any());
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM5(any(), eq(1));
+        verify(communicationsModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any(), eq(0));
+        verify(communicationsModule).requestDM5(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -169,13 +169,13 @@ public class Part08Step06ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm5 = DM5DiagnosticReadinessPacket.create(0, 1, 1, 0x22);
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(RequestResult.of(dm5));
-        when(diagnosticMessageModule.requestDM5(any(), eq(0))).thenReturn(BusResult.of(dm5));
+        when(communicationsModule.requestDM5(any())).thenReturn(RequestResult.of(dm5));
+        when(communicationsModule.requestDM5(any(), eq(0))).thenReturn(BusResult.of(dm5));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any());
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0));
+        verify(communicationsModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -196,13 +196,13 @@ public class Part08Step06ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm5 = DM5DiagnosticReadinessPacket.create(0, 2, 2, 0x22);
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(RequestResult.of(dm5));
-        when(diagnosticMessageModule.requestDM5(any(), eq(0))).thenReturn(BusResult.of(dm5));
+        when(communicationsModule.requestDM5(any())).thenReturn(RequestResult.of(dm5));
+        when(communicationsModule.requestDM5(any(), eq(0))).thenReturn(BusResult.of(dm5));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any());
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0));
+        verify(communicationsModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -224,14 +224,14 @@ public class Part08Step06ControllerTest extends AbstractControllerTest {
 
         var dm5_1 = DM5DiagnosticReadinessPacket.create(0, 2, 1, 0x22);
 
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(RequestResult.of(dm5_1));
+        when(communicationsModule.requestDM5(any())).thenReturn(RequestResult.of(dm5_1));
         var dm5_2 = DM5DiagnosticReadinessPacket.create(0, 1, 2, 0x22);
-        when(diagnosticMessageModule.requestDM5(any(), eq(0))).thenReturn(BusResult.of(dm5_2));
+        when(communicationsModule.requestDM5(any(), eq(0))).thenReturn(BusResult.of(dm5_2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any());
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0));
+        verify(communicationsModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part08/Part08Step07ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part08/Part08Step07ControllerTest.java
@@ -32,7 +32,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -54,7 +54,7 @@ public class Part08Step07ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -91,7 +91,7 @@ public class Part08Step07ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -100,7 +100,7 @@ public class Part08Step07ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -110,7 +110,7 @@ public class Part08Step07ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -141,18 +141,18 @@ public class Part08Step07ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc), 8);
         dataRepository.putObdModule(obdModuleInformation);
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM28(any())).thenReturn(RequestResult.of(dm28));
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any())).thenReturn(RequestResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM28(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM28(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any());
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM28(any(), eq(1));
+        verify(communicationsModule).requestDM28(any());
+        verify(communicationsModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -165,13 +165,13 @@ public class Part08Step07ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF), 8);
         dataRepository.putObdModule(obdModuleInformation);
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM28(any())).thenReturn(RequestResult.of(dm28));
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any())).thenReturn(RequestResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any());
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any());
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -190,13 +190,13 @@ public class Part08Step07ControllerTest extends AbstractControllerTest {
 
         var dtc2 = DiagnosticTroubleCode.create(234, 1, 0, 1);
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc2);
-        when(diagnosticMessageModule.requestDM28(any())).thenReturn(RequestResult.of(dm28));
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any())).thenReturn(RequestResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any());
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any());
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -213,13 +213,13 @@ public class Part08Step07ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc), 8);
         dataRepository.putObdModule(obdModuleInformation);
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM28(any())).thenReturn(RequestResult.of(dm28));
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any())).thenReturn(RequestResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any());
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any());
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -238,13 +238,13 @@ public class Part08Step07ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc1, dtc2), 8);
         dataRepository.putObdModule(obdModuleInformation);
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc1, dtc2);
-        when(diagnosticMessageModule.requestDM28(any())).thenReturn(RequestResult.of(dm28));
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any())).thenReturn(RequestResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any());
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any());
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -261,7 +261,7 @@ public class Part08Step07ControllerTest extends AbstractControllerTest {
         obdModuleInformation0.set(DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc_0), 8);
         dataRepository.putObdModule(obdModuleInformation0);
         var dm28_0 = DM28PermanentEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc_0);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28_0));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28_0));
 
         OBDModuleInformation obdModuleInformation1 = new OBDModuleInformation(1);
         var dtc_1 = DiagnosticTroubleCode.create(234, 1, 0, 1);
@@ -269,15 +269,15 @@ public class Part08Step07ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation1);
         var dm28_1 = DM28PermanentEmissionDTCPacket.create(1, ON, OFF, OFF, OFF, dtc_1);
 
-        when(diagnosticMessageModule.requestDM28(any(), eq(1))).thenReturn(BusResult.of(dm28_1));
+        when(communicationsModule.requestDM28(any(), eq(1))).thenReturn(BusResult.of(dm28_1));
 
-        when(diagnosticMessageModule.requestDM28(any())).thenReturn(RequestResult.of(dm28_0, dm28_1));
+        when(communicationsModule.requestDM28(any())).thenReturn(RequestResult.of(dm28_0, dm28_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any());
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM28(any(), eq(1));
+        verify(communicationsModule).requestDM28(any());
+        verify(communicationsModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -295,14 +295,14 @@ public class Part08Step07ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc), 8);
         dataRepository.putObdModule(obdModuleInformation);
         var dm28_1 = DM28PermanentEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM28(any())).thenReturn(RequestResult.of(dm28_1));
+        when(communicationsModule.requestDM28(any())).thenReturn(RequestResult.of(dm28_1));
         var dm28_2 = DM28PermanentEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28_2));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28_2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any());
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any());
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -319,17 +319,17 @@ public class Part08Step07ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc), 8);
         dataRepository.putObdModule(obdModuleInformation);
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM28(any())).thenReturn(RequestResult.of(dm28));
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any())).thenReturn(RequestResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
-        when(diagnosticMessageModule.requestDM28(any(), eq(1))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM28(any(), eq(1))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any());
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM28(any(), eq(1));
+        verify(communicationsModule).requestDM28(any());
+        verify(communicationsModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part08/Part08Step08ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part08/Part08Step08ControllerTest.java
@@ -31,7 +31,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -53,7 +53,7 @@ public class Part08Step08ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -90,7 +90,7 @@ public class Part08Step08ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -99,7 +99,7 @@ public class Part08Step08ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -109,7 +109,7 @@ public class Part08Step08ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -147,11 +147,11 @@ public class Part08Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var dm29_1 = DM29DtcCounts.create(1, 0, 0, 0xFF, 0, 0, 0);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0, dm29_1));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0, dm29_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -161,11 +161,11 @@ public class Part08Step08ControllerTest extends AbstractControllerTest {
     @Test
     public void testNoResponse() {
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -191,11 +191,11 @@ public class Part08Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
         var dm29 = DM29DtcCounts.create(0, 0, 1, 0, 1, 1, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -216,11 +216,11 @@ public class Part08Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
         var dm29 = DM29DtcCounts.create(0, 0, 0, 0, 0, 1, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -238,11 +238,11 @@ public class Part08Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
         var dm29 = DM29DtcCounts.create(0, 0, 0, 0, 1, 1, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -263,11 +263,11 @@ public class Part08Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
         var dm29 = DM29DtcCounts.create(0, 0, 0, 0, 1, 0, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -288,11 +288,11 @@ public class Part08Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
         var dm29 = DM29DtcCounts.create(0, 0, 0, 0, 1, 1, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -313,11 +313,11 @@ public class Part08Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
         var dm29 = DM29DtcCounts.create(0, 0, 0, 0, 1, 1, 0);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -338,11 +338,11 @@ public class Part08Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
         var dm29 = DM29DtcCounts.create(0, 0, 0, 0, 1, 1, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -363,11 +363,11 @@ public class Part08Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
         var dm29 = DM29DtcCounts.create(0, 0, 0, 1, 1, 1, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -387,11 +387,11 @@ public class Part08Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
         var dm29 = DM29DtcCounts.create(0, 0, 0, 0, 1, 1, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -413,11 +413,11 @@ public class Part08Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
         var dm29 = DM29DtcCounts.create(0, 0, 0, 0, 2, 1, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -447,11 +447,11 @@ public class Part08Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation1);
         var dm29_1 = DM29DtcCounts.create(1, 0, 0, 0, 1, 0, 0);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0, dm29_1));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0, dm29_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -473,11 +473,11 @@ public class Part08Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
         var dm29 = DM29DtcCounts.create(0, 0, 0, 0, 1, 2, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -507,11 +507,11 @@ public class Part08Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation1);
         var dm29_1 = DM29DtcCounts.create(1, 0, 0, 0, 0, 1, 0);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0, dm29_1));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0, dm29_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -533,11 +533,11 @@ public class Part08Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
         var dm29 = DM29DtcCounts.create(0, 0, 0, 0, 1, 1, 2);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -567,11 +567,11 @@ public class Part08Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation1);
         var dm29_1 = DM29DtcCounts.create(1, 0, 0, 0, 0, 0, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0, dm29_1));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0, dm29_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part08/Part08Step09ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part08/Part08Step09ControllerTest.java
@@ -30,7 +30,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -52,7 +52,7 @@ public class Part08Step09ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -89,7 +89,7 @@ public class Part08Step09ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -98,7 +98,7 @@ public class Part08Step09ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -108,7 +108,7 @@ public class Part08Step09ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -148,11 +148,11 @@ public class Part08Step09ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var dm31_1 = DM31DtcToLampAssociation.create(1, 0);
 
-        when(diagnosticMessageModule.requestDM31(any())).thenReturn(RequestResult.of(dm31_0, dm31_1));
+        when(communicationsModule.requestDM31(any())).thenReturn(RequestResult.of(dm31_0, dm31_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any());
+        verify(communicationsModule).requestDM31(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -161,11 +161,11 @@ public class Part08Step09ControllerTest extends AbstractControllerTest {
 
     @Test
     public void testNoResponses() {
-        when(diagnosticMessageModule.requestDM31(any())).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM31(any())).thenReturn(RequestResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any());
+        verify(communicationsModule).requestDM31(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -186,11 +186,11 @@ public class Part08Step09ControllerTest extends AbstractControllerTest {
         var lampStatus3 = DTCLampStatus.create(dtc3, OFF, OFF, OFF, OFF);
         var dm31 = DM31DtcToLampAssociation.create(0, 0, lampStatus1, lampStatus2, lampStatus3);
 
-        when(diagnosticMessageModule.requestDM31(any())).thenReturn(RequestResult.of(dm31));
+        when(communicationsModule.requestDM31(any())).thenReturn(RequestResult.of(dm31));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any());
+        verify(communicationsModule).requestDM31(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -213,11 +213,11 @@ public class Part08Step09ControllerTest extends AbstractControllerTest {
         var lampStatus2 = DTCLampStatus.create(dtc2, OFF, OFF, OFF, OFF);
         var dm31 = DM31DtcToLampAssociation.create(0, 0, lampStatus1, lampStatus2);
 
-        when(diagnosticMessageModule.requestDM31(any())).thenReturn(RequestResult.of(dm31));
+        when(communicationsModule.requestDM31(any())).thenReturn(RequestResult.of(dm31));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any());
+        verify(communicationsModule).requestDM31(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -240,11 +240,11 @@ public class Part08Step09ControllerTest extends AbstractControllerTest {
         var lampStatus2 = DTCLampStatus.create(dtc2, OFF, NOT_SUPPORTED, OFF, OFF);
         var dm31 = DM31DtcToLampAssociation.create(0, 0, lampStatus1, lampStatus2);
 
-        when(diagnosticMessageModule.requestDM31(any())).thenReturn(RequestResult.of(dm31));
+        when(communicationsModule.requestDM31(any())).thenReturn(RequestResult.of(dm31));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any());
+        verify(communicationsModule).requestDM31(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part08/Part08Step10ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part08/Part08Step10ControllerTest.java
@@ -33,7 +33,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -55,7 +55,7 @@ public class Part08Step10ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -92,7 +92,7 @@ public class Part08Step10ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -101,7 +101,7 @@ public class Part08Step10ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -111,7 +111,7 @@ public class Part08Step10ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -148,21 +148,21 @@ public class Part08Step10ControllerTest extends AbstractControllerTest {
         var ff2 = new FreezeFrame(dtc2, new int[0]);
 
         var dm25_0 = DM25ExpandedFreezeFrame.create(0, ff1, ff2);
-        when(diagnosticMessageModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25_0));
+        when(communicationsModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25_0));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM25(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM25(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         dataRepository.putObdModule(new OBDModuleInformation(2));
         var dm25_2 = DM25ExpandedFreezeFrame.create(2);
-        when(diagnosticMessageModule.requestDM25(any(), eq(2))).thenReturn(BusResult.of(dm25_2));
+        when(communicationsModule.requestDM25(any(), eq(2))).thenReturn(BusResult.of(dm25_2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM25(any(), eq(1));
-        verify(diagnosticMessageModule).requestDM25(any(), eq(2));
+        verify(communicationsModule).requestDM25(any(), eq(0));
+        verify(communicationsModule).requestDM25(any(), eq(1));
+        verify(communicationsModule).requestDM25(any(), eq(2));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -184,11 +184,11 @@ public class Part08Step10ControllerTest extends AbstractControllerTest {
         var ff3 = new FreezeFrame(dtc3, new int[0]);
 
         var dm25_0 = DM25ExpandedFreezeFrame.create(0, ff1, ff2, ff3);
-        when(diagnosticMessageModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25_0));
+        when(communicationsModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(0));
+        verify(communicationsModule).requestDM25(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -203,11 +203,11 @@ public class Part08Step10ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
         var dm25 = DM25ExpandedFreezeFrame.create(0);
-        when(diagnosticMessageModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
+        when(communicationsModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(0));
+        verify(communicationsModule).requestDM25(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -231,15 +231,15 @@ public class Part08Step10ControllerTest extends AbstractControllerTest {
         var ff2 = new FreezeFrame(dtc2, new int[0]);
 
         var dm25_0 = DM25ExpandedFreezeFrame.create(0, ff1, ff2);
-        when(diagnosticMessageModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25_0));
+        when(communicationsModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25_0));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
-        when(diagnosticMessageModule.requestDM25(any(), eq(1))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM25(any(), eq(1))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM25(any(), eq(1));
+        verify(communicationsModule).requestDM25(any(), eq(0));
+        verify(communicationsModule).requestDM25(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -261,11 +261,11 @@ public class Part08Step10ControllerTest extends AbstractControllerTest {
 
         var ff1 = new FreezeFrame(dtc1, new int[0]);
         var dm25 = DM25ExpandedFreezeFrame.create(0, ff1);
-        when(diagnosticMessageModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
+        when(communicationsModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(0));
+        verify(communicationsModule).requestDM25(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part08/Part08Step11ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part08/Part08Step11ControllerTest.java
@@ -24,7 +24,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -46,7 +46,7 @@ public class Part08Step11ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -83,7 +83,7 @@ public class Part08Step11ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -92,7 +92,7 @@ public class Part08Step11ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -102,7 +102,7 @@ public class Part08Step11ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -146,22 +146,22 @@ public class Part08Step11ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm30_1 = DM30ScaledTestResultsPacket.create(0, 0, str1);
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0),
-                                                        eq(247),
-                                                        eq(spn1),
-                                                        eq(31))).thenReturn(List.of(dm30_1));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0),
+                                                     eq(247),
+                                                     eq(spn1),
+                                                     eq(31))).thenReturn(List.of(dm30_1));
 
         var dm30_2 = DM30ScaledTestResultsPacket.create(0, 0, str2);
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0),
-                                                        eq(247),
-                                                        eq(spn2),
-                                                        eq(31))).thenReturn(List.of(dm30_2));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0),
+                                                     eq(247),
+                                                     eq(spn2),
+                                                     eq(31))).thenReturn(List.of(dm30_2));
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(247), eq(spn1), eq(31));
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(247), eq(spn2), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(247), eq(spn1), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(247), eq(spn2), eq(31));
 
         var nonInitializedTests = dataRepository.getObdModule(0).getNonInitializedTests();
         assertEquals(1, nonInitializedTests.size());

--- a/src-test/org/etools/j1939_84/controllers/part08/Part08Step12ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part08/Part08Step12ControllerTest.java
@@ -45,7 +45,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -67,7 +67,7 @@ public class Part08Step12ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -107,7 +107,7 @@ public class Part08Step12ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               verifier);
 
         setup(instance,
@@ -117,7 +117,7 @@ public class Part08Step12ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -127,7 +127,7 @@ public class Part08Step12ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener,
                                  verifier);
     }
@@ -162,36 +162,36 @@ public class Part08Step12ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var dm22_1 = create(1, 0, CLR_ACT_NACK, GENERAL_NACK, 0x7FFFF, 31);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(1),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(BusResult.of(dm22_1));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(1),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(BusResult.of(dm22_1));
 
         var dm22_0 = create(0, 0, CLR_PA_NACK, GENERAL_NACK, 123, 10);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(0),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(123),
-                                                 eq(10))).thenReturn(BusResult.of(dm22_0));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(0),
+                                              eq(CLR_PA_REQ),
+                                              eq(123),
+                                              eq(10))).thenReturn(BusResult.of(dm22_0));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(0), eq(CLR_PA_REQ), eq(123), eq(10));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(0), eq(CLR_PA_REQ), eq(123), eq(10));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.8.12.10.d"));
 
@@ -205,28 +205,28 @@ public class Part08Step12ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var dm22_1 = create(1, 0, CLR_PA_ACK, NOT_SUPPORTED, 0x7FFFF, 31);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(1),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(BusResult.of(dm22_1));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(1),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(BusResult.of(dm22_1));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.8.12.10.d"));
 
@@ -248,28 +248,28 @@ public class Part08Step12ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var dm22_1 = create(1, 0, CLR_ACT_ACK, NOT_SUPPORTED, 0x7FFFF, 31);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(1),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(BusResult.of(dm22_1));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(1),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(BusResult.of(dm22_1));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.8.12.10.d"));
 
@@ -291,28 +291,28 @@ public class Part08Step12ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var ack = AcknowledgmentPacket.create(1, ACK);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(1),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(BusResult.of(ack));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(1),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(BusResult.of(ack));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.8.12.10.d"));
 
@@ -334,28 +334,28 @@ public class Part08Step12ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var dm22_1 = create(1, 0, CLR_ACT_NACK, ACCESS_DENIED, 0x7FFFF, 31);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(1),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(BusResult.of(dm22_1));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(1),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(BusResult.of(dm22_1));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.8.12.10.d"));
 
@@ -377,28 +377,28 @@ public class Part08Step12ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var dm22_1 = create(1, 0, CLR_PA_NACK, ACCESS_DENIED, 0x7FFFF, 31);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(1),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(BusResult.of(dm22_1));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(1),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(BusResult.of(dm22_1));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.8.12.10.d"));
 
@@ -420,28 +420,28 @@ public class Part08Step12ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(1),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(1),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(BusResult.of(nack));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.8.12.10.d"));
 
@@ -466,28 +466,28 @@ public class Part08Step12ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm22_0 = create(0, 0, CLR_PA_ACK, NOT_SUPPORTED, 123, 10);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(0),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(123),
-                                                 eq(10))).thenReturn(BusResult.of(dm22_0));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(0),
+                                              eq(CLR_PA_REQ),
+                                              eq(123),
+                                              eq(10))).thenReturn(BusResult.of(dm22_0));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(0), eq(CLR_PA_REQ), eq(123), eq(10));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(0), eq(CLR_PA_REQ), eq(123), eq(10));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.8.12.10.d"));
 
@@ -512,28 +512,28 @@ public class Part08Step12ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm22_0 = create(0, 0, CLR_ACT_ACK, NOT_SUPPORTED, 123, 10);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(0),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(123),
-                                                 eq(10))).thenReturn(BusResult.of(dm22_0));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(0),
+                                              eq(CLR_PA_REQ),
+                                              eq(123),
+                                              eq(10))).thenReturn(BusResult.of(dm22_0));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(0), eq(CLR_PA_REQ), eq(123), eq(10));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(0), eq(CLR_PA_REQ), eq(123), eq(10));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.8.12.10.d"));
 
@@ -558,28 +558,28 @@ public class Part08Step12ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var ack = AcknowledgmentPacket.create(0, ACK);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(0),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(123),
-                                                 eq(10))).thenReturn(BusResult.of(ack));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(0),
+                                              eq(CLR_PA_REQ),
+                                              eq(123),
+                                              eq(10))).thenReturn(BusResult.of(ack));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(0), eq(CLR_PA_REQ), eq(123), eq(10));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(0), eq(CLR_PA_REQ), eq(123), eq(10));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.8.12.10.d"));
 
@@ -604,28 +604,28 @@ public class Part08Step12ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm22_0 = create(0, 0, CLR_ACT_NACK, ACCESS_DENIED, 123, 10);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(0),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(123),
-                                                 eq(10))).thenReturn(BusResult.of(dm22_0));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(0),
+                                              eq(CLR_PA_REQ),
+                                              eq(123),
+                                              eq(10))).thenReturn(BusResult.of(dm22_0));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(0), eq(CLR_PA_REQ), eq(123), eq(10));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(0), eq(CLR_PA_REQ), eq(123), eq(10));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.8.12.10.d"));
 
@@ -650,28 +650,28 @@ public class Part08Step12ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var nack = AcknowledgmentPacket.create(0, NACK);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(0),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(123),
-                                                 eq(10))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(0),
+                                              eq(CLR_PA_REQ),
+                                              eq(123),
+                                              eq(10))).thenReturn(BusResult.of(nack));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(0), eq(CLR_PA_REQ), eq(123), eq(10));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(0), eq(CLR_PA_REQ), eq(123), eq(10));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.8.12.10.d"));
 
@@ -693,21 +693,21 @@ public class Part08Step12ControllerTest extends AbstractControllerTest {
 
         var dm22_0 = create(0, 0, CLR_PA_ACK, NOT_SUPPORTED, 0x7FFFF, 31);
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.of(dm22_0));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.of(dm22_0));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.8.12.10.d"));
 
@@ -725,21 +725,21 @@ public class Part08Step12ControllerTest extends AbstractControllerTest {
 
         var dm22_0 = create(0, 0, CLR_ACT_ACK, NOT_SUPPORTED, 0x7FFFF, 31);
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.of(dm22_0));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.of(dm22_0));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.8.12.10.d"));
 
@@ -755,21 +755,21 @@ public class Part08Step12ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForACK() {
         var ack = AcknowledgmentPacket.create(0, ACK);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(new RequestResult<>(false, ack));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(new RequestResult<>(false, ack));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.8.12.10.d"));
 
@@ -787,21 +787,21 @@ public class Part08Step12ControllerTest extends AbstractControllerTest {
 
         var dm22_0 = create(0, 0, CLR_ACT_NACK, NOT_SUPPORTED, 0x7FFFF, 31);
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.of(dm22_0));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.of(dm22_0));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.8.12.10.d"));
 
@@ -819,21 +819,21 @@ public class Part08Step12ControllerTest extends AbstractControllerTest {
 
         var dm22_0 = create(0, 0, CLR_PA_NACK, NOT_SUPPORTED, 0x7FFFF, 31);
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.of(dm22_0));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.of(dm22_0));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.8.12.10.d"));
 
@@ -851,21 +851,21 @@ public class Part08Step12ControllerTest extends AbstractControllerTest {
 
         var dm22_0 = create(0, 0, CLR_PA_ACK, NOT_SUPPORTED, 0x7FFFF, 31);
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.of(dm22_0));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.of(dm22_0));
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.8.12.10.d"));
 
@@ -883,21 +883,21 @@ public class Part08Step12ControllerTest extends AbstractControllerTest {
 
         var dm22_0 = create(0, 0, CLR_ACT_ACK, NOT_SUPPORTED, 0x7FFFF, 31);
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.of(dm22_0));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.of(dm22_0));
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.8.12.10.d"));
 
@@ -914,21 +914,21 @@ public class Part08Step12ControllerTest extends AbstractControllerTest {
     public void testFailureForACK4() {
         var ack = AcknowledgmentPacket.create(0, ACK);
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(new RequestResult<>(false, ack));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(new RequestResult<>(false, ack));
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.8.12.10.d"));
 
@@ -946,21 +946,21 @@ public class Part08Step12ControllerTest extends AbstractControllerTest {
 
         var dm22_0 = create(0, 0, CLR_ACT_NACK, UNKNOWN_DTC, 0x7FFFF, 31);
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.of());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.of());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.of(dm22_0));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.of(dm22_0));
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.8.12.10.d"));
 
@@ -978,21 +978,21 @@ public class Part08Step12ControllerTest extends AbstractControllerTest {
 
         var dm22_0 = create(0, 0, CLR_PA_NACK, DTC_NOT_PA, 0x7FFFF, 31);
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.of());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.of());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.of(dm22_0));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.of(dm22_0));
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.8.12.10.d"));
 

--- a/src-test/org/etools/j1939_84/controllers/part08/Part08Step13ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part08/Part08Step13ControllerTest.java
@@ -27,7 +27,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -49,7 +49,7 @@ public class Part08Step13ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -92,7 +92,7 @@ public class Part08Step13ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               verifier);
 
         setup(instance,
@@ -102,7 +102,7 @@ public class Part08Step13ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -112,7 +112,7 @@ public class Part08Step13ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener,
                                  verifier);
     }
@@ -142,14 +142,14 @@ public class Part08Step13ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
         var nack = AcknowledgmentPacket.create(0, NACK);
-        when(diagnosticMessageModule.requestDM3(any(), eq(0))).thenReturn(List.of(nack));
+        when(communicationsModule.requestDM3(any(), eq(0))).thenReturn(List.of(nack));
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
 
-        verify(diagnosticMessageModule).requestDM3(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM3(any());
+        verify(communicationsModule).requestDM3(any(), eq(0));
+        verify(communicationsModule).requestDM3(any());
 
         verify(verifier).verifyDataNotErased(any(), eq("6.8.13.2.a"));
         verify(verifier).verifyDataNotErased(any(), eq("6.8.13.4.a"));
@@ -177,16 +177,16 @@ public class Part08Step13ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var nack = AcknowledgmentPacket.create(0, ACK);
-        when(diagnosticMessageModule.requestDM3(any(), eq(0))).thenReturn(List.of(nack));
-        when(diagnosticMessageModule.requestDM3(any(), eq(1))).thenReturn(List.of());
+        when(communicationsModule.requestDM3(any(), eq(0))).thenReturn(List.of(nack));
+        when(communicationsModule.requestDM3(any(), eq(1))).thenReturn(List.of());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
 
-        verify(diagnosticMessageModule).requestDM3(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM3(any(), eq(1));
-        verify(diagnosticMessageModule).requestDM3(any());
+        verify(communicationsModule).requestDM3(any(), eq(0));
+        verify(communicationsModule).requestDM3(any(), eq(1));
+        verify(communicationsModule).requestDM3(any());
 
         verify(verifier).verifyDataNotErased(any(), eq("6.8.13.2.a"));
         verify(verifier).verifyDataNotErased(any(), eq("6.8.13.4.a"));

--- a/src-test/org/etools/j1939_84/controllers/part08/Part08Step14ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part08/Part08Step14ControllerTest.java
@@ -24,7 +24,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -46,7 +46,7 @@ public class Part08Step14ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -83,7 +83,7 @@ public class Part08Step14ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -92,7 +92,7 @@ public class Part08Step14ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -102,7 +102,7 @@ public class Part08Step14ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -137,23 +137,23 @@ public class Part08Step14ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var dm30_123 = DM30ScaledTestResultsPacket.create(0, 0, str1);
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0),
-                                                        eq(250),
-                                                        eq(123),
-                                                        eq(14))).thenReturn(List.of(dm30_123));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0),
+                                                     eq(250),
+                                                     eq(123),
+                                                     eq(14))).thenReturn(List.of(dm30_123));
 
         var dm30_456 = DM30ScaledTestResultsPacket.create(0, 0, str2);
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0),
-                                                        eq(250),
-                                                        eq(456),
-                                                        eq(3))).thenReturn(List.of(dm30_456));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0),
+                                                     eq(250),
+                                                     eq(456),
+                                                     eq(3))).thenReturn(List.of(dm30_456));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(250), eq(123), eq(14));
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(250), eq(456), eq(3));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(250), eq(123), eq(14));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(250), eq(456), eq(3));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -171,15 +171,15 @@ public class Part08Step14ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var dm30_123 = DM30ScaledTestResultsPacket.create(0, 0, str2);
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0),
-                                                        eq(250),
-                                                        eq(123),
-                                                        eq(14))).thenReturn(List.of(dm30_123));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0),
+                                                     eq(250),
+                                                     eq(123),
+                                                     eq(14))).thenReturn(List.of(dm30_123));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(250), eq(123), eq(14));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(250), eq(123), eq(14));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part08/Part08Step15ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part08/Part08Step15ControllerTest.java
@@ -26,7 +26,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -48,7 +48,7 @@ public class Part08Step15ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -85,7 +85,7 @@ public class Part08Step15ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -94,7 +94,7 @@ public class Part08Step15ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -104,7 +104,7 @@ public class Part08Step15ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -132,16 +132,16 @@ public class Part08Step15ControllerTest extends AbstractControllerTest {
     public void testHappyPathNoFailures() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm26 = DM26TripDiagnosticReadinessPacket.create(0, 234, 6);
-        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
+        when(communicationsModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM26(any(), eq(1))).thenReturn(new RequestResult<>(false, nack));
+        when(communicationsModule.requestDM26(any(), eq(1))).thenReturn(new RequestResult<>(false, nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM26(any(), eq(1));
+        verify(communicationsModule).requestDM26(any(), eq(0));
+        verify(communicationsModule).requestDM26(any(), eq(1));
 
         assertEquals(dm26, dataRepository.getObdModule(0).getLatest(DM26TripDiagnosticReadinessPacket.class));
 
@@ -153,11 +153,11 @@ public class Part08Step15ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForNoNACK() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
-        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of());
+        when(communicationsModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
+        verify(communicationsModule).requestDM26(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part08/Part08Step16ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part08/Part08Step16ControllerTest.java
@@ -27,7 +27,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -50,7 +50,7 @@ public class Part08Step16ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -84,7 +84,7 @@ public class Part08Step16ControllerTest extends AbstractControllerTest {
                                               DataRepository.newInstance(),
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -93,7 +93,7 @@ public class Part08Step16ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -103,7 +103,7 @@ public class Part08Step16ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09ControllerTest.java
@@ -24,7 +24,7 @@ public class Part09ControllerTest extends AbstractPartControllerTest {
                                         DataRepository.newInstance(),
                                         engineSpeedModule,
                                         vehicleInformationModule,
-                                        diagnosticMessageModule,
+                                        communicationsModule,
                                         step01Controller,
                                         step02Controller,
                                         step03Controller,

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step01ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step01ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -51,7 +51,7 @@ public class Part09Step01ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -85,7 +85,7 @@ public class Part09Step01ControllerTest extends AbstractControllerTest {
                                               DataRepository.newInstance(),
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -94,7 +94,7 @@ public class Part09Step01ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -104,7 +104,7 @@ public class Part09Step01ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step02ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step02ControllerTest.java
@@ -29,7 +29,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -51,7 +51,7 @@ public class Part09Step02ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -88,7 +88,7 @@ public class Part09Step02ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -97,7 +97,7 @@ public class Part09Step02ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -107,7 +107,7 @@ public class Part09Step02ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -146,13 +146,13 @@ public class Part09Step02ControllerTest extends AbstractControllerTest {
         var nack = AcknowledgmentPacket.create(1, NACK);
 
         var dm12_1 = DM12MILOnEmissionDTCPacket.create(0x17, ON, ON, ON, ON);
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(new RequestResult<>(false,
-                                                                                        List.of(dm12_0, dm12_1),
-                                                                                        List.of(nack)));
+        when(communicationsModule.requestDM12(any())).thenReturn(new RequestResult<>(false,
+                                                                                     List.of(dm12_0, dm12_1),
+                                                                                     List.of(nack)));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any());
 
         assertEquals(dm12_0, dataRepository.getObdModule(0).getLatest(DM12MILOnEmissionDTCPacket.class));
         assertEquals("", listener.getMessages());
@@ -163,11 +163,11 @@ public class Part09Step02ControllerTest extends AbstractControllerTest {
     @Test
     public void testNoResponses() {
 
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM12(any())).thenReturn(RequestResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -190,11 +190,11 @@ public class Part09Step02ControllerTest extends AbstractControllerTest {
 
         var dtc2 = DiagnosticTroubleCode.create(123, 12, 0, 1);
         var dm12 = DM12MILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc2);
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(RequestResult.of(dm12));
+        when(communicationsModule.requestDM12(any())).thenReturn(RequestResult.of(dm12));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -211,11 +211,11 @@ public class Part09Step02ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm12 = DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(RequestResult.of(dm12));
+        when(communicationsModule.requestDM12(any())).thenReturn(RequestResult.of(dm12));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -234,11 +234,11 @@ public class Part09Step02ControllerTest extends AbstractControllerTest {
 
         var dtc2 = DiagnosticTroubleCode.create(456, 12, 0, 1);
         var dm12 = DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc2);
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(RequestResult.of(dm12));
+        when(communicationsModule.requestDM12(any())).thenReturn(RequestResult.of(dm12));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -257,11 +257,11 @@ public class Part09Step02ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm12 = DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc1, dtc2);
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(RequestResult.of(dm12));
+        when(communicationsModule.requestDM12(any())).thenReturn(RequestResult.of(dm12));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -285,11 +285,11 @@ public class Part09Step02ControllerTest extends AbstractControllerTest {
 
         var dm12_0 = DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc1);
         var dm12_1 = DM12MILOnEmissionDTCPacket.create(1, ON, OFF, OFF, OFF, dtc2);
-        when(diagnosticMessageModule.requestDM12(any())).thenReturn(RequestResult.of(dm12_0, dm12_1));
+        when(communicationsModule.requestDM12(any())).thenReturn(RequestResult.of(dm12_0, dm12_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any());
+        verify(communicationsModule).requestDM12(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step03ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step03ControllerTest.java
@@ -45,7 +45,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -67,7 +67,7 @@ public class Part09Step03ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -107,7 +107,7 @@ public class Part09Step03ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               verifier);
 
         setup(instance,
@@ -117,7 +117,7 @@ public class Part09Step03ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -127,7 +127,7 @@ public class Part09Step03ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener,
                                  verifier);
     }
@@ -162,36 +162,36 @@ public class Part09Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var dm22_1 = create(1, 0, CLR_ACT_NACK, GENERAL_NACK, 0x7FFFF, 31);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(1),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(BusResult.of(dm22_1));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(1),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(BusResult.of(dm22_1));
 
         var dm22_0 = create(0, 0, CLR_PA_NACK, GENERAL_NACK, 123, 10);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(0),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(123),
-                                                 eq(10))).thenReturn(BusResult.of(dm22_0));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(0),
+                                              eq(CLR_PA_REQ),
+                                              eq(123),
+                                              eq(10))).thenReturn(BusResult.of(dm22_0));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(0), eq(CLR_PA_REQ), eq(123), eq(10));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(0), eq(CLR_PA_REQ), eq(123), eq(10));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.9.3.10.d"));
 
@@ -205,28 +205,28 @@ public class Part09Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var dm22_1 = create(1, 0, CLR_PA_ACK, NOT_SUPPORTED, 0x7FFFF, 31);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(1),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(BusResult.of(dm22_1));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(1),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(BusResult.of(dm22_1));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.9.3.10.d"));
 
@@ -248,28 +248,28 @@ public class Part09Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var dm22_1 = create(1, 0, CLR_ACT_ACK, NOT_SUPPORTED, 0x7FFFF, 31);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(1),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(BusResult.of(dm22_1));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(1),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(BusResult.of(dm22_1));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.9.3.10.d"));
 
@@ -291,28 +291,28 @@ public class Part09Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var ack = AcknowledgmentPacket.create(1, ACK);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(1),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(BusResult.of(ack));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(1),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(BusResult.of(ack));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.9.3.10.d"));
 
@@ -334,28 +334,28 @@ public class Part09Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var dm22_1 = create(1, 0, CLR_ACT_NACK, ACCESS_DENIED, 0x7FFFF, 31);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(1),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(BusResult.of(dm22_1));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(1),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(BusResult.of(dm22_1));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.9.3.10.d"));
 
@@ -377,28 +377,28 @@ public class Part09Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var dm22_1 = create(1, 0, CLR_PA_NACK, ACCESS_DENIED, 0x7FFFF, 31);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(1),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(BusResult.of(dm22_1));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(1),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(BusResult.of(dm22_1));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.9.3.10.d"));
 
@@ -420,28 +420,28 @@ public class Part09Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(1),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(1),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(BusResult.of(nack));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(1), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.9.3.10.d"));
 
@@ -466,28 +466,28 @@ public class Part09Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm22_0 = create(0, 0, CLR_PA_ACK, NOT_SUPPORTED, 123, 10);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(0),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(123),
-                                                 eq(10))).thenReturn(BusResult.of(dm22_0));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(0),
+                                              eq(CLR_PA_REQ),
+                                              eq(123),
+                                              eq(10))).thenReturn(BusResult.of(dm22_0));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(0), eq(CLR_PA_REQ), eq(123), eq(10));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(0), eq(CLR_PA_REQ), eq(123), eq(10));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.9.3.10.d"));
 
@@ -512,28 +512,28 @@ public class Part09Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm22_0 = create(0, 0, CLR_ACT_ACK, NOT_SUPPORTED, 123, 10);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(0),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(123),
-                                                 eq(10))).thenReturn(BusResult.of(dm22_0));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(0),
+                                              eq(CLR_PA_REQ),
+                                              eq(123),
+                                              eq(10))).thenReturn(BusResult.of(dm22_0));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(0), eq(CLR_PA_REQ), eq(123), eq(10));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(0), eq(CLR_PA_REQ), eq(123), eq(10));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.9.3.10.d"));
 
@@ -558,28 +558,28 @@ public class Part09Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var ack = AcknowledgmentPacket.create(0, ACK);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(0),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(123),
-                                                 eq(10))).thenReturn(BusResult.of(ack));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(0),
+                                              eq(CLR_PA_REQ),
+                                              eq(123),
+                                              eq(10))).thenReturn(BusResult.of(ack));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(0), eq(CLR_PA_REQ), eq(123), eq(10));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(0), eq(CLR_PA_REQ), eq(123), eq(10));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.9.3.10.d"));
 
@@ -604,28 +604,28 @@ public class Part09Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm22_0 = create(0, 0, CLR_ACT_NACK, ACCESS_DENIED, 123, 10);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(0),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(123),
-                                                 eq(10))).thenReturn(BusResult.of(dm22_0));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(0),
+                                              eq(CLR_PA_REQ),
+                                              eq(123),
+                                              eq(10))).thenReturn(BusResult.of(dm22_0));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(0), eq(CLR_PA_REQ), eq(123), eq(10));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(0), eq(CLR_PA_REQ), eq(123), eq(10));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.9.3.10.d"));
 
@@ -650,28 +650,28 @@ public class Part09Step03ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var nack = AcknowledgmentPacket.create(0, NACK);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(0),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(123),
-                                                 eq(10))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(0),
+                                              eq(CLR_PA_REQ),
+                                              eq(123),
+                                              eq(10))).thenReturn(BusResult.of(nack));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(0), eq(CLR_PA_REQ), eq(123), eq(10));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(0), eq(CLR_PA_REQ), eq(123), eq(10));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.9.3.10.d"));
 
@@ -693,21 +693,21 @@ public class Part09Step03ControllerTest extends AbstractControllerTest {
 
         var dm22_0 = create(0, 0, CLR_PA_ACK, NOT_SUPPORTED, 0x7FFFF, 31);
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.of(dm22_0));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.of(dm22_0));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.9.3.10.d"));
 
@@ -725,21 +725,21 @@ public class Part09Step03ControllerTest extends AbstractControllerTest {
 
         var dm22_0 = create(0, 0, CLR_ACT_ACK, NOT_SUPPORTED, 0x7FFFF, 31);
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.of(dm22_0));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.of(dm22_0));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.9.3.10.d"));
 
@@ -755,21 +755,21 @@ public class Part09Step03ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForACK() {
         var ack = AcknowledgmentPacket.create(0, ACK);
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(new RequestResult<>(false, ack));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(new RequestResult<>(false, ack));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.9.3.10.d"));
 
@@ -787,21 +787,21 @@ public class Part09Step03ControllerTest extends AbstractControllerTest {
 
         var dm22_0 = create(0, 0, CLR_ACT_NACK, NOT_SUPPORTED, 0x7FFFF, 31);
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.of(dm22_0));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.of(dm22_0));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.9.3.10.d"));
 
@@ -819,21 +819,21 @@ public class Part09Step03ControllerTest extends AbstractControllerTest {
 
         var dm22_0 = create(0, 0, CLR_PA_NACK, NOT_SUPPORTED, 0x7FFFF, 31);
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.of(dm22_0));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.of(dm22_0));
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.9.3.10.d"));
 
@@ -851,21 +851,21 @@ public class Part09Step03ControllerTest extends AbstractControllerTest {
 
         var dm22_0 = create(0, 0, CLR_PA_ACK, NOT_SUPPORTED, 0x7FFFF, 31);
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.of(dm22_0));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.of(dm22_0));
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.9.3.10.d"));
 
@@ -883,21 +883,21 @@ public class Part09Step03ControllerTest extends AbstractControllerTest {
 
         var dm22_0 = create(0, 0, CLR_ACT_ACK, NOT_SUPPORTED, 0x7FFFF, 31);
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.of(dm22_0));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.of(dm22_0));
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.9.3.10.d"));
 
@@ -914,21 +914,21 @@ public class Part09Step03ControllerTest extends AbstractControllerTest {
     public void testFailureForACK4() {
         var ack = AcknowledgmentPacket.create(0, ACK);
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(new RequestResult<>(false, ack));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(new RequestResult<>(false, ack));
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.9.3.10.d"));
 
@@ -946,21 +946,21 @@ public class Part09Step03ControllerTest extends AbstractControllerTest {
 
         var dm22_0 = create(0, 0, CLR_ACT_NACK, UNKNOWN_DTC, 0x7FFFF, 31);
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.of());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.of());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.of(dm22_0));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.of(dm22_0));
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.9.3.10.d"));
 
@@ -978,21 +978,21 @@ public class Part09Step03ControllerTest extends AbstractControllerTest {
 
         var dm22_0 = create(0, 0, CLR_PA_NACK, DTC_NOT_PA, 0x7FFFF, 31);
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_PA_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.of());
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_PA_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.of());
 
-        when(diagnosticMessageModule.requestDM22(any(),
-                                                 eq(CLR_ACT_REQ),
-                                                 eq(0x7FFFF),
-                                                 eq(31))).thenReturn(RequestResult.of(dm22_0));
+        when(communicationsModule.requestDM22(any(),
+                                              eq(CLR_ACT_REQ),
+                                              eq(0x7FFFF),
+                                              eq(31))).thenReturn(RequestResult.of(dm22_0));
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
-        verify(diagnosticMessageModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_PA_REQ), eq(0x7FFFF), eq(31));
+        verify(communicationsModule).requestDM22(any(), eq(CLR_ACT_REQ), eq(0x7FFFF), eq(31));
 
         verify(verifier).verifyDataNotErased(any(), eq("6.9.3.10.d"));
 

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step04ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step04ControllerTest.java
@@ -24,7 +24,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -46,7 +46,7 @@ public class Part09Step04ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -83,7 +83,7 @@ public class Part09Step04ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -92,7 +92,7 @@ public class Part09Step04ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -102,7 +102,7 @@ public class Part09Step04ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -132,11 +132,11 @@ public class Part09Step04ControllerTest extends AbstractControllerTest {
 
         var dm20_0 = DM20MonitorPerformanceRatioPacket.create(0, 1, 10);
         var dm20_1 = DM20MonitorPerformanceRatioPacket.create(1, 1, 10);
-        when(diagnosticMessageModule.requestDM20(any())).thenReturn(RequestResult.of(dm20_0, dm20_1));
+        when(communicationsModule.requestDM20(any())).thenReturn(RequestResult.of(dm20_0, dm20_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any());
+        verify(communicationsModule).requestDM20(any());
 
         assertSame(dm20_0, dataRepository.getObdModule(0).getLatest(DM20MonitorPerformanceRatioPacket.class));
         assertNull(dataRepository.getObdModule(1));

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step05ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step05ControllerTest.java
@@ -26,7 +26,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -48,7 +48,7 @@ public class Part09Step05ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -85,7 +85,7 @@ public class Part09Step05ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -94,7 +94,7 @@ public class Part09Step05ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -104,7 +104,7 @@ public class Part09Step05ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -132,21 +132,21 @@ public class Part09Step05ControllerTest extends AbstractControllerTest {
     public void testHappyPathNoFailures() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm21_0 = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 5, 10);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21_0));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21_0));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var dm21_1 = DM21DiagnosticReadinessPacket.create(1, 0, 0, 0, 3, 11);
-        when(diagnosticMessageModule.requestDM21(any(), eq(1))).thenReturn(BusResult.of(dm21_1));
+        when(communicationsModule.requestDM21(any(), eq(1))).thenReturn(BusResult.of(dm21_1));
 
         dataRepository.putObdModule(new OBDModuleInformation(2));
         var nack = AcknowledgmentPacket.create(2, NACK);
-        when(diagnosticMessageModule.requestDM21(any(), eq(2))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM21(any(), eq(2))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(1));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(2));
+        verify(communicationsModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(1));
+        verify(communicationsModule).requestDM21(any(), eq(2));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -157,11 +157,11 @@ public class Part09Step05ControllerTest extends AbstractControllerTest {
     public void testFailureForDistanceSCC() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm21_0 = DM21DiagnosticReadinessPacket.create(0, 0, 0, 1, 5, 10);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21_0));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -175,11 +175,11 @@ public class Part09Step05ControllerTest extends AbstractControllerTest {
     public void testFailureForTimeSCC() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm21_0 = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 5, 0);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21_0));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -206,15 +206,15 @@ public class Part09Step05ControllerTest extends AbstractControllerTest {
     public void testFailureForNoNACK() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm21_0 = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 5, 1);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21_0));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21_0));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
-        when(diagnosticMessageModule.requestDM21(any(), eq(1))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM21(any(), eq(1))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(1));
+        verify(communicationsModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -228,16 +228,16 @@ public class Part09Step05ControllerTest extends AbstractControllerTest {
     public void testWarningForTimeDifference() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm21_0 = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 5, 10);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21_0));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21_0));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var dm21_1 = DM21DiagnosticReadinessPacket.create(1, 0, 0, 0, 3, 12);
-        when(diagnosticMessageModule.requestDM21(any(), eq(1))).thenReturn(BusResult.of(dm21_1));
+        when(communicationsModule.requestDM21(any(), eq(1))).thenReturn(BusResult.of(dm21_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(1));
+        verify(communicationsModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step06ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step06ControllerTest.java
@@ -24,7 +24,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -46,7 +46,7 @@ public class Part09Step06ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -83,7 +83,7 @@ public class Part09Step06ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -92,7 +92,7 @@ public class Part09Step06ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -102,7 +102,7 @@ public class Part09Step06ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -138,23 +138,23 @@ public class Part09Step06ControllerTest extends AbstractControllerTest {
 
         ScaledTestResult str1 = ScaledTestResult.create(247, 123, 14, 0, 0, 0, 0);
         var dm30_123 = DM30ScaledTestResultsPacket.create(0, 0, str1, str2);
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0),
-                                                        eq(247),
-                                                        eq(123),
-                                                        eq(31))).thenReturn(List.of(dm30_123));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0),
+                                                     eq(247),
+                                                     eq(123),
+                                                     eq(31))).thenReturn(List.of(dm30_123));
 
         var dm30_456 = DM30ScaledTestResultsPacket.create(0, 0, str3);
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0),
-                                                        eq(247),
-                                                        eq(456),
-                                                        eq(31))).thenReturn(List.of(dm30_456));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0),
+                                                     eq(247),
+                                                     eq(456),
+                                                     eq(31))).thenReturn(List.of(dm30_456));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(247), eq(123), eq(31));
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(247), eq(456), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(247), eq(123), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(247), eq(456), eq(31));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -172,15 +172,15 @@ public class Part09Step06ControllerTest extends AbstractControllerTest {
 
         ScaledTestResult str2 = ScaledTestResult.create(247, 123, 13, 0, 0, 0, 0);
         var dm30_123 = DM30ScaledTestResultsPacket.create(0, 0, str2);
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0),
-                                                        eq(247),
-                                                        eq(123),
-                                                        eq(31))).thenReturn(List.of(dm30_123));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0),
+                                                     eq(247),
+                                                     eq(123),
+                                                     eq(31))).thenReturn(List.of(dm30_123));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(247), eq(123), eq(31));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(247), eq(123), eq(31));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step07ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step07ControllerTest.java
@@ -27,7 +27,7 @@ import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -49,7 +49,7 @@ public class Part09Step07ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -86,7 +86,7 @@ public class Part09Step07ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -95,7 +95,7 @@ public class Part09Step07ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -105,7 +105,7 @@ public class Part09Step07ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -142,11 +142,11 @@ public class Part09Step07ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
         var dm33_0 = DM33EmissionIncreasingAECDActiveTime.create(0, 0, EngineHoursTimer.create(0, 1, 1));
 
-        when(diagnosticMessageModule.requestDM33(any())).thenReturn(RequestResult.of(dm33_0));
+        when(communicationsModule.requestDM33(any())).thenReturn(RequestResult.of(dm33_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM33(any());
+        verify(communicationsModule).requestDM33(any());
 
         assertSame(dm33_0, dataRepository.getObdModule(0).getLatest(DM33EmissionIncreasingAECDActiveTime.class));
 
@@ -162,11 +162,11 @@ public class Part09Step07ControllerTest extends AbstractControllerTest {
         vehicleInformation.setFuelType(FuelType.DSL);
         dataRepository.setVehicleInformation(vehicleInformation);
 
-        when(diagnosticMessageModule.requestDM33(any())).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM33(any())).thenReturn(RequestResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM33(any());
+        verify(communicationsModule).requestDM33(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -190,11 +190,11 @@ public class Part09Step07ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var dm33_1 = DM33EmissionIncreasingAECDActiveTime.create(1, 0, EngineHoursTimer.create(0, 1, 1));
 
-        when(diagnosticMessageModule.requestDM33(any())).thenReturn(RequestResult.of(dm33_0, dm33_1));
+        when(communicationsModule.requestDM33(any())).thenReturn(RequestResult.of(dm33_0, dm33_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM33(any());
+        verify(communicationsModule).requestDM33(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -225,11 +225,11 @@ public class Part09Step07ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var dm33_1 = DM33EmissionIncreasingAECDActiveTime.create(1, 0, EngineHoursTimer.create(0, 1, 1));
 
-        when(diagnosticMessageModule.requestDM33(any())).thenReturn(RequestResult.of(dm33_0, dm33_1));
+        when(communicationsModule.requestDM33(any())).thenReturn(RequestResult.of(dm33_0, dm33_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM33(any());
+        verify(communicationsModule).requestDM33(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -260,11 +260,11 @@ public class Part09Step07ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var dm33_1 = DM33EmissionIncreasingAECDActiveTime.create(1, 0, EngineHoursTimer.create(0, 1, 1));
 
-        when(diagnosticMessageModule.requestDM33(any())).thenReturn(RequestResult.of(dm33_0, dm33_1));
+        when(communicationsModule.requestDM33(any())).thenReturn(RequestResult.of(dm33_0, dm33_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM33(any());
+        verify(communicationsModule).requestDM33(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step08ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step08ControllerTest.java
@@ -32,7 +32,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -54,7 +54,7 @@ public class Part09Step08ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -97,7 +97,7 @@ public class Part09Step08ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               verifier);
 
         setup(instance,
@@ -107,7 +107,7 @@ public class Part09Step08ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -117,7 +117,7 @@ public class Part09Step08ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener,
                                  verifier);
     }
@@ -151,17 +151,17 @@ public class Part09Step08ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
-        when(diagnosticMessageModule.requestDM11(any(), eq(0))).thenReturn(List.of());
-        when(diagnosticMessageModule.requestDM11(any(), eq(1))).thenReturn(List.of());
-        when(diagnosticMessageModule.requestDM11(any())).thenReturn(List.of());
+        when(communicationsModule.requestDM11(any(), eq(0))).thenReturn(List.of());
+        when(communicationsModule.requestDM11(any(), eq(1))).thenReturn(List.of());
+        when(communicationsModule.requestDM11(any())).thenReturn(List.of());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
 
-        verify(diagnosticMessageModule).requestDM11(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM11(any(), eq(1));
-        verify(diagnosticMessageModule).requestDM11(any());
+        verify(communicationsModule).requestDM11(any(), eq(0));
+        verify(communicationsModule).requestDM11(any(), eq(1));
+        verify(communicationsModule).requestDM11(any());
 
         verify(verifier).verifyDataNotPartialErased(any(), eq("6.9.8.2.a"), eq("6.9.8.2.b"), eq(false));
         verify(verifier).verifyDataNotPartialErased(any(), eq("6.9.8.4.a"), eq("6.9.8.4.b"), eq(false));
@@ -180,18 +180,18 @@ public class Part09Step08ControllerTest extends AbstractControllerTest {
     public void testFailureForNACK() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
-        when(diagnosticMessageModule.requestDM11(any(), eq(0))).thenReturn(List.of());
+        when(communicationsModule.requestDM11(any(), eq(0))).thenReturn(List.of());
 
         var nack_0 = AcknowledgmentPacket.create(0, NACK);
         var nack_1 = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM11(any())).thenReturn(List.of(nack_0, nack_1));
+        when(communicationsModule.requestDM11(any())).thenReturn(List.of(nack_0, nack_1));
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
 
-        verify(diagnosticMessageModule).requestDM11(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM11(any());
+        verify(communicationsModule).requestDM11(any(), eq(0));
+        verify(communicationsModule).requestDM11(any());
 
         verify(verifier).verifyDataNotPartialErased(any(), eq("6.9.8.2.a"), eq("6.9.8.2.b"), eq(false));
         verify(verifier).verifyDataNotPartialErased(any(), eq("6.9.8.4.a"), eq("6.9.8.4.b"), eq(false));
@@ -212,18 +212,18 @@ public class Part09Step08ControllerTest extends AbstractControllerTest {
     public void testWarningForACK() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
-        when(diagnosticMessageModule.requestDM11(any(), eq(0))).thenReturn(List.of());
+        when(communicationsModule.requestDM11(any(), eq(0))).thenReturn(List.of());
 
         var ack_0 = AcknowledgmentPacket.create(0, ACK);
         var ack_1 = AcknowledgmentPacket.create(1, ACK);
-        when(diagnosticMessageModule.requestDM11(any())).thenReturn(List.of(ack_0, ack_1));
+        when(communicationsModule.requestDM11(any())).thenReturn(List.of(ack_0, ack_1));
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
 
-        verify(diagnosticMessageModule).requestDM11(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM11(any());
+        verify(communicationsModule).requestDM11(any(), eq(0));
+        verify(communicationsModule).requestDM11(any());
 
         verify(verifier).verifyDataNotPartialErased(any(), eq("6.9.8.2.a"), eq("6.9.8.2.b"), eq(false));
         verify(verifier).verifyDataNotPartialErased(any(), eq("6.9.8.4.a"), eq("6.9.8.4.b"), eq(false));

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step09ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step09ControllerTest.java
@@ -26,7 +26,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -48,7 +48,7 @@ public class Part09Step09ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -85,7 +85,7 @@ public class Part09Step09ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -94,7 +94,7 @@ public class Part09Step09ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -104,7 +104,7 @@ public class Part09Step09ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -132,21 +132,21 @@ public class Part09Step09ControllerTest extends AbstractControllerTest {
     public void testHappyPathNoFailures() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm21_0 = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21_0));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21_0));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var dm21_1 = DM21DiagnosticReadinessPacket.create(1, 0, 0, 0, 0xFFFF, 0xFFFF);
-        when(diagnosticMessageModule.requestDM21(any(), eq(1))).thenReturn(BusResult.of(dm21_1));
+        when(communicationsModule.requestDM21(any(), eq(1))).thenReturn(BusResult.of(dm21_1));
 
         dataRepository.putObdModule(new OBDModuleInformation(2));
         var nack = AcknowledgmentPacket.create(2, NACK);
-        when(diagnosticMessageModule.requestDM21(any(), eq(2))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM21(any(), eq(2))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(1));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(2));
+        verify(communicationsModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(1));
+        verify(communicationsModule).requestDM21(any(), eq(2));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -157,11 +157,11 @@ public class Part09Step09ControllerTest extends AbstractControllerTest {
     public void testFailureForMIL() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm21_0 = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 1, 0);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21_0));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -175,11 +175,11 @@ public class Part09Step09ControllerTest extends AbstractControllerTest {
     public void testFailureForTSCC() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm21_0 = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 0, 1);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21_0));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -193,11 +193,11 @@ public class Part09Step09ControllerTest extends AbstractControllerTest {
     public void testFailureForNoDM21() {
         dataRepository.putObdModule(new OBDModuleInformation(2));
         var nack = AcknowledgmentPacket.create(2, NACK);
-        when(diagnosticMessageModule.requestDM21(any(), eq(2))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM21(any(), eq(2))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(2));
+        verify(communicationsModule).requestDM21(any(), eq(2));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -211,15 +211,15 @@ public class Part09Step09ControllerTest extends AbstractControllerTest {
     public void testFailureForNoNACK() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm21_0 = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21_0));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21_0));
 
         dataRepository.putObdModule(new OBDModuleInformation(2));
-        when(diagnosticMessageModule.requestDM21(any(), eq(2))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM21(any(), eq(2))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(2));
+        verify(communicationsModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(2));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step10ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step10ControllerTest.java
@@ -24,7 +24,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -46,7 +46,7 @@ public class Part09Step10ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -83,7 +83,7 @@ public class Part09Step10ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -92,7 +92,7 @@ public class Part09Step10ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -102,7 +102,7 @@ public class Part09Step10ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -138,26 +138,26 @@ public class Part09Step10ControllerTest extends AbstractControllerTest {
 
         var str123 = ScaledTestResult.create(250, 123, 14, 0, 0, 0, 0);
         var dm30_123 = DM30ScaledTestResultsPacket.create(0, 0, str123);
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0),
-                                                        eq(250),
-                                                        eq(123),
-                                                        eq(14))).thenReturn(List.of(dm30_123));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0),
+                                                     eq(250),
+                                                     eq(123),
+                                                     eq(14))).thenReturn(List.of(dm30_123));
 
         var str456 = ScaledTestResult.create(250, 456, 9, 0, 0, 0, 0);
         var dm30_456 = DM30ScaledTestResultsPacket.create(0, 0, str456, str456);
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0),
-                                                        eq(250),
-                                                        eq(456),
-                                                        eq(9))).thenReturn(List.of(dm30_456));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0),
+                                                     eq(250),
+                                                     eq(456),
+                                                     eq(9))).thenReturn(List.of(dm30_456));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(250), eq(123), eq(14));
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(250), eq(456), eq(9));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(250), eq(123), eq(14));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(250), eq(456), eq(9));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -174,24 +174,24 @@ public class Part09Step10ControllerTest extends AbstractControllerTest {
 
         var str123 = ScaledTestResult.create(250, 123, 14, 0, 0, 0, 0);
         var dm30_123 = DM30ScaledTestResultsPacket.create(0, 0, str123);
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0),
-                                                        eq(250),
-                                                        eq(123),
-                                                        eq(14))).thenReturn(List.of(dm30_123));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0),
+                                                     eq(250),
+                                                     eq(123),
+                                                     eq(14))).thenReturn(List.of(dm30_123));
 
         var str456 = ScaledTestResult.create(250, 456, 9, 0, 5, 10, 0);
         var dm30_456 = DM30ScaledTestResultsPacket.create(0, 0, str456);
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0),
-                                                        eq(250),
-                                                        eq(456),
-                                                        eq(9))).thenReturn(List.of(dm30_456));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0),
+                                                     eq(250),
+                                                     eq(456),
+                                                     eq(9))).thenReturn(List.of(dm30_456));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(250), eq(123), eq(14));
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(250), eq(456), eq(9));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(250), eq(123), eq(14));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(250), eq(456), eq(9));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -212,25 +212,25 @@ public class Part09Step10ControllerTest extends AbstractControllerTest {
 
         var str123 = ScaledTestResult.create(250, 123, 14, 0, 0, 0, 0);
         var dm30_123 = DM30ScaledTestResultsPacket.create(0, 0, str123);
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0),
-                                                        eq(250),
-                                                        eq(123),
-                                                        eq(14))).thenReturn(List.of(dm30_123));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0),
+                                                     eq(250),
+                                                     eq(123),
+                                                     eq(14))).thenReturn(List.of(dm30_123));
 
         var str456_1 = ScaledTestResult.create(250, 456, 9, 0, 0, 0, 0);
         var str456_2 = ScaledTestResult.create(250, 456, 1, 0, 0, 0, 0);
         var dm30_456 = DM30ScaledTestResultsPacket.create(0, 0, str456_1, str456_2);
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0),
-                                                        eq(250),
-                                                        eq(456),
-                                                        eq(9))).thenReturn(List.of(dm30_456));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0),
+                                                     eq(250),
+                                                     eq(456),
+                                                     eq(9))).thenReturn(List.of(dm30_456));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(250), eq(123), eq(14));
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(250), eq(456), eq(9));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(250), eq(123), eq(14));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(250), eq(456), eq(9));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -251,22 +251,22 @@ public class Part09Step10ControllerTest extends AbstractControllerTest {
 
         var str123 = ScaledTestResult.create(250, 123, 14, 0, 0, 0, 0);
         var dm30_123 = DM30ScaledTestResultsPacket.create(0, 0, str123);
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0),
-                                                        eq(250),
-                                                        eq(123),
-                                                        eq(14))).thenReturn(List.of(dm30_123));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0),
+                                                     eq(250),
+                                                     eq(123),
+                                                     eq(14))).thenReturn(List.of(dm30_123));
 
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0),
-                                                        eq(250),
-                                                        eq(456),
-                                                        eq(9))).thenReturn(List.of());
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0),
+                                                     eq(250),
+                                                     eq(456),
+                                                     eq(9))).thenReturn(List.of());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(250), eq(123), eq(14));
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(250), eq(456), eq(9));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(250), eq(123), eq(14));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(250), eq(456), eq(9));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step11ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step11ControllerTest.java
@@ -26,7 +26,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -48,7 +48,7 @@ public class Part09Step11ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -85,7 +85,7 @@ public class Part09Step11ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -94,7 +94,7 @@ public class Part09Step11ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -104,7 +104,7 @@ public class Part09Step11ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -139,13 +139,13 @@ public class Part09Step11ControllerTest extends AbstractControllerTest {
         var ratio11 = new PerformanceRatio(123, 1, 10, 0);
         var ratio21 = new PerformanceRatio(456, 8, 100, 0);
         var dm20 = DM20MonitorPerformanceRatioPacket.create(0, 4, 2, ratio11, ratio21);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -163,11 +163,11 @@ public class Part09Step11ControllerTest extends AbstractControllerTest {
         var ratio11 = new PerformanceRatio(123, 1, 10, 0);
         var ratio21 = new PerformanceRatio(456, 8, 100, 0);
         var dm20 = DM20MonitorPerformanceRatioPacket.create(0, 8, 2, ratio11, ratio21);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -188,11 +188,11 @@ public class Part09Step11ControllerTest extends AbstractControllerTest {
         var ratio11 = new PerformanceRatio(123, 1, 10, 0);
         var ratio21 = new PerformanceRatio(789, 8, 100, 0);
         var dm20 = DM20MonitorPerformanceRatioPacket.create(0, 4, 2, ratio11, ratio21);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -211,11 +211,11 @@ public class Part09Step11ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var nack = AcknowledgmentPacket.create(0, AcknowledgmentPacket.Response.NACK);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -233,11 +233,11 @@ public class Part09Step11ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(DM20MonitorPerformanceRatioPacket.create(0, 4, 2, ratio1, ratio2), 9);
         dataRepository.putObdModule(obdModuleInformation);
 
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step12ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step12ControllerTest.java
@@ -32,7 +32,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -54,7 +54,7 @@ public class Part09Step12ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -91,7 +91,7 @@ public class Part09Step12ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -100,7 +100,7 @@ public class Part09Step12ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -110,7 +110,7 @@ public class Part09Step12ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -141,16 +141,16 @@ public class Part09Step12ControllerTest extends AbstractControllerTest {
         obdModule0.set(DM12MILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc), 9);
         dataRepository.putObdModule(obdModule0);
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM28(any(), eq(1))).thenReturn(new BusResult<>(false, nack));
+        when(communicationsModule.requestDM28(any(), eq(1))).thenReturn(new BusResult<>(false, nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM28(any(), eq(1));
+        verify(communicationsModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -164,11 +164,11 @@ public class Part09Step12ControllerTest extends AbstractControllerTest {
         obdModule0.set(DM12MILOnEmissionDTCPacket.create(0, ALTERNATE_OFF, OFF, OFF, OFF, dtc), 9);
         dataRepository.putObdModule(obdModule0);
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, ALTERNATE_OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -185,11 +185,11 @@ public class Part09Step12ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dtc = DiagnosticTroubleCode.create(123, 1, 0, 3);
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -207,11 +207,11 @@ public class Part09Step12ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModule0);
 
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -224,11 +224,11 @@ public class Part09Step12ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForNoNACK() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step13ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step13ControllerTest.java
@@ -31,7 +31,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -53,7 +53,7 @@ public class Part09Step13ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -90,7 +90,7 @@ public class Part09Step13ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -99,7 +99,7 @@ public class Part09Step13ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -109,7 +109,7 @@ public class Part09Step13ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -140,14 +140,14 @@ public class Part09Step13ControllerTest extends AbstractControllerTest {
         obdModuleInformation0.set(DM28PermanentEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc0), 9);
         dataRepository.putObdModule(obdModuleInformation0);
         var dm31_0 = DM31DtcToLampAssociation.create(0, 0, DTCLampStatus.create(dtc0, OFF, OFF, OFF, OFF));
-        when(diagnosticMessageModule.requestDM31(any(), eq(0))).thenReturn(RequestResult.of(dm31_0));
+        when(communicationsModule.requestDM31(any(), eq(0))).thenReturn(RequestResult.of(dm31_0));
 
         OBDModuleInformation obdModuleInformation1 = new OBDModuleInformation(1);
         var dtc1 = DiagnosticTroubleCode.create(456, 9, 0, 1);
         obdModuleInformation1.set(DM28PermanentEmissionDTCPacket.create(1, OFF, OFF, OFF, OFF, dtc1), 9);
         dataRepository.putObdModule(obdModuleInformation1);
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM31(any(), eq(1))).thenReturn(new RequestResult<>(false, nack));
+        when(communicationsModule.requestDM31(any(), eq(1))).thenReturn(new RequestResult<>(false, nack));
 
         // Module 2 doesn't have any DTCs
         OBDModuleInformation obdModuleInformation2 = new OBDModuleInformation(2);
@@ -159,8 +159,8 @@ public class Part09Step13ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM31(any(), eq(1));
+        verify(communicationsModule).requestDM31(any(), eq(0));
+        verify(communicationsModule).requestDM31(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -174,11 +174,11 @@ public class Part09Step13ControllerTest extends AbstractControllerTest {
         obdModuleInformation0.set(DM28PermanentEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc0), 9);
         dataRepository.putObdModule(obdModuleInformation0);
         var dm31_0 = DM31DtcToLampAssociation.create(0, 0, DTCLampStatus.create(dtc0, OFF, ON, OFF, OFF));
-        when(diagnosticMessageModule.requestDM31(any(), eq(0))).thenReturn(RequestResult.of(dm31_0));
+        when(communicationsModule.requestDM31(any(), eq(0))).thenReturn(RequestResult.of(dm31_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any(), eq(0));
+        verify(communicationsModule).requestDM31(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -194,11 +194,11 @@ public class Part09Step13ControllerTest extends AbstractControllerTest {
         var dtc0 = DiagnosticTroubleCode.create(123, 1, 0, 1);
         obdModuleInformation0.set(DM28PermanentEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc0), 9);
         dataRepository.putObdModule(obdModuleInformation0);
-        when(diagnosticMessageModule.requestDM31(any(), eq(0))).thenReturn(RequestResult.of());
+        when(communicationsModule.requestDM31(any(), eq(0))).thenReturn(RequestResult.of());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM31(any(), eq(0));
+        verify(communicationsModule).requestDM31(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step14ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step14ControllerTest.java
@@ -30,7 +30,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -52,7 +52,7 @@ public class Part09Step14ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -89,7 +89,7 @@ public class Part09Step14ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -98,7 +98,7 @@ public class Part09Step14ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -108,7 +108,7 @@ public class Part09Step14ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -136,22 +136,22 @@ public class Part09Step14ControllerTest extends AbstractControllerTest {
     public void testHappyPathNoFailures() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm27_0 = DM27AllPendingDTCsPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM27(any(), eq(0))).thenReturn(BusResult.of(dm27_0));
+        when(communicationsModule.requestDM27(any(), eq(0))).thenReturn(BusResult.of(dm27_0));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM27(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM27(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         var dtc = DiagnosticTroubleCode.create(123, 1, 1, 1);
         var dm27_2 = DM27AllPendingDTCsPacket.create(2, ON, ON, ON, ON, dtc);
 
-        when(diagnosticMessageModule.requestDM27(any())).thenReturn(RequestResult.of(dm27_0, dm27_2));
+        when(communicationsModule.requestDM27(any())).thenReturn(RequestResult.of(dm27_0, dm27_2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM27(any(), eq(1));
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0));
+        verify(communicationsModule).requestDM27(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -163,14 +163,14 @@ public class Part09Step14ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dtc = DiagnosticTroubleCode.create(123, 1, 1, 1);
         var dm27_0 = DM27AllPendingDTCsPacket.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM27(any(), eq(0))).thenReturn(BusResult.of(dm27_0));
+        when(communicationsModule.requestDM27(any(), eq(0))).thenReturn(BusResult.of(dm27_0));
 
-        when(diagnosticMessageModule.requestDM27(any())).thenReturn(RequestResult.of(dm27_0));
+        when(communicationsModule.requestDM27(any())).thenReturn(RequestResult.of(dm27_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0));
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -185,15 +185,15 @@ public class Part09Step14ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dtc = DiagnosticTroubleCode.create(123, 1, 1, 1);
         var dm27_0 = DM27AllPendingDTCsPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM27(any())).thenReturn(RequestResult.of(dm27_0));
+        when(communicationsModule.requestDM27(any())).thenReturn(RequestResult.of(dm27_0));
 
         var dm27_1 = DM27AllPendingDTCsPacket.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM27(any(), eq(0))).thenReturn(BusResult.of(dm27_1));
+        when(communicationsModule.requestDM27(any(), eq(0))).thenReturn(BusResult.of(dm27_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0));
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -206,13 +206,13 @@ public class Part09Step14ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForNoNACK() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
-        when(diagnosticMessageModule.requestDM27(any())).thenReturn(RequestResult.of());
-        when(diagnosticMessageModule.requestDM27(any(), eq(0))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM27(any())).thenReturn(RequestResult.of());
+        when(communicationsModule.requestDM27(any(), eq(0))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM27(any());
-        verify(diagnosticMessageModule).requestDM27(any(), eq(0));
+        verify(communicationsModule).requestDM27(any());
+        verify(communicationsModule).requestDM27(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step15ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step15ControllerTest.java
@@ -27,7 +27,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -49,7 +49,7 @@ public class Part09Step15ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -86,7 +86,7 @@ public class Part09Step15ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -95,7 +95,7 @@ public class Part09Step15ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -105,7 +105,7 @@ public class Part09Step15ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -143,11 +143,11 @@ public class Part09Step15ControllerTest extends AbstractControllerTest {
         var dm29_1 = DM29DtcCounts.create(1, 0, 0, 0xFF, 0, 0, 0);
 
         var dm29_2 = DM29DtcCounts.create(2, 0, 0, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0, dm29_1, dm29_2));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0, dm29_1, dm29_2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -155,11 +155,11 @@ public class Part09Step15ControllerTest extends AbstractControllerTest {
 
     @Test
     public void testNoResponse() {
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of());
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -178,11 +178,11 @@ public class Part09Step15ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
         var dm29_0 = DM29DtcCounts.create(0, 0, 1, 0, 0, 0, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -201,11 +201,11 @@ public class Part09Step15ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
         var dm29_0 = DM29DtcCounts.create(0, 0, 0, 0, 1, 0, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -224,11 +224,11 @@ public class Part09Step15ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
         var dm29_0 = DM29DtcCounts.create(0, 0, 0, 0, 0, 1, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -246,11 +246,11 @@ public class Part09Step15ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
         var dm29_0 = DM29DtcCounts.create(0, 0, 0, 0, 0, 0, 0);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -270,11 +270,11 @@ public class Part09Step15ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
         var dm29_0 = DM29DtcCounts.create(0, 0, 0, 0, 0, 0, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -293,11 +293,11 @@ public class Part09Step15ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
         var dm29_0 = DM29DtcCounts.create(0, 0, 0, 1, 0, 0, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -315,11 +315,11 @@ public class Part09Step15ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
         var dm29_0 = DM29DtcCounts.create(0, 0, 0, 0, 0, 0, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -339,11 +339,11 @@ public class Part09Step15ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
         var dm29_0 = DM29DtcCounts.create(0, 0, 0, 0, 0, 0, 2);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -368,11 +368,11 @@ public class Part09Step15ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation1);
         var dm29_1 = DM29DtcCounts.create(1, 0, 0, 0xFF, 0, 0, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0, dm29_1));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0, dm29_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step16ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step16ControllerTest.java
@@ -26,7 +26,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -48,7 +48,7 @@ public class Part09Step16ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -85,7 +85,7 @@ public class Part09Step16ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -94,7 +94,7 @@ public class Part09Step16ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -104,7 +104,7 @@ public class Part09Step16ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -134,28 +134,28 @@ public class Part09Step16ControllerTest extends AbstractControllerTest {
         obdModuleInformation0.set(DM26TripDiagnosticReadinessPacket.create(0, 0, 0), 8);
         dataRepository.putObdModule(obdModuleInformation0);
         var dm26_0 = DM26TripDiagnosticReadinessPacket.create(0, 0, 0);
-        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26_0));
+        when(communicationsModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26_0));
 
         OBDModuleInformation obdModuleInformation1 = new OBDModuleInformation(1);
         obdModuleInformation1.set(DM26TripDiagnosticReadinessPacket.create(1, 0, 1), 8);
         dataRepository.putObdModule(obdModuleInformation1);
         var dm26_1 = DM26TripDiagnosticReadinessPacket.create(1, 0, 0);
-        when(diagnosticMessageModule.requestDM26(any(), eq(1))).thenReturn(RequestResult.of(dm26_1));
+        when(communicationsModule.requestDM26(any(), eq(1))).thenReturn(RequestResult.of(dm26_1));
 
         dataRepository.putObdModule(new OBDModuleInformation(2));
         var dm26_2 = DM26TripDiagnosticReadinessPacket.create(2, 100, 100);
-        when(diagnosticMessageModule.requestDM26(any(), eq(2))).thenReturn(RequestResult.of(dm26_2));
+        when(communicationsModule.requestDM26(any(), eq(2))).thenReturn(RequestResult.of(dm26_2));
 
         dataRepository.putObdModule(new OBDModuleInformation(3));
         var nack = AcknowledgmentPacket.create(3, NACK);
-        when(diagnosticMessageModule.requestDM26(any(), eq(3))).thenReturn(new RequestResult<>(false, nack));
+        when(communicationsModule.requestDM26(any(), eq(3))).thenReturn(new RequestResult<>(false, nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM26(any(), eq(1));
-        verify(diagnosticMessageModule).requestDM26(any(), eq(2));
-        verify(diagnosticMessageModule).requestDM26(any(), eq(3));
+        verify(communicationsModule).requestDM26(any(), eq(0));
+        verify(communicationsModule).requestDM26(any(), eq(1));
+        verify(communicationsModule).requestDM26(any(), eq(2));
+        verify(communicationsModule).requestDM26(any(), eq(3));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -168,11 +168,11 @@ public class Part09Step16ControllerTest extends AbstractControllerTest {
         obdModuleInformation1.set(DM26TripDiagnosticReadinessPacket.create(1, 0, 1), 8);
         dataRepository.putObdModule(obdModuleInformation1);
         var dm26_1 = DM26TripDiagnosticReadinessPacket.create(1, 0, 1);
-        when(diagnosticMessageModule.requestDM26(any(), eq(1))).thenReturn(RequestResult.of(dm26_1));
+        when(communicationsModule.requestDM26(any(), eq(1))).thenReturn(RequestResult.of(dm26_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM26(any(), eq(1));
+        verify(communicationsModule).requestDM26(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -185,11 +185,11 @@ public class Part09Step16ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForNoNACK() {
         dataRepository.putObdModule(new OBDModuleInformation(1));
-        when(diagnosticMessageModule.requestDM26(any(), eq(1))).thenReturn(RequestResult.of());
+        when(communicationsModule.requestDM26(any(), eq(1))).thenReturn(RequestResult.of());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM26(any(), eq(1));
+        verify(communicationsModule).requestDM26(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step17ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step17ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -50,7 +50,7 @@ public class Part09Step17ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -87,7 +87,7 @@ public class Part09Step17ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -96,7 +96,7 @@ public class Part09Step17ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -106,7 +106,7 @@ public class Part09Step17ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -137,24 +137,24 @@ public class Part09Step17ControllerTest extends AbstractControllerTest {
         obdModuleInformation0.set(DM25ExpandedFreezeFrame.create(0), 8);
         dataRepository.putObdModule(obdModuleInformation0);
         var dm25 = DM25ExpandedFreezeFrame.create(0);
-        when(diagnosticMessageModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
+        when(communicationsModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
 
         // Module 1 - NACKs
         OBDModuleInformation obdModuleInformation1 = new OBDModuleInformation(1);
         obdModuleInformation1.set(DM25ExpandedFreezeFrame.create(1), 8);
         dataRepository.putObdModule(obdModuleInformation1);
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM25(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM25(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         // Module 2 - No Previous DM25 and no NACK
         dataRepository.putObdModule(new OBDModuleInformation(2));
-        when(diagnosticMessageModule.requestDM25(any(), eq(2))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM25(any(), eq(2))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM25(any(), eq(1));
-        verify(diagnosticMessageModule).requestDM25(any(), eq(2));
+        verify(communicationsModule).requestDM25(any(), eq(0));
+        verify(communicationsModule).requestDM25(any(), eq(1));
+        verify(communicationsModule).requestDM25(any(), eq(2));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -169,11 +169,11 @@ public class Part09Step17ControllerTest extends AbstractControllerTest {
         var dtc = DiagnosticTroubleCode.create(123, 1, 1, 1);
         var freezeFrame = new FreezeFrame(dtc, new int[10]);
         var dm25 = DM25ExpandedFreezeFrame.create(0, freezeFrame);
-        when(diagnosticMessageModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
+        when(communicationsModule.requestDM25(any(), eq(0))).thenReturn(BusResult.of(dm25));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(0));
+        verify(communicationsModule).requestDM25(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -189,11 +189,11 @@ public class Part09Step17ControllerTest extends AbstractControllerTest {
         OBDModuleInformation obdModuleInformation1 = new OBDModuleInformation(1);
         obdModuleInformation1.set(DM25ExpandedFreezeFrame.create(1), 8);
         dataRepository.putObdModule(obdModuleInformation1);
-        when(diagnosticMessageModule.requestDM25(any(), eq(1))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM25(any(), eq(1))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM25(any(), eq(1));
+        verify(communicationsModule).requestDM25(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step18ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step18ControllerTest.java
@@ -30,7 +30,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -52,7 +52,7 @@ public class Part09Step18ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -89,7 +89,7 @@ public class Part09Step18ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -98,7 +98,7 @@ public class Part09Step18ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -108,7 +108,7 @@ public class Part09Step18ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -136,16 +136,16 @@ public class Part09Step18ControllerTest extends AbstractControllerTest {
     public void testHappyPathNoFailures() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm23 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(BusResult.of(dm23));
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(BusResult.of(dm23));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM23(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM23(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM23(any(), eq(1));
+        verify(communicationsModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -156,11 +156,11 @@ public class Part09Step18ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dtc = DiagnosticTroubleCode.create(123, 0, 1, 1);
         var dm23 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(BusResult.of(dm23));
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(BusResult.of(dm23));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -174,11 +174,11 @@ public class Part09Step18ControllerTest extends AbstractControllerTest {
     public void testFailureForMILNotOff() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm23 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(BusResult.of(dm23));
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(BusResult.of(dm23));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -191,11 +191,11 @@ public class Part09Step18ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForNoNACK() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -209,11 +209,11 @@ public class Part09Step18ControllerTest extends AbstractControllerTest {
     public void testWarningForAlternateOff() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm23 = DM23PreviouslyMILOnEmissionDTCPacket.create(0, ALTERNATE_OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM23(any(), eq(0))).thenReturn(BusResult.of(dm23));
+        when(communicationsModule.requestDM23(any(), eq(0))).thenReturn(BusResult.of(dm23));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM23(any(), eq(0));
+        verify(communicationsModule).requestDM23(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step19ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step19ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -50,7 +50,7 @@ public class Part09Step19ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -87,7 +87,7 @@ public class Part09Step19ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -96,7 +96,7 @@ public class Part09Step19ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -106,7 +106,7 @@ public class Part09Step19ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -134,16 +134,16 @@ public class Part09Step19ControllerTest extends AbstractControllerTest {
     public void testHappyPathNoFailures() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm12 = DM12MILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM12(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM12(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM12(any(), eq(1));
+        verify(communicationsModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -154,11 +154,11 @@ public class Part09Step19ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dtc = DiagnosticTroubleCode.create(123, 1, 1, 1);
         var dm12 = DM12MILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -172,11 +172,11 @@ public class Part09Step19ControllerTest extends AbstractControllerTest {
     public void testFailureForMILNotOff() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm12 = DM12MILOnEmissionDTCPacket.create(0, ALTERNATE_OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -190,15 +190,15 @@ public class Part09Step19ControllerTest extends AbstractControllerTest {
     public void testFailureForNoNACK() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm12 = DM12MILOnEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(dm12));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
-        when(diagnosticMessageModule.requestDM12(any(), eq(1))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM12(any(), eq(1))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM12(any(), eq(1));
+        verify(communicationsModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -213,11 +213,11 @@ public class Part09Step19ControllerTest extends AbstractControllerTest {
     public void testFailureForNoDM12() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var nack = AcknowledgmentPacket.create(0, NACK);
-        when(diagnosticMessageModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM12(any(), eq(0))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM12(any(), eq(0));
+        verify(communicationsModule).requestDM12(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step20ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step20ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -50,7 +50,7 @@ public class Part09Step20ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -87,7 +87,7 @@ public class Part09Step20ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -96,7 +96,7 @@ public class Part09Step20ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -106,7 +106,7 @@ public class Part09Step20ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -134,19 +134,19 @@ public class Part09Step20ControllerTest extends AbstractControllerTest {
     public void testHappyPathNoFailures() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm6 = DM6PendingEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.of(dm6));
+        when(communicationsModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.of(dm6));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM6(any(), eq(1))).thenReturn(new RequestResult<>(false, nack));
+        when(communicationsModule.requestDM6(any(), eq(1))).thenReturn(new RequestResult<>(false, nack));
 
-        when(diagnosticMessageModule.requestDM6(any())).thenReturn(RequestResult.of(dm6));
+        when(communicationsModule.requestDM6(any())).thenReturn(RequestResult.of(dm6));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM6(any());
-        verify(diagnosticMessageModule).requestDM6(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM6(any(), eq(1));
+        verify(communicationsModule).requestDM6(any());
+        verify(communicationsModule).requestDM6(any(), eq(0));
+        verify(communicationsModule).requestDM6(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -157,14 +157,14 @@ public class Part09Step20ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dtc = DiagnosticTroubleCode.create(123, 1, 1, 1);
         var dm6 = DM6PendingEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.of(dm6));
+        when(communicationsModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.of(dm6));
 
-        when(diagnosticMessageModule.requestDM6(any())).thenReturn(RequestResult.of(dm6));
+        when(communicationsModule.requestDM6(any())).thenReturn(RequestResult.of(dm6));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM6(any());
-        verify(diagnosticMessageModule).requestDM6(any(), eq(0));
+        verify(communicationsModule).requestDM6(any());
+        verify(communicationsModule).requestDM6(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -178,14 +178,14 @@ public class Part09Step20ControllerTest extends AbstractControllerTest {
     public void testFailureForNoDM6() {
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM6(any(), eq(1))).thenReturn(new RequestResult<>(false, nack));
+        when(communicationsModule.requestDM6(any(), eq(1))).thenReturn(new RequestResult<>(false, nack));
 
-        when(diagnosticMessageModule.requestDM6(any())).thenReturn(RequestResult.of());
+        when(communicationsModule.requestDM6(any())).thenReturn(RequestResult.of());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM6(any());
-        verify(diagnosticMessageModule).requestDM6(any(), eq(1));
+        verify(communicationsModule).requestDM6(any());
+        verify(communicationsModule).requestDM6(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -199,15 +199,15 @@ public class Part09Step20ControllerTest extends AbstractControllerTest {
     public void testFailureForDifference() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm6 = DM6PendingEmissionDTCPacket.create(0, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.of(dm6));
+        when(communicationsModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.of(dm6));
 
         var dm6_2 = DM6PendingEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM6(any())).thenReturn(RequestResult.of(dm6_2));
+        when(communicationsModule.requestDM6(any())).thenReturn(RequestResult.of(dm6_2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM6(any());
-        verify(diagnosticMessageModule).requestDM6(any(), eq(0));
+        verify(communicationsModule).requestDM6(any());
+        verify(communicationsModule).requestDM6(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -221,18 +221,18 @@ public class Part09Step20ControllerTest extends AbstractControllerTest {
     public void testFailureForNoNACK() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm6 = DM6PendingEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.of(dm6));
+        when(communicationsModule.requestDM6(any(), eq(0))).thenReturn(RequestResult.of(dm6));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
-        when(diagnosticMessageModule.requestDM6(any(), eq(1))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM6(any(), eq(1))).thenReturn(RequestResult.empty());
 
-        when(diagnosticMessageModule.requestDM6(any())).thenReturn(RequestResult.of(dm6));
+        when(communicationsModule.requestDM6(any())).thenReturn(RequestResult.of(dm6));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM6(any());
-        verify(diagnosticMessageModule).requestDM6(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM6(any(), eq(1));
+        verify(communicationsModule).requestDM6(any());
+        verify(communicationsModule).requestDM6(any(), eq(0));
+        verify(communicationsModule).requestDM6(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step21ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step21ControllerTest.java
@@ -25,7 +25,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -48,7 +48,7 @@ public class Part09Step21ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -85,7 +85,7 @@ public class Part09Step21ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -94,7 +94,7 @@ public class Part09Step21ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -104,7 +104,7 @@ public class Part09Step21ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -156,12 +156,12 @@ public class Part09Step21ControllerTest extends AbstractControllerTest {
                                                                                                 List.of(packet0,
                                                                                                         packet21),
                                                                                                 List.of(packet44));
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(globalRequestResponse);
+        when(communicationsModule.requestDM5(any())).thenReturn(globalRequestResponse);
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM5(any());
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM5(any());
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -186,7 +186,7 @@ public class Part09Step21ControllerTest extends AbstractControllerTest {
                                                                                                 List.of(packet,
                                                                                                         packet0),
                                                                                                 List.of());
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(globalRequestResponse);
+        when(communicationsModule.requestDM5(any())).thenReturn(globalRequestResponse);
 
         OBDModuleInformation obdModule = new OBDModuleInformation(0x03);
         dataRepository.putObdModule(obdModule);
@@ -197,8 +197,8 @@ public class Part09Step21ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM5(any());
+        verify(communicationsModule).setJ1939(j1939);
+        verify(communicationsModule).requestDM5(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -214,11 +214,11 @@ public class Part09Step21ControllerTest extends AbstractControllerTest {
         var dm5 = DM5DiagnosticReadinessPacket.create(0, 0, 0, 0x22);
         var dm5_1 = DM5DiagnosticReadinessPacket.create(1, 0, 0, 0x22);
 
-        when(diagnosticMessageModule.requestDM5(any())).thenReturn(new RequestResult<>(false, dm5, dm5_1));
+        when(communicationsModule.requestDM5(any())).thenReturn(new RequestResult<>(false, dm5, dm5_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any());
+        verify(communicationsModule).requestDM5(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step22ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step22ControllerTest.java
@@ -30,7 +30,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -52,7 +52,7 @@ public class Part09Step22ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -89,7 +89,7 @@ public class Part09Step22ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -98,7 +98,7 @@ public class Part09Step22ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -108,7 +108,7 @@ public class Part09Step22ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -139,18 +139,18 @@ public class Part09Step22ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var dm2 = DM2PreviouslyActiveDTC.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(new RequestResult<>(false, List.of(), List.of()));
+        when(communicationsModule.requestDM2(any())).thenReturn(new RequestResult<>(false, List.of(), List.of()));
 
-        when(diagnosticMessageModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dm2));
+        when(communicationsModule.requestDM2(any(), eq(0))).thenReturn(BusResult.of(dm2));
 
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM2(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM2(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
-        verify(diagnosticMessageModule).requestDM2(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM2(any(), eq(1));
+        verify(communicationsModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any(), eq(0));
+        verify(communicationsModule).requestDM2(any(), eq(1));
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -168,18 +168,18 @@ public class Part09Step22ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var dm2 = DM2PreviouslyActiveDTC.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(new RequestResult<>(false, dm2));
+        when(communicationsModule.requestDM2(any())).thenReturn(new RequestResult<>(false, dm2));
 
-        when(diagnosticMessageModule.requestDM2(any(), eq(0))).thenReturn(new BusResult<>(false, dm2));
+        when(communicationsModule.requestDM2(any(), eq(0))).thenReturn(new BusResult<>(false, dm2));
 
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM2(any(), eq(1))).thenReturn(new BusResult<>(false, nack));
+        when(communicationsModule.requestDM2(any(), eq(1))).thenReturn(new BusResult<>(false, nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
-        verify(diagnosticMessageModule).requestDM2(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM2(any(), eq(1));
+        verify(communicationsModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any(), eq(0));
+        verify(communicationsModule).requestDM2(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -192,17 +192,17 @@ public class Part09Step22ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         var dm2 = DM2PreviouslyActiveDTC.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(new RequestResult<>(false, dm2));
+        when(communicationsModule.requestDM2(any())).thenReturn(new RequestResult<>(false, dm2));
 
-        when(diagnosticMessageModule.requestDM2(any(), eq(0))).thenReturn(new BusResult<>(false, dm2));
+        when(communicationsModule.requestDM2(any(), eq(0))).thenReturn(new BusResult<>(false, dm2));
 
-        when(diagnosticMessageModule.requestDM2(any(), eq(1))).thenReturn(new BusResult<>(true));
+        when(communicationsModule.requestDM2(any(), eq(1))).thenReturn(new BusResult<>(true));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
-        verify(diagnosticMessageModule).requestDM2(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM2(any(), eq(1));
+        verify(communicationsModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any(), eq(0));
+        verify(communicationsModule).requestDM2(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -220,13 +220,13 @@ public class Part09Step22ControllerTest extends AbstractControllerTest {
 
         var dtc = DiagnosticTroubleCode.create(123, 12, 0, 1);
         var dm2 = DM2PreviouslyActiveDTC.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(new RequestResult<>(false, dm2));
-        when(diagnosticMessageModule.requestDM2(any(), eq(0))).thenReturn(new BusResult<>(false, dm2));
+        when(communicationsModule.requestDM2(any())).thenReturn(new RequestResult<>(false, dm2));
+        when(communicationsModule.requestDM2(any(), eq(0))).thenReturn(new BusResult<>(false, dm2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
-        verify(diagnosticMessageModule).requestDM2(any(), eq(0));
+        verify(communicationsModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -243,13 +243,13 @@ public class Part09Step22ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModule);
 
         var dm2 = DM2PreviouslyActiveDTC.create(0, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(new RequestResult<>(false, dm2));
-        when(diagnosticMessageModule.requestDM2(any(), eq(0))).thenReturn(new BusResult<>(false, dm2));
+        when(communicationsModule.requestDM2(any())).thenReturn(new RequestResult<>(false, dm2));
+        when(communicationsModule.requestDM2(any(), eq(0))).thenReturn(new BusResult<>(false, dm2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
-        verify(diagnosticMessageModule).requestDM2(any(), eq(0));
+        verify(communicationsModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -265,15 +265,15 @@ public class Part09Step22ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
         var globalDM2 = DM2PreviouslyActiveDTC.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM2(any())).thenReturn(new RequestResult<>(false, globalDM2));
+        when(communicationsModule.requestDM2(any())).thenReturn(new RequestResult<>(false, globalDM2));
 
         var dsDM2 = DM2PreviouslyActiveDTC.create(0, ON, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM2(any(), eq(0))).thenReturn(new BusResult<>(false, dsDM2));
+        when(communicationsModule.requestDM2(any(), eq(0))).thenReturn(new BusResult<>(false, dsDM2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM2(any());
-        verify(diagnosticMessageModule).requestDM2(any(), eq(0));
+        verify(communicationsModule).requestDM2(any());
+        verify(communicationsModule).requestDM2(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step23ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step23ControllerTest.java
@@ -27,7 +27,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -49,7 +49,7 @@ public class Part09Step23ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -86,7 +86,7 @@ public class Part09Step23ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -95,7 +95,7 @@ public class Part09Step23ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -105,7 +105,7 @@ public class Part09Step23ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -136,11 +136,11 @@ public class Part09Step23ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_21));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_21));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -153,11 +153,11 @@ public class Part09Step23ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_21));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_21));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -170,11 +170,11 @@ public class Part09Step23ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_21));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_21));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -187,11 +187,11 @@ public class Part09Step23ControllerTest extends AbstractControllerTest {
 
     @Test
     public void testFailureForNoResponse() {
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of());
+        when(communicationsModule.readDM1(any())).thenReturn(List.of());
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -207,11 +207,11 @@ public class Part09Step23ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_21));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_21));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step24ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step24ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -50,7 +50,7 @@ public class Part09Step24ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -87,7 +87,7 @@ public class Part09Step24ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -96,7 +96,7 @@ public class Part09Step24ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -106,7 +106,7 @@ public class Part09Step24ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -139,7 +139,7 @@ public class Part09Step24ControllerTest extends AbstractControllerTest {
         obdModule.set(dsPacket, 9);
         dataRepository.putObdModule(obdModule);
 
-        when(diagnosticMessageModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.of(dsPacket));
+        when(communicationsModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.of(dsPacket));
 
         var vehInfo = new VehicleInformation();
         vehInfo.setEngineModelYear(2020);
@@ -148,7 +148,7 @@ public class Part09Step24ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM33(any(), eq(0x00));
+        verify(communicationsModule).requestDM33(any(), eq(0x00));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -158,7 +158,7 @@ public class Part09Step24ControllerTest extends AbstractControllerTest {
     @Test
     public void testNoResponsesCIEngine() {
 
-        when(diagnosticMessageModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.empty());
 
         var vehInfo = new VehicleInformation();
         vehInfo.setEngineModelYear(2025);
@@ -173,7 +173,7 @@ public class Part09Step24ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM33(any(), eq(0x00));
+        verify(communicationsModule).requestDM33(any(), eq(0x00));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -191,7 +191,7 @@ public class Part09Step24ControllerTest extends AbstractControllerTest {
         var previousPacket = create(0, 0, timer1);
         var packet = create(0, 0, timer1, timer2);
 
-        when(diagnosticMessageModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.of(packet));
 
         var vehInfo = new VehicleInformation();
         vehInfo.setEngineModelYear(2020);
@@ -205,7 +205,7 @@ public class Part09Step24ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM33(any(), eq(0x00));
+        verify(communicationsModule).requestDM33(any(), eq(0x00));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -222,7 +222,7 @@ public class Part09Step24ControllerTest extends AbstractControllerTest {
         var timer2 = EngineHoursTimer.create(1, 7, 9);
         var packet = create(0, 0, timer1);
 
-        when(diagnosticMessageModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.of(packet));
+        when(communicationsModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.of(packet));
 
         var vehInfo = new VehicleInformation();
         vehInfo.setEngineModelYear(2024);
@@ -235,7 +235,7 @@ public class Part09Step24ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM33(any(), eq(0x00));
+        verify(communicationsModule).requestDM33(any(), eq(0x00));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -251,7 +251,7 @@ public class Part09Step24ControllerTest extends AbstractControllerTest {
         var globalPacket = create(0, 0, EngineHoursTimer.create(1, 4, 10));
         var dsPacket = create(0, 0, EngineHoursTimer.create(1, 7, 9));
 
-        when(diagnosticMessageModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.of(dsPacket));
+        when(communicationsModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.of(dsPacket));
 
         var vehInfo = new VehicleInformation();
         vehInfo.setEngineModelYear(2020);
@@ -265,7 +265,7 @@ public class Part09Step24ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM33(any(), eq(0x00));
+        verify(communicationsModule).requestDM33(any(), eq(0x00));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -281,7 +281,7 @@ public class Part09Step24ControllerTest extends AbstractControllerTest {
         var globalPacket = create(0, 0, EngineHoursTimer.create(1, 7, 9));
         var dsPacket = create(0, 0, EngineHoursTimer.create(1, 3, 10));
 
-        when(diagnosticMessageModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.of(dsPacket));
+        when(communicationsModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.of(dsPacket));
 
         var vehInfo = new VehicleInformation();
         vehInfo.setEngineModelYear(2020);
@@ -295,7 +295,7 @@ public class Part09Step24ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM33(any(), eq(0x00));
+        verify(communicationsModule).requestDM33(any(), eq(0x00));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -311,7 +311,7 @@ public class Part09Step24ControllerTest extends AbstractControllerTest {
         var globalPacket = create(0, 0, EngineHoursTimer.create(1, 7, 9));
         var dsPacket = create(0, 0, EngineHoursTimer.create(1, 3, 10));
 
-        when(diagnosticMessageModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.of(dsPacket));
+        when(communicationsModule.requestDM33(any(), eq(0))).thenReturn(RequestResult.of(dsPacket));
 
         var vehInfo = new VehicleInformation();
         vehInfo.setEngineModelYear(2025);
@@ -325,7 +325,7 @@ public class Part09Step24ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM33(any(), eq(0x00));
+        verify(communicationsModule).requestDM33(any(), eq(0x00));
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step25ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step25ControllerTest.java
@@ -29,7 +29,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -52,7 +52,7 @@ public class Part09Step25ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -86,7 +86,7 @@ public class Part09Step25ControllerTest extends AbstractControllerTest {
                                               DataRepository.newInstance(),
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -95,7 +95,7 @@ public class Part09Step25ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -105,7 +105,7 @@ public class Part09Step25ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part10/Part10ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part10/Part10ControllerTest.java
@@ -24,7 +24,7 @@ public class Part10ControllerTest extends AbstractPartControllerTest {
                                         DataRepository.newInstance(),
                                         engineSpeedModule,
                                         vehicleInformationModule,
-                                        diagnosticMessageModule,
+                                        communicationsModule,
                                         step01Controller,
                                         step02Controller,
                                         step03Controller,

--- a/src-test/org/etools/j1939_84/controllers/part10/Part10Step01ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part10/Part10Step01ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -51,7 +51,7 @@ public class Part10Step01ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -85,7 +85,7 @@ public class Part10Step01ControllerTest extends AbstractControllerTest {
                                               DataRepository.newInstance(),
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -94,7 +94,7 @@ public class Part10Step01ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -104,7 +104,7 @@ public class Part10Step01ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part10/Part10Step02ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part10/Part10Step02ControllerTest.java
@@ -31,7 +31,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -54,7 +54,7 @@ public class Part10Step02ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -91,7 +91,7 @@ public class Part10Step02ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -100,7 +100,7 @@ public class Part10Step02ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -110,7 +110,7 @@ public class Part10Step02ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part10/Part10Step03ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part10/Part10Step03ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -51,7 +51,7 @@ public class Part10Step03ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -85,7 +85,7 @@ public class Part10Step03ControllerTest extends AbstractControllerTest {
                                               DataRepository.newInstance(),
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -94,7 +94,7 @@ public class Part10Step03ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -104,7 +104,7 @@ public class Part10Step03ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part10/Part10Step04ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part10/Part10Step04ControllerTest.java
@@ -29,7 +29,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -51,7 +51,7 @@ public class Part10Step04ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -88,7 +88,7 @@ public class Part10Step04ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -97,7 +97,7 @@ public class Part10Step04ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -107,7 +107,7 @@ public class Part10Step04ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -136,16 +136,16 @@ public class Part10Step04ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dtc = DiagnosticTroubleCode.create(123, 1, 0, 1);
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM28(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM28(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM28(any(), eq(1));
+        verify(communicationsModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -155,11 +155,11 @@ public class Part10Step04ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForNoDTC() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -179,11 +179,11 @@ public class Part10Step04ControllerTest extends AbstractControllerTest {
 
         var dtc2 = DiagnosticTroubleCode.create(234, 1, 0, 1);
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc2);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -199,15 +199,15 @@ public class Part10Step04ControllerTest extends AbstractControllerTest {
 
         var dtc = DiagnosticTroubleCode.create(123, 1, 0, 1);
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
-        when(diagnosticMessageModule.requestDM28(any(), eq(1))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM28(any(), eq(1))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM28(any(), eq(1));
+        verify(communicationsModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part10/Part10Step05ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part10/Part10Step05ControllerTest.java
@@ -29,7 +29,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -52,7 +52,7 @@ public class Part10Step05ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -89,7 +89,7 @@ public class Part10Step05ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -98,7 +98,7 @@ public class Part10Step05ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -108,7 +108,7 @@ public class Part10Step05ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part11/Part11ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part11/Part11ControllerTest.java
@@ -24,7 +24,7 @@ public class Part11ControllerTest extends AbstractPartControllerTest {
                                         DataRepository.newInstance(),
                                         engineSpeedModule,
                                         vehicleInformationModule,
-                                        diagnosticMessageModule,
+                                        communicationsModule,
                                         step01Controller,
                                         step02Controller,
                                         step03Controller,

--- a/src-test/org/etools/j1939_84/controllers/part11/Part11Step01ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part11/Part11Step01ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -51,7 +51,7 @@ public class Part11Step01ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -84,7 +84,7 @@ public class Part11Step01ControllerTest extends AbstractControllerTest {
                                               DataRepository.newInstance(),
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -93,7 +93,7 @@ public class Part11Step01ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -103,7 +103,7 @@ public class Part11Step01ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part11/Part11Step02ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part11/Part11Step02ControllerTest.java
@@ -24,7 +24,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -46,7 +46,7 @@ public class Part11Step02ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -83,7 +83,7 @@ public class Part11Step02ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -92,7 +92,7 @@ public class Part11Step02ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -102,7 +102,7 @@ public class Part11Step02ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -134,11 +134,11 @@ public class Part11Step02ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var dm26_1 = DM26TripDiagnosticReadinessPacket.create(1, 17, 1);
 
-        when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.of(dm26_0, dm26_1));
+        when(communicationsModule.requestDM26(any())).thenReturn(RequestResult.of(dm26_0, dm26_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM26(any());
+        verify(communicationsModule).requestDM26(any());
 
         assertSame(dm26_0, dataRepository.getObdModule(0).getLatest(DM26TripDiagnosticReadinessPacket.class));
         assertSame(dm26_1, dataRepository.getObdModule(1).getLatest(DM26TripDiagnosticReadinessPacket.class));
@@ -150,11 +150,11 @@ public class Part11Step02ControllerTest extends AbstractControllerTest {
 
     @Test
     public void testNoResponses() {
-        when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.empty());
+        when(communicationsModule.requestDM26(any())).thenReturn(RequestResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM26(any());
+        verify(communicationsModule).requestDM26(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -172,11 +172,11 @@ public class Part11Step02ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var dm26_1 = DM26TripDiagnosticReadinessPacket.create(1, 18, 1);
 
-        when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.of(dm26_0, dm26_1));
+        when(communicationsModule.requestDM26(any())).thenReturn(RequestResult.of(dm26_0, dm26_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM26(any());
+        verify(communicationsModule).requestDM26(any());
 
         assertSame(dm26_0, dataRepository.getObdModule(0).getLatest(DM26TripDiagnosticReadinessPacket.class));
         assertSame(dm26_1, dataRepository.getObdModule(1).getLatest(DM26TripDiagnosticReadinessPacket.class));

--- a/src-test/org/etools/j1939_84/controllers/part11/Part11Step03ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part11/Part11Step03ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -50,7 +50,7 @@ public class Part11Step03ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -87,7 +87,7 @@ public class Part11Step03ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -96,7 +96,7 @@ public class Part11Step03ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -106,7 +106,7 @@ public class Part11Step03ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -134,16 +134,16 @@ public class Part11Step03ControllerTest extends AbstractControllerTest {
     public void testHappyPathNoFailures() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm21 = DM21DiagnosticReadinessPacket.create(0, 0, 1, 2, 3, 4);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM21(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM21(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(1));
+        verify(communicationsModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(1));
 
         assertSame(dm21, dataRepository.getObdModule(0).getLatest(DM21DiagnosticReadinessPacket.class));
         assertNull(dataRepository.getObdModule(1).getLatest(DM21DiagnosticReadinessPacket.class));
@@ -156,11 +156,11 @@ public class Part11Step03ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForNoNACK() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part11/Part11Step04ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part11/Part11Step04ControllerTest.java
@@ -25,7 +25,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -47,7 +47,7 @@ public class Part11Step04ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -84,7 +84,7 @@ public class Part11Step04ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -93,7 +93,7 @@ public class Part11Step04ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -103,7 +103,7 @@ public class Part11Step04ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -139,11 +139,11 @@ public class Part11Step04ControllerTest extends AbstractControllerTest {
         var dm29_1 = DM29DtcCounts.create(1, 0, 0, 0xFF, 0, 0, 0);
 
         var dm29_2 = DM29DtcCounts.create(2, 0, 0, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0, dm29_1, dm29_2));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0, dm29_1, dm29_2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -151,11 +151,11 @@ public class Part11Step04ControllerTest extends AbstractControllerTest {
 
     @Test
     public void testNoResponse() {
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of());
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -172,11 +172,11 @@ public class Part11Step04ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
         var dm29_0 = DM29DtcCounts.create(0, 0, 1, 0, 0, 0, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -193,11 +193,11 @@ public class Part11Step04ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
         var dm29_0 = DM29DtcCounts.create(0, 0, 0, 0, 1, 0, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -214,11 +214,11 @@ public class Part11Step04ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
         var dm29_0 = DM29DtcCounts.create(0, 0, 0, 0, 0, 1, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -235,11 +235,11 @@ public class Part11Step04ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
         var dm29_0 = DM29DtcCounts.create(0, 0, 0, 0, 0, 0, 0);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -256,11 +256,11 @@ public class Part11Step04ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
         var dm29_0 = DM29DtcCounts.create(0, 0, 0, 1, 0, 0, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -275,11 +275,11 @@ public class Part11Step04ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm29_0 = DM29DtcCounts.create(0, 0, 0, 0, 0, 0, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -296,11 +296,11 @@ public class Part11Step04ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
         var dm29_0 = DM29DtcCounts.create(0, 0, 0, 0, 0, 0, 2);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -320,11 +320,11 @@ public class Part11Step04ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var dm29_1 = DM29DtcCounts.create(1, 0, 0, 0xFF, 0, 0, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0, dm29_1));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0, dm29_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part11/Part11Step05ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part11/Part11Step05ControllerTest.java
@@ -23,7 +23,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -45,7 +45,7 @@ public class Part11Step05ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -82,7 +82,7 @@ public class Part11Step05ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -91,7 +91,7 @@ public class Part11Step05ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -101,7 +101,7 @@ public class Part11Step05ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -131,11 +131,11 @@ public class Part11Step05ControllerTest extends AbstractControllerTest {
 
         var dm20_0 = DM20MonitorPerformanceRatioPacket.create(0, 1, 1);
         var dm20_1 = DM20MonitorPerformanceRatioPacket.create(1, 0, 0);
-        when(diagnosticMessageModule.requestDM20(any())).thenReturn(RequestResult.of(dm20_0, dm20_1));
+        when(communicationsModule.requestDM20(any())).thenReturn(RequestResult.of(dm20_0, dm20_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any());
+        verify(communicationsModule).requestDM20(any());
 
         assertSame(dm20_0, dataRepository.getObdModule(0).getLatest(DM20MonitorPerformanceRatioPacket.class));
         assertNull(dataRepository.getObdModule(1));

--- a/src-test/org/etools/j1939_84/controllers/part11/Part11Step06ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part11/Part11Step06ControllerTest.java
@@ -25,7 +25,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -47,7 +47,7 @@ public class Part11Step06ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -84,7 +84,7 @@ public class Part11Step06ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -93,7 +93,7 @@ public class Part11Step06ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -103,7 +103,7 @@ public class Part11Step06ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -139,11 +139,11 @@ public class Part11Step06ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var dm28_1 = DM28PermanentEmissionDTCPacket.create(1, OFF, OFF, OFF, OFF);
 
-        when(diagnosticMessageModule.requestDM28(any())).thenReturn(RequestResult.of(dm28_0, dm28_1));
+        when(communicationsModule.requestDM28(any())).thenReturn(RequestResult.of(dm28_0, dm28_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any());
+        verify(communicationsModule).requestDM28(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -154,11 +154,11 @@ public class Part11Step06ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var dm28_1 = DM28PermanentEmissionDTCPacket.create(1, OFF, OFF, OFF, OFF);
 
-        when(diagnosticMessageModule.requestDM28(any())).thenReturn(RequestResult.of(dm28_1));
+        when(communicationsModule.requestDM28(any())).thenReturn(RequestResult.of(dm28_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any());
+        verify(communicationsModule).requestDM28(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -174,11 +174,11 @@ public class Part11Step06ControllerTest extends AbstractControllerTest {
         var dtc = DiagnosticTroubleCode.create(123, 1, 1, 1);
         var dm28_0 = DM28PermanentEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc);
 
-        when(diagnosticMessageModule.requestDM28(any())).thenReturn(RequestResult.of(dm28_0));
+        when(communicationsModule.requestDM28(any())).thenReturn(RequestResult.of(dm28_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any());
+        verify(communicationsModule).requestDM28(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part11/Part11Step07ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part11/Part11Step07ControllerTest.java
@@ -39,7 +39,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -65,7 +65,7 @@ public class Part11Step07ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -108,7 +108,7 @@ public class Part11Step07ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               validator);
 
         setup(instance,
@@ -118,7 +118,7 @@ public class Part11Step07ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -128,7 +128,7 @@ public class Part11Step07ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener,
                                  validator);
     }
@@ -166,11 +166,11 @@ public class Part11Step07ControllerTest extends AbstractControllerTest {
 
         var ratio2 = new PerformanceRatio(12, 1, 10, 0);
         var dm20 = DM20MonitorPerformanceRatioPacket.create(0, 1, 0, ratio2);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
 
         var dtc2 = DiagnosticTroubleCode.create(123, 1, 0, 1);
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc2);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         dataRepository.setPart11StartTime(dateTimeModule.getTimeAsLong());
 
@@ -219,8 +219,8 @@ public class Part11Step07ControllerTest extends AbstractControllerTest {
         verify(engineSpeedModule, atLeastOnce()).secondsAtIdle();
         verify(engineSpeedModule, atLeastOnce()).isEngineAtIdle();
 
-        verify(diagnosticMessageModule, atLeastOnce()).requestDM20(any(), eq(0));
-        verify(diagnosticMessageModule, atLeastOnce()).requestDM28(any(), eq(0));
+        verify(communicationsModule, atLeastOnce()).requestDM20(any(), eq(0));
+        verify(communicationsModule, atLeastOnce()).requestDM28(any(), eq(0));
 
         verify(mockListener, times(2)).onUrgentMessage(any(), any(), eq(WARNING), any());
 
@@ -262,7 +262,7 @@ public class Part11Step07ControllerTest extends AbstractControllerTest {
 
         var ratio2 = new PerformanceRatio(12, 1, 11, 0);
         var dm20 = DM20MonitorPerformanceRatioPacket.create(0, 1, 0, ratio2);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
 
         dataRepository.setPart11StartTime(dateTimeModule.getTimeAsLong());
 
@@ -283,7 +283,7 @@ public class Part11Step07ControllerTest extends AbstractControllerTest {
 
         verify(engineSpeedModule, atLeastOnce()).secondsAtSpeed();
 
-        verify(diagnosticMessageModule, times(2)).requestDM20(any(), eq(0));
+        verify(communicationsModule, times(2)).requestDM20(any(), eq(0));
 
         verify(mockListener, times(2)).onUrgentMessage(any(), any(), eq(WARNING), any());
 
@@ -302,7 +302,7 @@ public class Part11Step07ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
 
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         dataRepository.setPart11StartTime(dateTimeModule.getTimeAsLong());
 
@@ -323,7 +323,7 @@ public class Part11Step07ControllerTest extends AbstractControllerTest {
 
         verify(engineSpeedModule, atLeastOnce()).secondsAtSpeed();
 
-        verify(diagnosticMessageModule, times(2)).requestDM28(any(), eq(0));
+        verify(communicationsModule, times(2)).requestDM28(any(), eq(0));
 
         verify(mockListener, times(2)).onUrgentMessage(any(), any(), eq(WARNING), any());
 

--- a/src-test/org/etools/j1939_84/controllers/part11/Part11Step08ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part11/Part11Step08ControllerTest.java
@@ -31,7 +31,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -53,7 +53,7 @@ public class Part11Step08ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -90,7 +90,7 @@ public class Part11Step08ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -99,7 +99,7 @@ public class Part11Step08ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -109,7 +109,7 @@ public class Part11Step08ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -180,7 +180,7 @@ public class Part11Step08ControllerTest extends AbstractControllerTest {
         var ratio123 = new PerformanceRatio(123, 2, 2, 0);
         var ratio5322 = new PerformanceRatio(5322, 0xFFFF, 0xFFFF, 0);
         var dm20 = DM20MonitorPerformanceRatioPacket.create(0, 4, 4, ratio3058, ratio123, ratio5322);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
 
         // Module 1 won't be queried
         dataRepository.putObdModule(new OBDModuleInformation(1));
@@ -190,7 +190,7 @@ public class Part11Step08ControllerTest extends AbstractControllerTest {
         obdModuleInformation2.set(DM20MonitorPerformanceRatioPacket.create(2, 3, 3), 11);
         dataRepository.putObdModule(obdModuleInformation2);
         var nack = AcknowledgmentPacket.create(2, NACK);
-        when(diagnosticMessageModule.requestDM20(any(), eq(2))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM20(any(), eq(2))).thenReturn(BusResult.of(nack));
 
         // Module 3 will respond the same as Module 0
         OBDModuleInformation obdModuleInformation3 = new OBDModuleInformation(3);
@@ -207,13 +207,13 @@ public class Part11Step08ControllerTest extends AbstractControllerTest {
 
         var ratio3058_3 = new PerformanceRatio(3058, 2, 3, 3);
         var dm20_3 = DM20MonitorPerformanceRatioPacket.create(3, 4, 4, ratio3058_3);
-        when(diagnosticMessageModule.requestDM20(any(), eq(3))).thenReturn(BusResult.of(dm20_3));
+        when(communicationsModule.requestDM20(any(), eq(3))).thenReturn(BusResult.of(dm20_3));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM20(any(), eq(2));
-        verify(diagnosticMessageModule).requestDM20(any(), eq(3));
+        verify(communicationsModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(2));
+        verify(communicationsModule).requestDM20(any(), eq(3));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -231,12 +231,12 @@ public class Part11Step08ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation2);
         var nack = AcknowledgmentPacket.create(2, NACK);
 
-        when(diagnosticMessageModule.requestDM20(any(), eq(2))).thenReturn(BusResult.empty())
+        when(communicationsModule.requestDM20(any(), eq(2))).thenReturn(BusResult.empty())
                                                                .thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule, times(2)).requestDM20(any(), eq(2));
+        verify(communicationsModule, times(2)).requestDM20(any(), eq(2));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -266,11 +266,11 @@ public class Part11Step08ControllerTest extends AbstractControllerTest {
 
         var ratio3058 = new PerformanceRatio(3058, 2, 2, 0);
         var dm20 = DM20MonitorPerformanceRatioPacket.create(0, 4, 4, ratio3058);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -290,11 +290,11 @@ public class Part11Step08ControllerTest extends AbstractControllerTest {
         obdModuleInformation2.set(DM20MonitorPerformanceRatioPacket.create(2, 3, 3), 11);
         dataRepository.putObdModule(obdModuleInformation2);
 
-        when(diagnosticMessageModule.requestDM20(any(), eq(2))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM20(any(), eq(2))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule, times(2)).requestDM20(any(), eq(2));
+        verify(communicationsModule, times(2)).requestDM20(any(), eq(2));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -388,11 +388,11 @@ public class Part11Step08ControllerTest extends AbstractControllerTest {
                                                             ratio4792,
                                                             ratio5308,
                                                             ratio4364);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -488,11 +488,11 @@ public class Part11Step08ControllerTest extends AbstractControllerTest {
                                                             ratio3058,
                                                             ratio5318,
                                                             ratio5321);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -542,11 +542,11 @@ public class Part11Step08ControllerTest extends AbstractControllerTest {
 
         var ratio3058 = new PerformanceRatio(3058, 2, 5, 0);
         var dm20 = DM20MonitorPerformanceRatioPacket.create(0, 4, 4, ratio3058);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -576,11 +576,11 @@ public class Part11Step08ControllerTest extends AbstractControllerTest {
 
         var ratio3058 = new PerformanceRatio(3058, 2, 3, 0);
         var dm20 = DM20MonitorPerformanceRatioPacket.create(0, 4, 5, ratio3058);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -610,11 +610,11 @@ public class Part11Step08ControllerTest extends AbstractControllerTest {
 
         var ratio3058 = new PerformanceRatio(3058, 5, 3, 0);
         var dm20 = DM20MonitorPerformanceRatioPacket.create(0, 4, 4, ratio3058);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -644,11 +644,11 @@ public class Part11Step08ControllerTest extends AbstractControllerTest {
 
         var ratio3058 = new PerformanceRatio(3058, 0, 3, 0);
         var dm20 = DM20MonitorPerformanceRatioPacket.create(0, 4, 4, ratio3058);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -678,11 +678,11 @@ public class Part11Step08ControllerTest extends AbstractControllerTest {
 
         var ratio3058 = new PerformanceRatio(3058, 1, 3, 0);
         var dm20 = DM20MonitorPerformanceRatioPacket.create(0, 4, 4, ratio3058);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -712,11 +712,11 @@ public class Part11Step08ControllerTest extends AbstractControllerTest {
 
         var ratio3058 = new PerformanceRatio(3058, 1, 3, 0);
         var dm20 = DM20MonitorPerformanceRatioPacket.create(0, 5, 4, ratio3058);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -746,7 +746,7 @@ public class Part11Step08ControllerTest extends AbstractControllerTest {
 
         var ratio3058 = new PerformanceRatio(3058, 2, 3, 0);
         var dm20 = DM20MonitorPerformanceRatioPacket.create(0, 5, 4, ratio3058);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
 
         OBDModuleInformation obdModuleInformation3 = new OBDModuleInformation(3);
         var ratio3058_1_3 = new PerformanceRatio(3058, 1, 1, 3);
@@ -762,12 +762,12 @@ public class Part11Step08ControllerTest extends AbstractControllerTest {
 
         var ratio3058_3 = new PerformanceRatio(3058, 2, 3, 3);
         var dm20_3 = DM20MonitorPerformanceRatioPacket.create(3, 5, 5, ratio3058_3);
-        when(diagnosticMessageModule.requestDM20(any(), eq(3))).thenReturn(BusResult.of(dm20_3));
+        when(communicationsModule.requestDM20(any(), eq(3))).thenReturn(BusResult.of(dm20_3));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM20(any(), eq(3));
+        verify(communicationsModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(3));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -797,7 +797,7 @@ public class Part11Step08ControllerTest extends AbstractControllerTest {
 
         var ratio3058 = new PerformanceRatio(3058, 2, 3, 0);
         var dm20 = DM20MonitorPerformanceRatioPacket.create(0, 4, 4, ratio3058);
-        when(diagnosticMessageModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
+        when(communicationsModule.requestDM20(any(), eq(0))).thenReturn(BusResult.of(dm20));
 
         OBDModuleInformation obdModuleInformation3 = new OBDModuleInformation(3);
         var ratio3058_1_3 = new PerformanceRatio(3058, 1, 1, 3);
@@ -813,12 +813,12 @@ public class Part11Step08ControllerTest extends AbstractControllerTest {
 
         var ratio3058_3 = new PerformanceRatio(3058, 2, 3, 3);
         var dm20_3 = DM20MonitorPerformanceRatioPacket.create(3, 5, 4, ratio3058_3);
-        when(diagnosticMessageModule.requestDM20(any(), eq(3))).thenReturn(BusResult.of(dm20_3));
+        when(communicationsModule.requestDM20(any(), eq(3))).thenReturn(BusResult.of(dm20_3));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM20(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM20(any(), eq(3));
+        verify(communicationsModule).requestDM20(any(), eq(0));
+        verify(communicationsModule).requestDM20(any(), eq(3));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part11/Part11Step09ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part11/Part11Step09ControllerTest.java
@@ -27,7 +27,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -49,7 +49,7 @@ public class Part11Step09ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -86,7 +86,7 @@ public class Part11Step09ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -95,7 +95,7 @@ public class Part11Step09ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -105,7 +105,7 @@ public class Part11Step09ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -138,16 +138,16 @@ public class Part11Step09ControllerTest extends AbstractControllerTest {
 
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 2);
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc1);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM28(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM28(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM28(any(), eq(1));
+        verify(communicationsModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -160,11 +160,11 @@ public class Part11Step09ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
 
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -180,11 +180,11 @@ public class Part11Step09ControllerTest extends AbstractControllerTest {
 
         var dtc1 = DiagnosticTroubleCode.create(456, 12, 0, 2);
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc1);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -203,15 +203,15 @@ public class Part11Step09ControllerTest extends AbstractControllerTest {
 
         var dtc1 = DiagnosticTroubleCode.create(123, 12, 0, 2);
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc1);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
-        when(diagnosticMessageModule.requestDM28(any(), eq(1))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM28(any(), eq(1))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM28(any(), eq(1));
+        verify(communicationsModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part11/Part11Step10ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part11/Part11Step10ControllerTest.java
@@ -26,7 +26,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -48,7 +48,7 @@ public class Part11Step10ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -85,7 +85,7 @@ public class Part11Step10ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -94,7 +94,7 @@ public class Part11Step10ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -104,7 +104,7 @@ public class Part11Step10ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -165,15 +165,15 @@ public class Part11Step10ControllerTest extends AbstractControllerTest {
                                                                       0x00,
                                                                       0x00));
 
-        when(diagnosticMessageModule.requestDM5(any(), eq(0x00))).thenReturn(BusResult.of(packet0));
-        when(diagnosticMessageModule.requestDM5(any(), eq(0x17))).thenReturn(BusResult.of(packet17));
-        when(diagnosticMessageModule.requestDM5(any(), eq(0x23))).thenReturn(BusResult.of(packet23));
+        when(communicationsModule.requestDM5(any(), eq(0x00))).thenReturn(BusResult.of(packet0));
+        when(communicationsModule.requestDM5(any(), eq(0x17))).thenReturn(BusResult.of(packet17));
+        when(communicationsModule.requestDM5(any(), eq(0x23))).thenReturn(BusResult.of(packet23));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0x00));
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0x17));
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0x23));
+        verify(communicationsModule).requestDM5(any(), eq(0x00));
+        verify(communicationsModule).requestDM5(any(), eq(0x17));
+        verify(communicationsModule).requestDM5(any(), eq(0x23));
 
         assertSame(packet0, dataRepository.getObdModule(0).getLatest(DM5DiagnosticReadinessPacket.class));
 

--- a/src-test/org/etools/j1939_84/controllers/part11/Part11Step11ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part11/Part11Step11ControllerTest.java
@@ -30,7 +30,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -52,7 +52,7 @@ public class Part11Step11ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -89,7 +89,7 @@ public class Part11Step11ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -98,7 +98,7 @@ public class Part11Step11ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -108,7 +108,7 @@ public class Part11Step11ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -138,16 +138,16 @@ public class Part11Step11ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(DM26TripDiagnosticReadinessPacket.create(0, 0, 0), 11);
         dataRepository.putObdModule(obdModuleInformation);
         var dm26 = DM26TripDiagnosticReadinessPacket.create(0, 9, 1);
-        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
+        when(communicationsModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM26(any(), eq(1))).thenReturn(new RequestResult<>(false, nack));
+        when(communicationsModule.requestDM26(any(), eq(1))).thenReturn(new RequestResult<>(false, nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM26(any(), eq(1));
+        verify(communicationsModule).requestDM26(any(), eq(0));
+        verify(communicationsModule).requestDM26(any(), eq(1));
 
         assertSame(dm26, dataRepository.getObdModule(0).getLatest(DM26TripDiagnosticReadinessPacket.class));
         assertNull(dataRepository.getObdModule(1).getLatest(DM26TripDiagnosticReadinessPacket.class));
@@ -184,11 +184,11 @@ public class Part11Step11ControllerTest extends AbstractControllerTest {
         obdModuleInformation.set(DM26TripDiagnosticReadinessPacket.create(0, 0, 0), 11);
         dataRepository.putObdModule(obdModuleInformation);
         var dm26 = DM26TripDiagnosticReadinessPacket.create(0, 100, 1);
-        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
+        when(communicationsModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
+        verify(communicationsModule).requestDM26(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         String expected = "" + NL;
@@ -226,11 +226,11 @@ public class Part11Step11ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation);
         var dm26 = DM26TripDiagnosticReadinessPacket.create(0, 5, 1);
         dm26.getPacket().setTimestamp(LocalDateTime.of(2020, 3, 4, 11, 33, 16));
-        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
+        when(communicationsModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
+        verify(communicationsModule).requestDM26(any(), eq(0));
 
         assertEquals("", listener.getMessages());
 
@@ -264,11 +264,11 @@ public class Part11Step11ControllerTest extends AbstractControllerTest {
     public void testFailureForNoNACK() {
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
-        when(diagnosticMessageModule.requestDM26(any(), eq(1))).thenReturn(new RequestResult<>(true));
+        when(communicationsModule.requestDM26(any(), eq(1))).thenReturn(new RequestResult<>(true));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM26(any(), eq(1));
+        verify(communicationsModule).requestDM26(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part11/Part11Step12ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part11/Part11Step12ControllerTest.java
@@ -26,7 +26,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -48,7 +48,7 @@ public class Part11Step12ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -85,7 +85,7 @@ public class Part11Step12ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -94,7 +94,7 @@ public class Part11Step12ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -104,7 +104,7 @@ public class Part11Step12ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -135,16 +135,16 @@ public class Part11Step12ControllerTest extends AbstractControllerTest {
         obdModuleInformation.setDeltaEngineStart(600.0);
         dataRepository.putObdModule(obdModuleInformation);
         var dm21 = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 0, 10);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM21(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM21(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM21(any(), eq(1));
+        verify(communicationsModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -158,11 +158,11 @@ public class Part11Step12ControllerTest extends AbstractControllerTest {
         obdModuleInformation.setDeltaEngineStart(600.0);
         dataRepository.putObdModule(obdModuleInformation);
         var dm21 = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 0, 11);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -179,11 +179,11 @@ public class Part11Step12ControllerTest extends AbstractControllerTest {
         obdModuleInformation.setDeltaEngineStart(600.0);
         dataRepository.putObdModule(obdModuleInformation);
         var dm21 = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 0, 9);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -200,11 +200,11 @@ public class Part11Step12ControllerTest extends AbstractControllerTest {
         obdModuleInformation.setDeltaEngineStart(600.0);
         dataRepository.putObdModule(obdModuleInformation);
         var dm21 = DM21DiagnosticReadinessPacket.create(0, 0, 0, 1, 0, 10);
-        when(diagnosticMessageModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
+        when(communicationsModule.requestDM21(any(), eq(0))).thenReturn(BusResult.of(dm21));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(0));
+        verify(communicationsModule).requestDM21(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -217,11 +217,11 @@ public class Part11Step12ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForNoNACK() {
         dataRepository.putObdModule(new OBDModuleInformation(1));
-        when(diagnosticMessageModule.requestDM21(any(), eq(1))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM21(any(), eq(1))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any(), eq(1));
+        verify(communicationsModule).requestDM21(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part11/Part11Step13ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part11/Part11Step13ControllerTest.java
@@ -24,7 +24,7 @@ import org.etools.j1939_84.controllers.ResultsListener;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.modules.BannerModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -46,7 +46,7 @@ public class Part11Step13ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -84,7 +84,7 @@ public class Part11Step13ControllerTest extends AbstractControllerTest {
                                               DataRepository.newInstance(),
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -93,7 +93,7 @@ public class Part11Step13ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -102,7 +102,7 @@ public class Part11Step13ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part12/Part12ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part12/Part12ControllerTest.java
@@ -24,7 +24,7 @@ public class Part12ControllerTest extends AbstractPartControllerTest {
                                         DataRepository.newInstance(),
                                         engineSpeedModule,
                                         vehicleInformationModule,
-                                        diagnosticMessageModule,
+                                        communicationsModule,
                                         step01Controller,
                                         step02Controller,
                                         step03Controller,

--- a/src-test/org/etools/j1939_84/controllers/part12/Part12Step01ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part12/Part12Step01ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -50,7 +50,7 @@ public class Part12Step01ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -84,7 +84,7 @@ public class Part12Step01ControllerTest extends AbstractControllerTest {
                                               DataRepository.newInstance(),
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -93,7 +93,7 @@ public class Part12Step01ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -103,7 +103,7 @@ public class Part12Step01ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part12/Part12Step02ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part12/Part12Step02ControllerTest.java
@@ -29,7 +29,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -51,7 +51,7 @@ public class Part12Step02ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -88,7 +88,7 @@ public class Part12Step02ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -97,7 +97,7 @@ public class Part12Step02ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -107,7 +107,7 @@ public class Part12Step02ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -145,7 +145,7 @@ public class Part12Step02ControllerTest extends AbstractControllerTest {
         obdModuleInformation0.set(DM26TripDiagnosticReadinessPacket.create(0, 0, 0, List.of(), List.of()), 11);
         dataRepository.putObdModule(obdModuleInformation0);
         var dm26_0 = DM26TripDiagnosticReadinessPacket.create(0, 0, 0, List.of(), List.of());
-        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26_0));
+        when(communicationsModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26_0));
 
         // Module 1 responds with changing status, but doesn't support any systems (probably not a real world test)
         OBDModuleInformation obdModuleInformation1 = new OBDModuleInformation(1);
@@ -158,12 +158,12 @@ public class Part12Step02ControllerTest extends AbstractControllerTest {
                                   11);
         dataRepository.putObdModule(obdModuleInformation1);
         var dm26_1 = DM26TripDiagnosticReadinessPacket.create(1, 0, 0, List.of(), List.of());
-        when(diagnosticMessageModule.requestDM26(any(), eq(1))).thenReturn(RequestResult.of(dm26_1));
+        when(communicationsModule.requestDM26(any(), eq(1))).thenReturn(RequestResult.of(dm26_1));
 
         // Module 2 NACKs the request
         dataRepository.putObdModule(new OBDModuleInformation(2));
         var nack = AcknowledgmentPacket.create(2, NACK);
-        when(diagnosticMessageModule.requestDM26(any(), eq(2))).thenReturn(new RequestResult<>(false, nack));
+        when(communicationsModule.requestDM26(any(), eq(2))).thenReturn(new RequestResult<>(false, nack));
 
         // Module 3 responds and doesn't change complete state and has all completions
         OBDModuleInformation obdModuleInformation3 = new OBDModuleInformation(3);
@@ -186,14 +186,14 @@ public class Part12Step02ControllerTest extends AbstractControllerTest {
                                                               0,
                                                               List.of(CompositeSystem.values()),
                                                               List.of(CompositeSystem.values()));
-        when(diagnosticMessageModule.requestDM26(any(), eq(3))).thenReturn(RequestResult.of(dm26_3));
+        when(communicationsModule.requestDM26(any(), eq(3))).thenReturn(RequestResult.of(dm26_3));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM26(any(), eq(1));
-        verify(diagnosticMessageModule).requestDM26(any(), eq(2));
-        verify(diagnosticMessageModule).requestDM26(any(), eq(3));
+        verify(communicationsModule).requestDM26(any(), eq(0));
+        verify(communicationsModule).requestDM26(any(), eq(1));
+        verify(communicationsModule).requestDM26(any(), eq(2));
+        verify(communicationsModule).requestDM26(any(), eq(3));
 
         assertSame(dm26_0, dataRepository.getObdModule(0).getLatest(DM26TripDiagnosticReadinessPacket.class));
         assertSame(dm26_1, dataRepository.getObdModule(1).getLatest(DM26TripDiagnosticReadinessPacket.class));
@@ -223,11 +223,11 @@ public class Part12Step02ControllerTest extends AbstractControllerTest {
                                   11);
         dataRepository.putObdModule(obdModuleInformation0);
         var dm26_0 = DM26TripDiagnosticReadinessPacket.create(0, 0, 0, List.of(), List.of());
-        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26_0));
+        when(communicationsModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
+        verify(communicationsModule).requestDM26(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -293,11 +293,11 @@ public class Part12Step02ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForNoNACK() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
-        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of());
+        when(communicationsModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
+        verify(communicationsModule).requestDM26(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part12/Part12Step03ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part12/Part12Step03ControllerTest.java
@@ -30,7 +30,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -52,7 +52,7 @@ public class Part12Step03ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -89,7 +89,7 @@ public class Part12Step03ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -98,7 +98,7 @@ public class Part12Step03ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -108,7 +108,7 @@ public class Part12Step03ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -146,7 +146,7 @@ public class Part12Step03ControllerTest extends AbstractControllerTest {
         obdModuleInformation0.set(DM26TripDiagnosticReadinessPacket.create(0, 0, 0, List.of(), List.of()), 12);
         dataRepository.putObdModule(obdModuleInformation0);
         var dm5_0 = DM5DiagnosticReadinessPacket.create(0, 0, 0, 0x22, List.of(), List.of());
-        when(diagnosticMessageModule.requestDM5(any(), eq(0))).thenReturn(BusResult.of(dm5_0));
+        when(communicationsModule.requestDM5(any(), eq(0))).thenReturn(BusResult.of(dm5_0));
 
         // Module 1 responds with changing status, but doesn't support any systems (probably not a real world test)
         OBDModuleInformation obdModuleInformation1 = new OBDModuleInformation(1);
@@ -165,7 +165,7 @@ public class Part12Step03ControllerTest extends AbstractControllerTest {
                                   12);
         dataRepository.putObdModule(obdModuleInformation1);
         var dm5_1 = DM5DiagnosticReadinessPacket.create(1, 0, 0, 0x22, List.of(), List.of());
-        when(diagnosticMessageModule.requestDM5(any(), eq(1))).thenReturn(BusResult.of(dm5_1));
+        when(communicationsModule.requestDM5(any(), eq(1))).thenReturn(BusResult.of(dm5_1));
 
         // Module 3 responds and doesn't change complete state and has all completions
         OBDModuleInformation obdModuleInformation3 = new OBDModuleInformation(3);
@@ -189,13 +189,13 @@ public class Part12Step03ControllerTest extends AbstractControllerTest {
                                                         0x22,
                                                         List.of(CompositeSystem.values()),
                                                         List.of(CompositeSystem.values()));
-        when(diagnosticMessageModule.requestDM5(any(), eq(3))).thenReturn(BusResult.of(dm5_3));
+        when(communicationsModule.requestDM5(any(), eq(3))).thenReturn(BusResult.of(dm5_3));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM5(any(), eq(1));
-        verify(diagnosticMessageModule).requestDM5(any(), eq(3));
+        verify(communicationsModule).requestDM5(any(), eq(0));
+        verify(communicationsModule).requestDM5(any(), eq(1));
+        verify(communicationsModule).requestDM5(any(), eq(3));
 
         assertEquals("", listener.getMessages());
         String expected = "" + NL;
@@ -233,11 +233,11 @@ public class Part12Step03ControllerTest extends AbstractControllerTest {
         obdModuleInformation0.set(DM26TripDiagnosticReadinessPacket.create(0, 0, 0, List.of(), List.of()), 12);
         dataRepository.putObdModule(obdModuleInformation0);
         var dm5_0 = DM5DiagnosticReadinessPacket.create(0, 0, 0, 0x22, List.of(CompositeSystem.values()), List.of());
-        when(diagnosticMessageModule.requestDM5(any(), eq(0))).thenReturn(BusResult.of(dm5_0));
+        when(communicationsModule.requestDM5(any(), eq(0))).thenReturn(BusResult.of(dm5_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0));
+        verify(communicationsModule).requestDM5(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         String expected = "" + NL;
@@ -345,11 +345,11 @@ public class Part12Step03ControllerTest extends AbstractControllerTest {
                                                         0x22,
                                                         List.of(CompositeSystem.values()),
                                                         List.of(CATALYST));
-        when(diagnosticMessageModule.requestDM5(any(), eq(0))).thenReturn(BusResult.of(dm5_0));
+        when(communicationsModule.requestDM5(any(), eq(0))).thenReturn(BusResult.of(dm5_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM5(any(), eq(0));
+        verify(communicationsModule).requestDM5(any(), eq(0));
 
         assertEquals("", listener.getMessages());
 

--- a/src-test/org/etools/j1939_84/controllers/part12/Part12Step04ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part12/Part12Step04ControllerTest.java
@@ -26,7 +26,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -48,7 +48,7 @@ public class Part12Step04ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -85,7 +85,7 @@ public class Part12Step04ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -94,7 +94,7 @@ public class Part12Step04ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -104,7 +104,7 @@ public class Part12Step04ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -132,16 +132,16 @@ public class Part12Step04ControllerTest extends AbstractControllerTest {
     public void testHappyPathNoFailures() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack = AcknowledgmentPacket.create(1, AcknowledgmentPacket.Response.NACK);
-        when(diagnosticMessageModule.requestDM28(any(), eq(1))).thenReturn(BusResult.of(nack));
+        when(communicationsModule.requestDM28(any(), eq(1))).thenReturn(BusResult.of(nack));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM28(any(), eq(1));
+        verify(communicationsModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(1));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -152,11 +152,11 @@ public class Part12Step04ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var dtc = DiagnosticTroubleCode.create(123, 1, 1, 1);
         var dm28 = DM28PermanentEmissionDTCPacket.create(0, OFF, OFF, OFF, OFF, dtc);
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -169,11 +169,11 @@ public class Part12Step04ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForNoNACK() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
-        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.empty());
+        when(communicationsModule.requestDM28(any(), eq(0))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM28(any(), eq(0));
+        verify(communicationsModule).requestDM28(any(), eq(0));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part12/Part12Step05ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part12/Part12Step05ControllerTest.java
@@ -24,7 +24,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -46,7 +46,7 @@ public class Part12Step05ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -83,7 +83,7 @@ public class Part12Step05ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -92,7 +92,7 @@ public class Part12Step05ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -102,7 +102,7 @@ public class Part12Step05ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -138,11 +138,11 @@ public class Part12Step05ControllerTest extends AbstractControllerTest {
         var dm29_1 = DM29DtcCounts.create(1, 0, 0, 0xFF, 0, 0, 0);
 
         var dm29_2 = DM29DtcCounts.create(2, 0, 0, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0, dm29_1, dm29_2));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0, dm29_1, dm29_2));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -150,11 +150,11 @@ public class Part12Step05ControllerTest extends AbstractControllerTest {
 
     @Test
     public void testNoResponse() {
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of());
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -171,11 +171,11 @@ public class Part12Step05ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
         var dm29_0 = DM29DtcCounts.create(0, 0, 1, 0, 0, 0, 0);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -192,11 +192,11 @@ public class Part12Step05ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
         var dm29_0 = DM29DtcCounts.create(0, 0, 0, 0, 1, 0, 0);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -213,11 +213,11 @@ public class Part12Step05ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
         var dm29_0 = DM29DtcCounts.create(0, 0, 0, 0, 0, 1, 0);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -234,11 +234,11 @@ public class Part12Step05ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
         var dm29_0 = DM29DtcCounts.create(0, 0, 0, 0, 0, 0, 1);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -255,11 +255,11 @@ public class Part12Step05ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
         var dm29_0 = DM29DtcCounts.create(0, 0, 0, 1, 0, 0, 0);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -275,11 +275,11 @@ public class Part12Step05ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModuleInformation0);
         var dm29_0 = DM29DtcCounts.create(0, 0, 0, 0, 0, 0, 0);
 
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -292,11 +292,11 @@ public class Part12Step05ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForNoOBDResponse() {
         var dm29_0 = DM29DtcCounts.create(0, 0, 0, 0, 0, 0, 0);
-        when(diagnosticMessageModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
+        when(communicationsModule.requestDM29(any())).thenReturn(RequestResult.of(dm29_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM29(any());
+        verify(communicationsModule).requestDM29(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part12/Part12Step06ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part12/Part12Step06ControllerTest.java
@@ -27,7 +27,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -49,7 +49,7 @@ public class Part12Step06ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -86,7 +86,7 @@ public class Part12Step06ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -95,7 +95,7 @@ public class Part12Step06ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -105,7 +105,7 @@ public class Part12Step06ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -134,11 +134,11 @@ public class Part12Step06ControllerTest extends AbstractControllerTest {
         var dm1_0 = DM1ActiveDTCsPacket.create(0, OFF, OFF, OFF, OFF);
         var dm1_1 = DM1ActiveDTCsPacket.create(1, NOT_SUPPORTED, OFF, OFF, OFF);
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_1));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_1));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -148,11 +148,11 @@ public class Part12Step06ControllerTest extends AbstractControllerTest {
     public void testWarningForAlternativeOff() {
         var dm1_0 = DM1ActiveDTCsPacket.create(0, ALTERNATE_OFF, OFF, OFF, OFF);
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -166,11 +166,11 @@ public class Part12Step06ControllerTest extends AbstractControllerTest {
     public void testFailureForMILNotOff() {
         var dm1_0 = DM1ActiveDTCsPacket.create(0, ON, OFF, OFF, OFF);
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -185,11 +185,11 @@ public class Part12Step06ControllerTest extends AbstractControllerTest {
         var dtc = DiagnosticTroubleCode.create(123, 1, 1, 1);
         var dm1_0 = DM1ActiveDTCsPacket.create(0, OFF, OFF, OFF, OFF, dtc);
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0));
+        when(communicationsModule.readDM1(any())).thenReturn(List.of(dm1_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).readDM1(any());
+        verify(communicationsModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part12/Part12Step07ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part12/Part12Step07ControllerTest.java
@@ -23,7 +23,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -45,7 +45,7 @@ public class Part12Step07ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -82,7 +82,7 @@ public class Part12Step07ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -91,7 +91,7 @@ public class Part12Step07ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -101,7 +101,7 @@ public class Part12Step07ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -133,11 +133,11 @@ public class Part12Step07ControllerTest extends AbstractControllerTest {
         var dm21_1 = DM21DiagnosticReadinessPacket.create(1, 0, 0, 0, 0, 0xFFFF);
         var dm21_3 = DM21DiagnosticReadinessPacket.create(3, 0, 0, 0, 0, 11);
 
-        when(diagnosticMessageModule.requestDM21(any())).thenReturn(RequestResult.of(dm21_0, dm21_1, dm21_3));
+        when(communicationsModule.requestDM21(any())).thenReturn(RequestResult.of(dm21_0, dm21_1, dm21_3));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any());
+        verify(communicationsModule).requestDM21(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -147,11 +147,11 @@ public class Part12Step07ControllerTest extends AbstractControllerTest {
     @Test
     public void testNoResponse() {
 
-        when(diagnosticMessageModule.requestDM21(any())).thenReturn(RequestResult.of());
+        when(communicationsModule.requestDM21(any())).thenReturn(RequestResult.of());
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any());
+        verify(communicationsModule).requestDM21(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -167,11 +167,11 @@ public class Part12Step07ControllerTest extends AbstractControllerTest {
 
         var dm21_0 = DM21DiagnosticReadinessPacket.create(0, 0, 0, 1, 0, 10);
 
-        when(diagnosticMessageModule.requestDM21(any())).thenReturn(RequestResult.of(dm21_0));
+        when(communicationsModule.requestDM21(any())).thenReturn(RequestResult.of(dm21_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any());
+        verify(communicationsModule).requestDM21(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -187,11 +187,11 @@ public class Part12Step07ControllerTest extends AbstractControllerTest {
 
         var dm21_0 = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 0, 9);
 
-        when(diagnosticMessageModule.requestDM21(any())).thenReturn(RequestResult.of(dm21_0));
+        when(communicationsModule.requestDM21(any())).thenReturn(RequestResult.of(dm21_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any());
+        verify(communicationsModule).requestDM21(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -208,11 +208,11 @@ public class Part12Step07ControllerTest extends AbstractControllerTest {
         var dm21_0 = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 0, 10);
         var dm21_3 = DM21DiagnosticReadinessPacket.create(3, 0, 0, 0, 0, 12);
 
-        when(diagnosticMessageModule.requestDM21(any())).thenReturn(RequestResult.of(dm21_0, dm21_3));
+        when(communicationsModule.requestDM21(any())).thenReturn(RequestResult.of(dm21_0, dm21_3));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any());
+        verify(communicationsModule).requestDM21(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
@@ -226,11 +226,11 @@ public class Part12Step07ControllerTest extends AbstractControllerTest {
     public void testFailureForNoOBDResponse() {
         var dm21_0 = DM21DiagnosticReadinessPacket.create(0, 0, 0, 0, 0, 10);
 
-        when(diagnosticMessageModule.requestDM21(any())).thenReturn(RequestResult.of(dm21_0));
+        when(communicationsModule.requestDM21(any())).thenReturn(RequestResult.of(dm21_0));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestDM21(any());
+        verify(communicationsModule).requestDM21(any());
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part12/Part12Step08ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part12/Part12Step08ControllerTest.java
@@ -23,7 +23,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -45,7 +45,7 @@ public class Part12Step08ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -82,7 +82,7 @@ public class Part12Step08ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -91,7 +91,7 @@ public class Part12Step08ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -101,7 +101,7 @@ public class Part12Step08ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -137,26 +137,26 @@ public class Part12Step08ControllerTest extends AbstractControllerTest {
 
         var str123 = ScaledTestResult.create(250, 123, 14, 0, 1, 10, 0);
         var dm30_123 = DM30ScaledTestResultsPacket.create(0, 0, str123);
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0),
-                                                        eq(250),
-                                                        eq(123),
-                                                        eq(14))).thenReturn(List.of(dm30_123));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0),
+                                                     eq(250),
+                                                     eq(123),
+                                                     eq(14))).thenReturn(List.of(dm30_123));
 
         var str456 = ScaledTestResult.create(250, 456, 9, 0, 0, 0, 0);
         var dm30_456 = DM30ScaledTestResultsPacket.create(0, 0, str456, str456);
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0),
-                                                        eq(250),
-                                                        eq(456),
-                                                        eq(9))).thenReturn(List.of(dm30_456));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0),
+                                                     eq(250),
+                                                     eq(456),
+                                                     eq(9))).thenReturn(List.of(dm30_456));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(250), eq(123), eq(14));
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(250), eq(456), eq(9));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(250), eq(123), eq(14));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(250), eq(456), eq(9));
 
         List<ScaledTestResult> nonInitializedTests = dataRepository.getObdModule(0).getNonInitializedTests();
         assertEquals(1, nonInitializedTests.size());

--- a/src-test/org/etools/j1939_84/controllers/part12/Part12Step09ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part12/Part12Step09ControllerTest.java
@@ -28,7 +28,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -50,7 +50,7 @@ public class Part12Step09ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -92,7 +92,7 @@ public class Part12Step09ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule,
+                                              communicationsModule,
                                               verifier);
 
         setup(instance,
@@ -102,7 +102,7 @@ public class Part12Step09ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -112,7 +112,7 @@ public class Part12Step09ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener,
                                  verifier);
     }
@@ -141,22 +141,22 @@ public class Part12Step09ControllerTest extends AbstractControllerTest {
     public void testHappyPathNoFailures() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var nack0 = AcknowledgmentPacket.create(0, NACK);
-        when(diagnosticMessageModule.requestDM11(any(), eq(0))).thenReturn(List.of(nack0));
+        when(communicationsModule.requestDM11(any(), eq(0))).thenReturn(List.of(nack0));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
         var nack1 = AcknowledgmentPacket.create(1, NACK);
-        when(diagnosticMessageModule.requestDM11(any(), eq(1))).thenReturn(List.of(nack1));
+        when(communicationsModule.requestDM11(any(), eq(1))).thenReturn(List.of(nack1));
 
         var ack = AcknowledgmentPacket.create(2, ACK);
-        when(diagnosticMessageModule.requestDM11(any())).thenReturn(List.of(ack));
+        when(communicationsModule.requestDM11(any())).thenReturn(List.of(ack));
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
 
-        verify(diagnosticMessageModule).requestDM11(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM11(any(), eq(1));
-        verify(diagnosticMessageModule).requestDM11(any());
+        verify(communicationsModule).requestDM11(any(), eq(0));
+        verify(communicationsModule).requestDM11(any(), eq(1));
+        verify(communicationsModule).requestDM11(any());
 
         verify(verifier).verifyDataNotPartialErased(any(), eq("6.12.9.2.b"), eq("6.12.9.2.c"), eq(false));
         verify(verifier).verifyDataNotPartialErased(any(), eq("6.12.9.4.c"), eq("6.12.9.4.d"), eq(true));
@@ -173,16 +173,16 @@ public class Part12Step09ControllerTest extends AbstractControllerTest {
     @Test
     public void testFailureForNoNACK() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
-        when(diagnosticMessageModule.requestDM11(any(), eq(0))).thenReturn(List.of());
+        when(communicationsModule.requestDM11(any(), eq(0))).thenReturn(List.of());
 
-        when(diagnosticMessageModule.requestDM11(any())).thenReturn(List.of());
+        when(communicationsModule.requestDM11(any())).thenReturn(List.of());
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
 
-        verify(diagnosticMessageModule).requestDM11(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM11(any());
+        verify(communicationsModule).requestDM11(any(), eq(0));
+        verify(communicationsModule).requestDM11(any());
 
         verify(verifier).verifyDataNotPartialErased(any(), eq("6.12.9.2.b"), eq("6.12.9.2.c"), eq(false));
         verify(verifier).verifyDataNotPartialErased(any(), eq("6.12.9.4.c"), eq("6.12.9.4.d"), eq(true));
@@ -203,16 +203,16 @@ public class Part12Step09ControllerTest extends AbstractControllerTest {
     public void testFailureForNACK() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var nack0 = AcknowledgmentPacket.create(0, NACK);
-        when(diagnosticMessageModule.requestDM11(any(), eq(0))).thenReturn(List.of(nack0));
+        when(communicationsModule.requestDM11(any(), eq(0))).thenReturn(List.of(nack0));
 
-        when(diagnosticMessageModule.requestDM11(any())).thenReturn(List.of(nack0));
+        when(communicationsModule.requestDM11(any())).thenReturn(List.of(nack0));
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
 
-        verify(diagnosticMessageModule).requestDM11(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM11(any());
+        verify(communicationsModule).requestDM11(any(), eq(0));
+        verify(communicationsModule).requestDM11(any());
 
         verify(verifier).verifyDataNotPartialErased(any(), eq("6.12.9.2.b"), eq("6.12.9.2.c"), eq(false));
         verify(verifier).verifyDataNotPartialErased(any(), eq("6.12.9.4.c"), eq("6.12.9.4.d"), eq(true));
@@ -233,17 +233,17 @@ public class Part12Step09ControllerTest extends AbstractControllerTest {
     public void testWarningForACK() {
         dataRepository.putObdModule(new OBDModuleInformation(0));
         var nack0 = AcknowledgmentPacket.create(0, NACK);
-        when(diagnosticMessageModule.requestDM11(any(), eq(0))).thenReturn(List.of(nack0));
+        when(communicationsModule.requestDM11(any(), eq(0))).thenReturn(List.of(nack0));
 
         var ack0 = AcknowledgmentPacket.create(0, ACK);
-        when(diagnosticMessageModule.requestDM11(any())).thenReturn(List.of(ack0));
+        when(communicationsModule.requestDM11(any())).thenReturn(List.of(ack0));
 
         runTest();
 
         verify(verifier).setJ1939(j1939);
 
-        verify(diagnosticMessageModule).requestDM11(any(), eq(0));
-        verify(diagnosticMessageModule).requestDM11(any());
+        verify(communicationsModule).requestDM11(any(), eq(0));
+        verify(communicationsModule).requestDM11(any());
 
         verify(verifier).verifyDataNotPartialErased(any(), eq("6.12.9.2.b"), eq("6.12.9.2.c"), eq(false));
         verify(verifier).verifyDataNotPartialErased(any(), eq("6.12.9.4.c"), eq("6.12.9.4.d"), eq(true));

--- a/src-test/org/etools/j1939_84/controllers/part12/Part12Step10ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part12/Part12Step10ControllerTest.java
@@ -23,7 +23,7 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.TestDateTimeModule;
@@ -45,7 +45,7 @@ public class Part12Step10ControllerTest extends AbstractControllerTest {
     private BannerModule bannerModule;
 
     @Mock
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     @Mock
     private EngineSpeedModule engineSpeedModule;
@@ -82,7 +82,7 @@ public class Part12Step10ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              communicationsModule);
 
         setup(instance,
               listener,
@@ -91,7 +91,7 @@ public class Part12Step10ControllerTest extends AbstractControllerTest {
               reportFileModule,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
     }
 
     @After
@@ -101,7 +101,7 @@ public class Part12Step10ControllerTest extends AbstractControllerTest {
                                  bannerModule,
                                  engineSpeedModule,
                                  vehicleInformationModule,
-                                 diagnosticMessageModule,
+                                 communicationsModule,
                                  mockListener);
     }
 
@@ -137,26 +137,26 @@ public class Part12Step10ControllerTest extends AbstractControllerTest {
 
         var str123 = ScaledTestResult.create(250, 123, 14, 0, 0, 0, 0);
         var dm30_123 = DM30ScaledTestResultsPacket.create(0, 0, str123);
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0),
-                                                        eq(250),
-                                                        eq(123),
-                                                        eq(14))).thenReturn(List.of(dm30_123));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0),
+                                                     eq(250),
+                                                     eq(123),
+                                                     eq(14))).thenReturn(List.of(dm30_123));
 
         var str456 = ScaledTestResult.create(250, 456, 9, 0, 0, 0, 0);
         var dm30_456 = DM30ScaledTestResultsPacket.create(0, 0, str456, str456);
-        when(diagnosticMessageModule.requestTestResults(any(),
-                                                        eq(0),
-                                                        eq(250),
-                                                        eq(456),
-                                                        eq(9))).thenReturn(List.of(dm30_456));
+        when(communicationsModule.requestTestResults(any(),
+                                                     eq(0),
+                                                     eq(250),
+                                                     eq(456),
+                                                     eq(9))).thenReturn(List.of(dm30_456));
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
         runTest();
 
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(250), eq(123), eq(14));
-        verify(diagnosticMessageModule).requestTestResults(any(), eq(0), eq(250), eq(456), eq(9));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(250), eq(123), eq(14));
+        verify(communicationsModule).requestTestResults(any(), eq(0), eq(250), eq(456), eq(9));
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/modules/CommunicationsModuleTest.java
+++ b/src-test/org/etools/j1939_84/modules/CommunicationsModuleTest.java
@@ -55,13 +55,13 @@ import org.mockito.junit.MockitoJUnitRunner;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
- * Unit tests for the {@link DiagnosticMessageModule} class
+ * Unit tests for the {@link CommunicationsModule} class
  *
  * @author Matt Gumbel (matt@soliddesign.net)
  */
 @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT", justification = "The values returned are properly ignored on verify statements.")
 @RunWith(MockitoJUnitRunner.class)
-public class DiagnosticMessageModuleTest {
+public class CommunicationsModuleTest {
 
     public static final int REQUEST_PGN = 0xEA00;
     public static final int ACK_PGN = AcknowledgmentPacket.PGN;
@@ -69,7 +69,7 @@ public class DiagnosticMessageModuleTest {
      * The Bus address of the tool for testing purposes
      */
     private static final int BUS_ADDR = 0xA5;
-    private DiagnosticMessageModule instance;
+    private CommunicationsModule instance;
 
     @Spy
     private J1939 j1939;
@@ -78,7 +78,7 @@ public class DiagnosticMessageModuleTest {
     public void setUp() throws Exception {
         DataRepository.clearInstance();
         DateTimeModule.setInstance(new TestDateTimeModule());
-        instance = new DiagnosticMessageModule();
+        instance = new CommunicationsModule();
         instance.setJ1939(j1939);
     }
 

--- a/src-test/org/etools/j1939_84/modules/DiagnosticReadinessModuleTest.java
+++ b/src-test/org/etools/j1939_84/modules/DiagnosticReadinessModuleTest.java
@@ -9,7 +9,7 @@ import static org.etools.j1939_84.bus.j1939.packets.CompositeSystem.AC_SYSTEM_RE
 import static org.etools.j1939_84.bus.j1939.packets.CompositeSystem.BOOST_PRESSURE_CONTROL_SYS;
 import static org.etools.j1939_84.bus.j1939.packets.CompositeSystem.CATALYST;
 import static org.etools.j1939_84.bus.j1939.packets.MonitoredSystemStatus.findStatus;
-import static org.etools.j1939_84.modules.DiagnosticMessageModule.getCompositeSystems;
+import static org.etools.j1939_84.modules.CommunicationsModule.getCompositeSystems;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -42,7 +42,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
- * Unit tests for the {@link DiagnosticMessageModule}
+ * Unit tests for the {@link CommunicationsModule}
  *
  * @author Matt Gumbel (matt@soliddesign.net)
  */
@@ -51,7 +51,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class DiagnosticReadinessModuleTest {
 
     private static final int BUS_ADDR = 0xA5;
-    private DiagnosticMessageModule instance;
+    private CommunicationsModule instance;
     @Spy
     private J1939 j1939;
     private TestResultsListener listener;
@@ -64,7 +64,7 @@ public class DiagnosticReadinessModuleTest {
     public void setUp() throws Exception {
         listener = new TestResultsListener();
         DateTimeModule.setInstance(new TestDateTimeModule());
-        instance = new DiagnosticMessageModule();
+        instance = new CommunicationsModule();
         instance.setJ1939(j1939);
         DataRepository.clearInstance();
     }

--- a/src-test/org/etools/j1939_84/utils/AbstractControllerTest.java
+++ b/src-test/org/etools/j1939_84/utils/AbstractControllerTest.java
@@ -10,7 +10,7 @@ import java.util.concurrent.Executor;
 import org.etools.j1939_84.bus.j1939.J1939;
 import org.etools.j1939_84.controllers.Controller;
 import org.etools.j1939_84.controllers.TestResultsListener;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -34,7 +34,7 @@ public abstract class AbstractControllerTest {
 
     private VehicleInformationModule vehicleInformationModule;
 
-    private DiagnosticMessageModule diagnosticMessageModule;
+    private CommunicationsModule communicationsModule;
 
     /**
      * This method will execute a test and capture the results for testing
@@ -51,8 +51,8 @@ public abstract class AbstractControllerTest {
         // this class, we need to verify them here.
         verify(engineSpeedModule).setJ1939(j1939);
         verify(vehicleInformationModule).setJ1939(j1939);
-        if (diagnosticMessageModule != null) {
-            verify(diagnosticMessageModule).setJ1939(j1939);
+        if (communicationsModule != null) {
+            verify(communicationsModule).setJ1939(j1939);
         }
     }
 
@@ -63,7 +63,7 @@ public abstract class AbstractControllerTest {
                          ReportFileModule reportFileModule,
                          EngineSpeedModule engineSpeedModule,
                          VehicleInformationModule vehicleInformationModule,
-                         DiagnosticMessageModule diagnosticMessageModule) {
+                         CommunicationsModule communicationsModule) {
         this.instance = instance;
         this.listener = listener;
         this.engineSpeedModule = engineSpeedModule;
@@ -71,7 +71,7 @@ public abstract class AbstractControllerTest {
         this.reportFileModule = reportFileModule;
         this.executor = executor;
         this.vehicleInformationModule = vehicleInformationModule;
-        this.diagnosticMessageModule = diagnosticMessageModule;
+        this.communicationsModule = communicationsModule;
     }
 
 }

--- a/src/org/etools/j1939_84/controllers/Controller.java
+++ b/src/org/etools/j1939_84/controllers/Controller.java
@@ -20,7 +20,7 @@ import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.model.VehicleInformationListener;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -48,7 +48,7 @@ public abstract class Controller {
     private final PartResultRepository partResultRepository;
     private final VehicleInformationModule vehicleInformationModule;
     private final DateTimeModule dateTimeModule;
-    private final DiagnosticMessageModule diagnosticMessageModule;
+    private final CommunicationsModule communicationsModule;
     private final DataRepository dataRepository;
     private CompositeResultsListener compositeListener;
     private J1939 j1939;
@@ -59,7 +59,7 @@ public abstract class Controller {
                          DataRepository dataRepository,
                          EngineSpeedModule engineSpeedModule,
                          VehicleInformationModule vehicleInformationModule,
-                         DiagnosticMessageModule diagnosticMessageModule) {
+                         CommunicationsModule communicationsModule) {
         this(executor,
              bannerModule,
              dateTimeModule,
@@ -67,7 +67,7 @@ public abstract class Controller {
              PartResultRepository.getInstance(),
              engineSpeedModule,
              vehicleInformationModule,
-             diagnosticMessageModule);
+             communicationsModule);
     }
 
     protected Controller(Executor executor,
@@ -77,13 +77,13 @@ public abstract class Controller {
                          PartResultRepository partResultRepository,
                          EngineSpeedModule engineSpeedModule,
                          VehicleInformationModule vehicleInformationModule,
-                         DiagnosticMessageModule diagnosticMessageModule) {
+                         CommunicationsModule communicationsModule) {
         this.executor = executor;
         this.engineSpeedModule = engineSpeedModule;
         this.bannerModule = bannerModule;
         this.vehicleInformationModule = vehicleInformationModule;
         this.dateTimeModule = dateTimeModule;
-        this.diagnosticMessageModule = diagnosticMessageModule;
+        this.communicationsModule = communicationsModule;
         this.partResultRepository = partResultRepository;
         this.dataRepository = dataRepository;
     }
@@ -307,8 +307,8 @@ public abstract class Controller {
         return vehicleInformationModule;
     }
 
-    protected DiagnosticMessageModule getDiagnosticMessageModule() {
-        return diagnosticMessageModule;
+    protected CommunicationsModule getDiagnosticMessageModule() {
+        return communicationsModule;
     }
 
     protected DataRepository getDataRepository() {

--- a/src/org/etools/j1939_84/controllers/OverallController.java
+++ b/src/org/etools/j1939_84/controllers/OverallController.java
@@ -24,7 +24,7 @@ import org.etools.j1939_84.controllers.part11.Part11Controller;
 import org.etools.j1939_84.controllers.part12.Part12Controller;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -49,7 +49,7 @@ public class OverallController extends Controller {
              dataRepository,
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new Part01Controller(dataRepository),
              new Part02Controller(dataRepository),
              new Part03Controller(dataRepository),
@@ -70,7 +70,7 @@ public class OverallController extends Controller {
                               DataRepository dataRepository,
                               EngineSpeedModule engineSpeedModule,
                               VehicleInformationModule vehicleInformationModule,
-                              DiagnosticMessageModule diagnosticMessageModule,
+                              CommunicationsModule communicationsModule,
                               PartController... partControllers) {
         super(executor,
               bannerModule,
@@ -78,7 +78,7 @@ public class OverallController extends Controller {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
         this.partControllers.addAll(Arrays.asList(partControllers));
     }
 

--- a/src/org/etools/j1939_84/controllers/PartController.java
+++ b/src/org/etools/j1939_84/controllers/PartController.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.model.PartResult;
 import org.etools.j1939_84.model.StepResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -30,7 +30,7 @@ public abstract class PartController extends Controller {
                              DataRepository dataRepository,
                              EngineSpeedModule engineSpeedModule,
                              VehicleInformationModule vehicleInformationModule,
-                             DiagnosticMessageModule diagnosticMessageModule,
+                             CommunicationsModule communicationsModule,
                              int partNumber,
                              StepController... stepControllers) {
         super(executor,
@@ -39,7 +39,7 @@ public abstract class PartController extends Controller {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
         this.partNumber = partNumber;
         this.stepControllers.addAll(Arrays.asList(stepControllers));
     }

--- a/src/org/etools/j1939_84/controllers/SectionA5MessageVerifier.java
+++ b/src/org/etools/j1939_84/controllers/SectionA5MessageVerifier.java
@@ -35,27 +35,27 @@ import org.etools.j1939_84.bus.j1939.packets.MonitoredSystem;
 import org.etools.j1939_84.bus.j1939.packets.MonitoredSystemStatus;
 import org.etools.j1939_84.bus.j1939.packets.ScaledTestResult;
 import org.etools.j1939_84.bus.j1939.packets.SupportedSPN;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
 public class SectionA5MessageVerifier {
 
     private final DataRepository dataRepository;
-    private final DiagnosticMessageModule diagMsgModule;
+    private final CommunicationsModule diagMsgModule;
     private final VehicleInformationModule vehInfoModule;
     private final int partNumber;
     private final int stepNumber;
 
     SectionA5MessageVerifier(int partNumber, int stepNumber) {
         this(DataRepository.getInstance(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new VehicleInformationModule(),
              partNumber,
              stepNumber);
     }
 
     protected SectionA5MessageVerifier(DataRepository dataRepository,
-                                       DiagnosticMessageModule diagMsgModule,
+                                       CommunicationsModule diagMsgModule,
                                        VehicleInformationModule vehInfoModule,
                                        int partNumber,
                                        int stepNumber) {

--- a/src/org/etools/j1939_84/controllers/StepController.java
+++ b/src/org/etools/j1939_84/controllers/StepController.java
@@ -45,7 +45,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -61,7 +61,7 @@ public abstract class StepController extends Controller {
                              DataRepository dataRepository,
                              EngineSpeedModule engineSpeedModule,
                              VehicleInformationModule vehicleInformationModule,
-                             DiagnosticMessageModule diagnosticMessageModule,
+                             CommunicationsModule communicationsModule,
                              int partNumber,
                              int stepNumber,
                              int totalSteps) {
@@ -71,7 +71,7 @@ public abstract class StepController extends Controller {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule);
+              communicationsModule);
         this.partNumber = partNumber;
         this.stepNumber = stepNumber;
         this.totalSteps = totalSteps;

--- a/src/org/etools/j1939_84/controllers/part01/Part01Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Controller.java
@@ -11,7 +11,7 @@ import org.etools.j1939_84.controllers.PartController;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -27,7 +27,7 @@ public class Part01Controller extends PartController {
              dataRepository,
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new Part01Step01Controller(),
              new Part01Step02Controller(),
              new Part01Step03Controller(dataRepository),
@@ -66,7 +66,7 @@ public class Part01Controller extends PartController {
                             DataRepository dataRepository,
                             EngineSpeedModule engineSpeedModule,
                             VehicleInformationModule vehicleInformationModule,
-                            DiagnosticMessageModule diagnosticMessageModule,
+                            CommunicationsModule communicationsModule,
                             StepController... stepControllers) {
         super(executor,
               bannerModule,
@@ -74,7 +74,7 @@ public class Part01Controller extends PartController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               1,
               stepControllers);
     }

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step01Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step01Controller.java
@@ -17,7 +17,7 @@ import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.model.VehicleInformationListener;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -34,7 +34,7 @@ public class Part01Step01Controller extends StepController {
              new EngineSpeedModule(),
              new BannerModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              DataRepository.getInstance(),
              DateTimeModule.getInstance());
     }
@@ -43,7 +43,7 @@ public class Part01Step01Controller extends StepController {
                            EngineSpeedModule engineSpeedModule,
                            BannerModule bannerModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule) {
         super(executor,
@@ -52,7 +52,7 @@ public class Part01Step01Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step02Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step02Controller.java
@@ -12,7 +12,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -32,7 +32,7 @@ public class Part01Step02Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part01Step02Controller(Executor executor,
@@ -41,14 +41,14 @@ public class Part01Step02Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step03Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step03Controller.java
@@ -3,7 +3,7 @@
  */
 package org.etools.j1939_84.controllers.part01;
 
-import static org.etools.j1939_84.modules.DiagnosticMessageModule.getCompositeSystems;
+import static org.etools.j1939_84.modules.CommunicationsModule.getCompositeSystems;
 
 import java.util.List;
 import java.util.concurrent.Executor;
@@ -18,7 +18,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -35,7 +35,7 @@ public class Part01Step03Controller extends StepController {
              new EngineSpeedModule(),
              new BannerModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              dataRepository,
              DateTimeModule.getInstance());
     }
@@ -44,7 +44,7 @@ public class Part01Step03Controller extends StepController {
                            EngineSpeedModule engineSpeedModule,
                            BannerModule bannerModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule) {
         super(executor,
@@ -53,7 +53,7 @@ public class Part01Step03Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step04Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step04Controller.java
@@ -21,7 +21,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.SupportedSpnModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -42,7 +42,7 @@ public class Part01Step04Controller extends StepController {
              new EngineSpeedModule(),
              new BannerModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new SupportedSpnModule(),
              dataRepository,
              DateTimeModule.getInstance());
@@ -52,7 +52,7 @@ public class Part01Step04Controller extends StepController {
                            EngineSpeedModule engineSpeedModule,
                            BannerModule bannerModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            SupportedSpnModule supportedSpnModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule) {
@@ -62,7 +62,7 @@ public class Part01Step04Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step05Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step05Controller.java
@@ -11,7 +11,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 import org.etools.j1939_84.utils.VinDecoder;
@@ -50,7 +50,7 @@ public class Part01Step05Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              new DiagnosticMessageModule(),
+              new CommunicationsModule(),
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step06Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step06Controller.java
@@ -12,7 +12,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -32,7 +32,7 @@ public class Part01Step06Controller extends StepController {
              new VehicleInformationModule(),
              dataRepository,
              DateTimeModule.getInstance(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part01Step06Controller(Executor executor,
@@ -41,14 +41,14 @@ public class Part01Step06Controller extends StepController {
                            VehicleInformationModule vehicleInformationModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step07Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step07Controller.java
@@ -19,7 +19,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 import org.etools.j1939_84.utils.StringUtils;
@@ -40,7 +40,7 @@ public class Part01Step07Controller extends StepController {
              new VehicleInformationModule(),
              dataRepository,
              DateTimeModule.getInstance(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part01Step07Controller(Executor executor,
@@ -49,7 +49,7 @@ public class Part01Step07Controller extends StepController {
                            VehicleInformationModule vehicleInformationModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
 
         super(executor,
               bannerModule,
@@ -57,7 +57,7 @@ public class Part01Step07Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step08Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step08Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -33,7 +33,7 @@ public class Part01Step08Controller extends StepController {
              new EngineSpeedModule(),
              new BannerModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              dataRepository,
              DateTimeModule.getInstance());
     }
@@ -42,7 +42,7 @@ public class Part01Step08Controller extends StepController {
                            EngineSpeedModule engineSpeedModule,
                            BannerModule bannerModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule) {
         super(executor,
@@ -51,7 +51,7 @@ public class Part01Step08Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step09Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step09Controller.java
@@ -20,7 +20,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -40,7 +40,7 @@ public class Part01Step09Controller extends StepController {
              new VehicleInformationModule(),
              dataRepository,
              DateTimeModule.getInstance(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     protected Part01Step09Controller(Executor executor,
@@ -49,14 +49,14 @@ public class Part01Step09Controller extends StepController {
                                      VehicleInformationModule vehicleInformationModule,
                                      DataRepository dataRepository,
                                      DateTimeModule dateTimeModule,
-                                     DiagnosticMessageModule diagnosticMessageModule) {
+                                     CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step10Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step10Controller.java
@@ -18,7 +18,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -36,7 +36,7 @@ public class Part01Step10Controller extends StepController {
              new EngineSpeedModule(),
              new BannerModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              DateTimeModule.getInstance(),
              dataRepository);
     }
@@ -45,7 +45,7 @@ public class Part01Step10Controller extends StepController {
                                      EngineSpeedModule engineSpeedModule,
                                      BannerModule bannerModule,
                                      VehicleInformationModule vehicleInformationModule,
-                                     DiagnosticMessageModule diagnosticMessageModule,
+                                     CommunicationsModule communicationsModule,
                                      DateTimeModule dateTimeModule,
                                      DataRepository dataRepository) {
         super(executor,
@@ -54,7 +54,7 @@ public class Part01Step10Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step11Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step11Controller.java
@@ -14,7 +14,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -31,7 +31,7 @@ public class Part01Step11Controller extends StepController {
         this(Executors.newSingleThreadScheduledExecutor(),
              new EngineSpeedModule(),
              new BannerModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new VehicleInformationModule(),
              dataRepository,
              DateTimeModule.getInstance());
@@ -40,7 +40,7 @@ public class Part01Step11Controller extends StepController {
     Part01Step11Controller(Executor executor,
                            EngineSpeedModule engineSpeedModule,
                            BannerModule bannerModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            VehicleInformationModule vehicleInformationModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule) {
@@ -50,7 +50,7 @@ public class Part01Step11Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step12Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step12Controller.java
@@ -24,7 +24,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -57,7 +57,7 @@ public class Part01Step12Controller extends StepController {
              new BannerModule(),
              dataRepository,
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new TableA7Validator(),
              DateTimeModule.getInstance());
     }
@@ -67,7 +67,7 @@ public class Part01Step12Controller extends StepController {
                            BannerModule bannerModule,
                            DataRepository dataRepository,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            TableA7Validator tableA7Validator,
                            DateTimeModule dateTimeModule) {
         super(executor,
@@ -76,7 +76,7 @@ public class Part01Step12Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step13Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step13Controller.java
@@ -3,7 +3,7 @@
  */
 package org.etools.j1939_84.controllers.part01;
 
-import static org.etools.j1939_84.modules.DiagnosticMessageModule.getCompositeSystems;
+import static org.etools.j1939_84.modules.CommunicationsModule.getCompositeSystems;
 
 import java.util.Collection;
 import java.util.List;
@@ -21,7 +21,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -41,7 +41,7 @@ public class Part01Step13Controller extends StepController {
              new EngineSpeedModule(),
              new BannerModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              dataRepository,
              new SectionA6Validator(dataRepository, PART_NUMBER, STEP_NUMBER),
              DateTimeModule.getInstance());
@@ -51,7 +51,7 @@ public class Part01Step13Controller extends StepController {
                            EngineSpeedModule engineSpeedModule,
                            BannerModule bannerModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            DataRepository dataRepository,
                            SectionA6Validator sectionA6Validator,
                            DateTimeModule dateTimeModule) {
@@ -61,7 +61,7 @@ public class Part01Step13Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step14Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step14Controller.java
@@ -3,7 +3,7 @@
  */
 package org.etools.j1939_84.controllers.part01;
 
-import static org.etools.j1939_84.modules.DiagnosticMessageModule.getCompositeSystems;
+import static org.etools.j1939_84.modules.CommunicationsModule.getCompositeSystems;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -18,7 +18,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -36,7 +36,7 @@ public class Part01Step14Controller extends StepController {
              new EngineSpeedModule(),
              new BannerModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              dataRepository,
              DateTimeModule.getInstance());
     }
@@ -45,7 +45,7 @@ public class Part01Step14Controller extends StepController {
                            EngineSpeedModule engineSpeedModule,
                            BannerModule bannerModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule) {
         super(executor,
@@ -54,7 +54,7 @@ public class Part01Step14Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step15Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step15Controller.java
@@ -18,7 +18,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -36,7 +36,7 @@ public class Part01Step15Controller extends StepController {
              new EngineSpeedModule(),
              new BannerModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              dataRepository,
              DateTimeModule.getInstance());
     }
@@ -45,7 +45,7 @@ public class Part01Step15Controller extends StepController {
                            EngineSpeedModule engineSpeedModule,
                            BannerModule bannerModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule) {
         super(executor,
@@ -54,7 +54,7 @@ public class Part01Step15Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step16Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step16Controller.java
@@ -17,7 +17,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -35,7 +35,7 @@ public class Part01Step16Controller extends StepController {
              new EngineSpeedModule(),
              new BannerModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              dataRepository,
              DateTimeModule.getInstance());
     }
@@ -44,7 +44,7 @@ public class Part01Step16Controller extends StepController {
                                      EngineSpeedModule engineSpeedModule,
                                      BannerModule bannerModule,
                                      VehicleInformationModule vehicleInformationModule,
-                                     DiagnosticMessageModule diagnosticMessageModule,
+                                     CommunicationsModule communicationsModule,
                                      DataRepository dataRepository,
                                      DateTimeModule dateTimeModule) {
         super(executor,
@@ -53,7 +53,7 @@ public class Part01Step16Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step17Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step17Controller.java
@@ -13,7 +13,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -31,7 +31,7 @@ public class Part01Step17Controller extends StepController {
              new EngineSpeedModule(),
              new BannerModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              dataRepository,
              DateTimeModule.getInstance());
     }
@@ -40,7 +40,7 @@ public class Part01Step17Controller extends StepController {
                            EngineSpeedModule engineSpeedModule,
                            BannerModule bannerModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule) {
         super(executor,
@@ -49,7 +49,7 @@ public class Part01Step17Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step18Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step18Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -34,7 +34,7 @@ public class Part01Step18Controller extends StepController {
              new EngineSpeedModule(),
              new BannerModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              dataRepository,
              DateTimeModule.getInstance());
     }
@@ -43,7 +43,7 @@ public class Part01Step18Controller extends StepController {
                            EngineSpeedModule engineSpeedModule,
                            BannerModule bannerModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule) {
         super(executor,
@@ -52,7 +52,7 @@ public class Part01Step18Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step19Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step19Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -33,7 +33,7 @@ public class Part01Step19Controller extends StepController {
              new EngineSpeedModule(),
              new BannerModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              dataRepository,
              DateTimeModule.getInstance());
     }
@@ -42,7 +42,7 @@ public class Part01Step19Controller extends StepController {
                            EngineSpeedModule engineSpeedModule,
                            BannerModule bannerModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule) {
         super(executor,
@@ -51,7 +51,7 @@ public class Part01Step19Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step20Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step20Controller.java
@@ -14,7 +14,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -32,7 +32,7 @@ public class Part01Step20Controller extends StepController {
              new EngineSpeedModule(),
              new BannerModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              dataRepository,
              DateTimeModule.getInstance());
     }
@@ -41,7 +41,7 @@ public class Part01Step20Controller extends StepController {
                            EngineSpeedModule engineSpeedModule,
                            BannerModule bannerModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule) {
         super(executor,
@@ -50,7 +50,7 @@ public class Part01Step20Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step21Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step21Controller.java
@@ -14,7 +14,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -32,7 +32,7 @@ public class Part01Step21Controller extends StepController {
              new EngineSpeedModule(),
              new BannerModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              dataRepository,
              DateTimeModule.getInstance());
     }
@@ -41,7 +41,7 @@ public class Part01Step21Controller extends StepController {
                            EngineSpeedModule engineSpeedModule,
                            BannerModule bannerModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule) {
         super(executor,
@@ -50,7 +50,7 @@ public class Part01Step21Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step22Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step22Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -33,7 +33,7 @@ public class Part01Step22Controller extends StepController {
              new EngineSpeedModule(),
              new BannerModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              dataRepository,
              DateTimeModule.getInstance());
     }
@@ -42,7 +42,7 @@ public class Part01Step22Controller extends StepController {
                            EngineSpeedModule engineSpeedModule,
                            BannerModule bannerModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule) {
         super(executor,
@@ -51,7 +51,7 @@ public class Part01Step22Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step23Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step23Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -33,7 +33,7 @@ public class Part01Step23Controller extends StepController {
              new EngineSpeedModule(),
              new BannerModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              DateTimeModule.getInstance(),
              DataRepository.getInstance());
     }
@@ -42,7 +42,7 @@ public class Part01Step23Controller extends StepController {
                            EngineSpeedModule engineSpeedModule,
                            BannerModule bannerModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            DateTimeModule dateTimeModule,
                            DataRepository dataRepository) {
         super(executor,
@@ -51,7 +51,7 @@ public class Part01Step23Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step24Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step24Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -33,7 +33,7 @@ public class Part01Step24Controller extends StepController {
              new EngineSpeedModule(),
              new BannerModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              dataRepository,
              DateTimeModule.getInstance());
     }
@@ -42,7 +42,7 @@ public class Part01Step24Controller extends StepController {
                            EngineSpeedModule engineSpeedModule,
                            BannerModule bannerModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule) {
         super(executor,
@@ -51,7 +51,7 @@ public class Part01Step24Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step25Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step25Controller.java
@@ -21,7 +21,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 import org.etools.j1939_84.utils.CollectionUtils;
@@ -40,7 +40,7 @@ public class Part01Step25Controller extends StepController {
              new EngineSpeedModule(),
              new BannerModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              dataRepository,
              DateTimeModule.getInstance());
     }
@@ -49,7 +49,7 @@ public class Part01Step25Controller extends StepController {
                            EngineSpeedModule engineSpeedModule,
                            BannerModule bannerModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule) {
         super(executor,
@@ -58,7 +58,7 @@ public class Part01Step25Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step26Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step26Controller.java
@@ -29,7 +29,7 @@ import org.etools.j1939_84.controllers.TableA1Validator;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -88,7 +88,7 @@ public class Part01Step26Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new TableA1Validator(DataRepository.getInstance(), PART_NUMBER, STEP_NUMBER),
              J1939DaRepository.getInstance(),
              new BroadcastValidator(DataRepository.getInstance(), J1939DaRepository.getInstance()),
@@ -101,7 +101,7 @@ public class Part01Step26Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            TableA1Validator tableA1Validator,
                            J1939DaRepository j1939DaRepository,
                            BroadcastValidator broadcastValidator,
@@ -112,7 +112,7 @@ public class Part01Step26Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               1,
               26,
               0);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step27Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step27Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -35,7 +35,7 @@ public class Part01Step27Controller extends StepController {
              new EngineSpeedModule(),
              new BannerModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              DateTimeModule.getInstance(),
              DataRepository.getInstance());
     }
@@ -44,7 +44,7 @@ public class Part01Step27Controller extends StepController {
                            EngineSpeedModule engineSpeedModule,
                            BannerModule bannerModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            DateTimeModule dateTimeModule,
                            DataRepository dataRepository) {
         super(executor,
@@ -53,7 +53,7 @@ public class Part01Step27Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part01/SectionA6Validator.java
+++ b/src/org/etools/j1939_84/controllers/part01/SectionA6Validator.java
@@ -20,7 +20,7 @@ import org.etools.j1939_84.bus.j1939.packets.ParsedPacket;
 import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.ResultsListener;
 import org.etools.j1939_84.model.RequestResult;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 
 /**
  * @author Marianne Schaefer (marianne.schaefer@gmail.com)
@@ -153,7 +153,7 @@ public class SectionA6Validator {
         // A6.2.b. If one or more responses indicates the status bit for a supported monitor is 1 = not complete,
         // A6.2.b.i. Then the composite vehicle readiness shall indicate 1 = not complete for that status bit/monitor,
         // A6.2..b.ii. Else it shall indicate 0 = complete for that status bit/monitor).
-        var compositeSystems = DiagnosticMessageModule.getCompositeSystems(obdPackets, true);
+        var compositeSystems = CommunicationsModule.getCompositeSystems(obdPackets, true);
 
         // A6.2.c. Fail if composite vehicle readiness does not meet any of the criteria in Table A-6.
         tableA6Validator.verify(listener, compositeSystems, section + " (A6.2.c)");

--- a/src/org/etools/j1939_84/controllers/part02/Part02Controller.java
+++ b/src/org/etools/j1939_84/controllers/part02/Part02Controller.java
@@ -11,7 +11,7 @@ import org.etools.j1939_84.controllers.PartController;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -27,7 +27,7 @@ public class Part02Controller extends PartController {
              dataRepository,
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new Part02Step01Controller(),
              new Part02Step02Controller(dataRepository),
              new Part02Step03Controller(dataRepository),
@@ -57,7 +57,7 @@ public class Part02Controller extends PartController {
                             DataRepository dataRepository,
                             EngineSpeedModule engineSpeedModule,
                             VehicleInformationModule vehicleInformationModule,
-                            DiagnosticMessageModule diagnosticMessageModule,
+                            CommunicationsModule communicationsModule,
                             StepController... stepControllers) {
         super(executor,
               bannerModule,
@@ -65,7 +65,7 @@ public class Part02Controller extends PartController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               2,
               stepControllers);
     }

--- a/src/org/etools/j1939_84/controllers/part02/Part02Step01Controller.java
+++ b/src/org/etools/j1939_84/controllers/part02/Part02Step01Controller.java
@@ -12,7 +12,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -32,7 +32,7 @@ public class Part02Step01Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part02Step01Controller(Executor executor,
@@ -41,14 +41,14 @@ public class Part02Step01Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part02/Part02Step02Controller.java
+++ b/src/org/etools/j1939_84/controllers/part02/Part02Step02Controller.java
@@ -4,7 +4,7 @@
 package org.etools.j1939_84.controllers.part02;
 
 import static org.etools.j1939_84.bus.j1939.Lookup.getAddressName;
-import static org.etools.j1939_84.modules.DiagnosticMessageModule.getCompositeSystems;
+import static org.etools.j1939_84.modules.CommunicationsModule.getCompositeSystems;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,7 +23,7 @@ import org.etools.j1939_84.controllers.part01.SectionA6Validator;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -42,7 +42,7 @@ public class Part02Step02Controller extends StepController {
              new EngineSpeedModule(),
              new BannerModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              DateTimeModule.getInstance(),
              new SectionA6Validator(dataRepository, PART_NUMBER, STEP_NUMBER),
              dataRepository);
@@ -52,7 +52,7 @@ public class Part02Step02Controller extends StepController {
                            EngineSpeedModule engineSpeedModule,
                            BannerModule bannerModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            DateTimeModule dateTimeModule,
                            SectionA6Validator sectionA6Validator,
                            DataRepository dataRepository) {
@@ -62,7 +62,7 @@ public class Part02Step02Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part02/Part02Step03Controller.java
+++ b/src/org/etools/j1939_84/controllers/part02/Part02Step03Controller.java
@@ -16,7 +16,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -34,7 +34,7 @@ public class Part02Step03Controller extends StepController {
              new EngineSpeedModule(),
              new BannerModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              dataRepository,
              DateTimeModule.getInstance());
     }
@@ -43,7 +43,7 @@ public class Part02Step03Controller extends StepController {
                            EngineSpeedModule engineSpeedModule,
                            BannerModule bannerModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule) {
         super(executor,
@@ -52,7 +52,7 @@ public class Part02Step03Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part02/Part02Step04Controller.java
+++ b/src/org/etools/j1939_84/controllers/part02/Part02Step04Controller.java
@@ -16,7 +16,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -34,7 +34,7 @@ public class Part02Step04Controller extends StepController {
              new EngineSpeedModule(),
              new BannerModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              dataRepository,
              DateTimeModule.getInstance());
     }
@@ -43,7 +43,7 @@ public class Part02Step04Controller extends StepController {
                            EngineSpeedModule engineSpeedModule,
                            BannerModule bannerModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule) {
         super(executor,
@@ -52,7 +52,7 @@ public class Part02Step04Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part02/Part02Step05Controller.java
+++ b/src/org/etools/j1939_84/controllers/part02/Part02Step05Controller.java
@@ -18,7 +18,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -39,7 +39,7 @@ public class Part02Step05Controller extends StepController {
              new VehicleInformationModule(),
              dataRepository,
              DateTimeModule.getInstance(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part02Step05Controller(Executor executor,
@@ -48,14 +48,14 @@ public class Part02Step05Controller extends StepController {
                            VehicleInformationModule vehicleInformationModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part02/Part02Step06Controller.java
+++ b/src/org/etools/j1939_84/controllers/part02/Part02Step06Controller.java
@@ -14,7 +14,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -34,7 +34,7 @@ public class Part02Step06Controller extends StepController {
              new VehicleInformationModule(),
              dataRepository,
              DateTimeModule.getInstance(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part02Step06Controller(Executor executor,
@@ -43,14 +43,14 @@ public class Part02Step06Controller extends StepController {
                            VehicleInformationModule vehicleInformationModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part02/Part02Step07Controller.java
+++ b/src/org/etools/j1939_84/controllers/part02/Part02Step07Controller.java
@@ -18,7 +18,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -38,7 +38,7 @@ public class Part02Step07Controller extends StepController {
              dataRepository,
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part02Step07Controller(Executor executor,
@@ -47,14 +47,14 @@ public class Part02Step07Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part02/Part02Step08Controller.java
+++ b/src/org/etools/j1939_84/controllers/part02/Part02Step08Controller.java
@@ -4,7 +4,7 @@
 package org.etools.j1939_84.controllers.part02;
 
 import static org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response.NACK;
-import static org.etools.j1939_84.modules.DiagnosticMessageModule.getCompositeSystems;
+import static org.etools.j1939_84.modules.CommunicationsModule.getCompositeSystems;
 
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -23,7 +23,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -41,7 +41,7 @@ public class Part02Step08Controller extends StepController {
              new EngineSpeedModule(),
              new BannerModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              dataRepository,
              DateTimeModule.getInstance());
     }
@@ -50,7 +50,7 @@ public class Part02Step08Controller extends StepController {
                            EngineSpeedModule engineSpeedModule,
                            BannerModule bannerModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule) {
         super(executor,
@@ -59,7 +59,7 @@ public class Part02Step08Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part02/Part02Step09Controller.java
+++ b/src/org/etools/j1939_84/controllers/part02/Part02Step09Controller.java
@@ -17,7 +17,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -37,7 +37,7 @@ public class Part02Step09Controller extends StepController {
              new VehicleInformationModule(),
              dataRepository,
              DateTimeModule.getInstance(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part02Step09Controller(Executor executor,
@@ -46,14 +46,14 @@ public class Part02Step09Controller extends StepController {
                            VehicleInformationModule vehicleInformationModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part02/Part02Step10Controller.java
+++ b/src/org/etools/j1939_84/controllers/part02/Part02Step10Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -34,7 +34,7 @@ public class Part02Step10Controller extends StepController {
              new BannerModule(),
              dataRepository,
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              DateTimeModule.getInstance());
     }
 
@@ -43,7 +43,7 @@ public class Part02Step10Controller extends StepController {
                            BannerModule bannerModule,
                            DataRepository dataRepository,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            DateTimeModule dateTimeModule) {
         super(executor,
               bannerModule,
@@ -51,7 +51,7 @@ public class Part02Step10Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part02/Part02Step11Controller.java
+++ b/src/org/etools/j1939_84/controllers/part02/Part02Step11Controller.java
@@ -18,7 +18,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -38,7 +38,7 @@ public class Part02Step11Controller extends StepController {
              new VehicleInformationModule(),
              dataRepository,
              DateTimeModule.getInstance(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part02Step11Controller(Executor executor,
@@ -47,14 +47,14 @@ public class Part02Step11Controller extends StepController {
                            VehicleInformationModule vehicleInformationModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part02/Part02Step12Controller.java
+++ b/src/org/etools/j1939_84/controllers/part02/Part02Step12Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -35,7 +35,7 @@ public class Part02Step12Controller extends StepController {
              new VehicleInformationModule(),
              dataRepository,
              DateTimeModule.getInstance(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part02Step12Controller(Executor executor,
@@ -44,14 +44,14 @@ public class Part02Step12Controller extends StepController {
                            VehicleInformationModule vehicleInformationModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part02/Part02Step13Controller.java
+++ b/src/org/etools/j1939_84/controllers/part02/Part02Step13Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -35,7 +35,7 @@ public class Part02Step13Controller extends StepController {
              new VehicleInformationModule(),
              dataRepository,
              DateTimeModule.getInstance(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part02Step13Controller(Executor executor,
@@ -44,14 +44,14 @@ public class Part02Step13Controller extends StepController {
                            VehicleInformationModule vehicleInformationModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part02/Part02Step14Controller.java
+++ b/src/org/etools/j1939_84/controllers/part02/Part02Step14Controller.java
@@ -14,7 +14,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -34,7 +34,7 @@ public class Part02Step14Controller extends StepController {
              new VehicleInformationModule(),
              dataRepository,
              DateTimeModule.getInstance(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part02Step14Controller(Executor executor,
@@ -43,14 +43,14 @@ public class Part02Step14Controller extends StepController {
                            VehicleInformationModule vehicleInformationModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part02/Part02Step15Controller.java
+++ b/src/org/etools/j1939_84/controllers/part02/Part02Step15Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -35,7 +35,7 @@ public class Part02Step15Controller extends StepController {
              new VehicleInformationModule(),
              dataRepository,
              DateTimeModule.getInstance(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part02Step15Controller(Executor executor,
@@ -44,14 +44,14 @@ public class Part02Step15Controller extends StepController {
                            VehicleInformationModule vehicleInformationModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part02/Part02Step16Controller.java
+++ b/src/org/etools/j1939_84/controllers/part02/Part02Step16Controller.java
@@ -21,7 +21,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -41,7 +41,7 @@ public class Part02Step16Controller extends StepController {
              new VehicleInformationModule(),
              dataRepository,
              DateTimeModule.getInstance(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part02Step16Controller(Executor executor,
@@ -50,14 +50,14 @@ public class Part02Step16Controller extends StepController {
                            VehicleInformationModule vehicleInformationModule,
                            DataRepository dataRepository,
                            DateTimeModule dateTimeModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part02/Part02Step17Controller.java
+++ b/src/org/etools/j1939_84/controllers/part02/Part02Step17Controller.java
@@ -27,7 +27,7 @@ import org.etools.j1939_84.controllers.TableA1Validator;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -54,7 +54,7 @@ public class Part02Step17Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new TableA1Validator(DataRepository.getInstance(), PART_NUMBER, STEP_NUMBER),
              J1939DaRepository.getInstance(),
              new BroadcastValidator(DataRepository.getInstance(), J1939DaRepository.getInstance()),
@@ -67,7 +67,7 @@ public class Part02Step17Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            TableA1Validator tableA1Validator,
                            J1939DaRepository j1939DaRepository,
                            BroadcastValidator broadcastValidator,
@@ -78,7 +78,7 @@ public class Part02Step17Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part02/Part02Step18Controller.java
+++ b/src/org/etools/j1939_84/controllers/part02/Part02Step18Controller.java
@@ -16,7 +16,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -36,7 +36,7 @@ public class Part02Step18Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part02Step18Controller(Executor executor,
@@ -45,14 +45,14 @@ public class Part02Step18Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part03/Part03Controller.java
+++ b/src/org/etools/j1939_84/controllers/part03/Part03Controller.java
@@ -11,7 +11,7 @@ import org.etools.j1939_84.controllers.PartController;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -27,7 +27,7 @@ public class Part03Controller extends PartController {
              dataRepository,
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new Part03Step01Controller(),
              new Part03Step02Controller(),
              new Part03Step03Controller(),
@@ -55,7 +55,7 @@ public class Part03Controller extends PartController {
                             DataRepository dataRepository,
                             EngineSpeedModule engineSpeedModule,
                             VehicleInformationModule vehicleInformationModule,
-                            DiagnosticMessageModule diagnosticMessageModule,
+                            CommunicationsModule communicationsModule,
                             StepController... stepControllers) {
         super(executor,
               bannerModule,
@@ -63,7 +63,7 @@ public class Part03Controller extends PartController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               3,
               stepControllers);
     }

--- a/src/org/etools/j1939_84/controllers/part03/Part03Step01Controller.java
+++ b/src/org/etools/j1939_84/controllers/part03/Part03Step01Controller.java
@@ -12,7 +12,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -32,7 +32,7 @@ public class Part03Step01Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part03Step01Controller(Executor executor,
@@ -41,14 +41,14 @@ public class Part03Step01Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part03/Part03Step02Controller.java
+++ b/src/org/etools/j1939_84/controllers/part03/Part03Step02Controller.java
@@ -18,7 +18,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -38,7 +38,7 @@ public class Part03Step02Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part03Step02Controller(Executor executor,
@@ -47,14 +47,14 @@ public class Part03Step02Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part03/Part03Step03Controller.java
+++ b/src/org/etools/j1939_84/controllers/part03/Part03Step03Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -35,7 +35,7 @@ public class Part03Step03Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part03Step03Controller(Executor executor,
@@ -44,14 +44,14 @@ public class Part03Step03Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part03/Part03Step04Controller.java
+++ b/src/org/etools/j1939_84/controllers/part03/Part03Step04Controller.java
@@ -18,7 +18,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -38,7 +38,7 @@ public class Part03Step04Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part03Step04Controller(Executor executor,
@@ -47,14 +47,14 @@ public class Part03Step04Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part03/Part03Step05Controller.java
+++ b/src/org/etools/j1939_84/controllers/part03/Part03Step05Controller.java
@@ -18,7 +18,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -38,7 +38,7 @@ public class Part03Step05Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part03Step05Controller(Executor executor,
@@ -47,14 +47,14 @@ public class Part03Step05Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part03/Part03Step06Controller.java
+++ b/src/org/etools/j1939_84/controllers/part03/Part03Step06Controller.java
@@ -17,7 +17,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -37,7 +37,7 @@ public class Part03Step06Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part03Step06Controller(Executor executor,
@@ -46,14 +46,14 @@ public class Part03Step06Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part03/Part03Step07Controller.java
+++ b/src/org/etools/j1939_84/controllers/part03/Part03Step07Controller.java
@@ -16,7 +16,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -36,7 +36,7 @@ public class Part03Step07Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part03Step07Controller(Executor executor,
@@ -45,14 +45,14 @@ public class Part03Step07Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part03/Part03Step08Controller.java
+++ b/src/org/etools/j1939_84/controllers/part03/Part03Step08Controller.java
@@ -13,7 +13,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -33,7 +33,7 @@ public class Part03Step08Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part03Step08Controller(Executor executor,
@@ -42,14 +42,14 @@ public class Part03Step08Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part03/Part03Step09Controller.java
+++ b/src/org/etools/j1939_84/controllers/part03/Part03Step09Controller.java
@@ -17,7 +17,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -37,7 +37,7 @@ public class Part03Step09Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part03Step09Controller(Executor executor,
@@ -46,14 +46,14 @@ public class Part03Step09Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part03/Part03Step10Controller.java
+++ b/src/org/etools/j1939_84/controllers/part03/Part03Step10Controller.java
@@ -16,7 +16,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -36,7 +36,7 @@ public class Part03Step10Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part03Step10Controller(Executor executor,
@@ -45,14 +45,14 @@ public class Part03Step10Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part03/Part03Step11Controller.java
+++ b/src/org/etools/j1939_84/controllers/part03/Part03Step11Controller.java
@@ -16,7 +16,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -36,7 +36,7 @@ public class Part03Step11Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part03Step11Controller(Executor executor,
@@ -45,14 +45,14 @@ public class Part03Step11Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part03/Part03Step12Controller.java
+++ b/src/org/etools/j1939_84/controllers/part03/Part03Step12Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -35,7 +35,7 @@ public class Part03Step12Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part03Step12Controller(Executor executor,
@@ -44,14 +44,14 @@ public class Part03Step12Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part03/Part03Step13Controller.java
+++ b/src/org/etools/j1939_84/controllers/part03/Part03Step13Controller.java
@@ -27,7 +27,7 @@ import org.etools.j1939_84.controllers.TableA2ValueValidator;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -50,7 +50,7 @@ public class Part03Step13Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new FreezeFrameDataTranslator(),
              new TableA2ValueValidator(PART_NUMBER, STEP_NUMBER));
     }
@@ -61,7 +61,7 @@ public class Part03Step13Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            FreezeFrameDataTranslator translator,
                            TableA2ValueValidator validator) {
         super(executor,
@@ -70,7 +70,7 @@ public class Part03Step13Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part03/Part03Step14Controller.java
+++ b/src/org/etools/j1939_84/controllers/part03/Part03Step14Controller.java
@@ -13,7 +13,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -33,7 +33,7 @@ public class Part03Step14Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part03Step14Controller(Executor executor,
@@ -42,14 +42,14 @@ public class Part03Step14Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part03/Part03Step15Controller.java
+++ b/src/org/etools/j1939_84/controllers/part03/Part03Step15Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -35,7 +35,7 @@ public class Part03Step15Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part03Step15Controller(Executor executor,
@@ -44,14 +44,14 @@ public class Part03Step15Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part03/Part03Step16Controller.java
+++ b/src/org/etools/j1939_84/controllers/part03/Part03Step16Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -35,7 +35,7 @@ public class Part03Step16Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part03Step16Controller(Executor executor,
@@ -44,14 +44,14 @@ public class Part03Step16Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part04/Part04Controller.java
+++ b/src/org/etools/j1939_84/controllers/part04/Part04Controller.java
@@ -11,7 +11,7 @@ import org.etools.j1939_84.controllers.PartController;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -27,7 +27,7 @@ public class Part04Controller extends PartController {
              dataRepository,
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new Part04Step01Controller(),
              new Part04Step02Controller(),
              new Part04Step03Controller(),
@@ -54,7 +54,7 @@ public class Part04Controller extends PartController {
                             DataRepository dataRepository,
                             EngineSpeedModule engineSpeedModule,
                             VehicleInformationModule vehicleInformationModule,
-                            DiagnosticMessageModule diagnosticMessageModule,
+                            CommunicationsModule communicationsModule,
                             StepController... stepControllers) {
         super(executor,
               bannerModule,
@@ -62,7 +62,7 @@ public class Part04Controller extends PartController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               4,
               stepControllers);
     }

--- a/src/org/etools/j1939_84/controllers/part04/Part04Step01Controller.java
+++ b/src/org/etools/j1939_84/controllers/part04/Part04Step01Controller.java
@@ -12,7 +12,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -31,7 +31,7 @@ public class Part04Step01Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part04Step01Controller(Executor executor,
@@ -40,14 +40,14 @@ public class Part04Step01Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part04/Part04Step02Controller.java
+++ b/src/org/etools/j1939_84/controllers/part04/Part04Step02Controller.java
@@ -25,7 +25,7 @@ import org.etools.j1939_84.controllers.QuestionListener;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -44,7 +44,7 @@ public class Part04Step02Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part04Step02Controller(Executor executor,
@@ -53,14 +53,14 @@ public class Part04Step02Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part04/Part04Step03Controller.java
+++ b/src/org/etools/j1939_84/controllers/part04/Part04Step03Controller.java
@@ -20,7 +20,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -39,7 +39,7 @@ public class Part04Step03Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part04Step03Controller(Executor executor,
@@ -48,14 +48,14 @@ public class Part04Step03Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part04/Part04Step04Controller.java
+++ b/src/org/etools/j1939_84/controllers/part04/Part04Step04Controller.java
@@ -14,7 +14,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -33,7 +33,7 @@ public class Part04Step04Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part04Step04Controller(Executor executor,
@@ -42,14 +42,14 @@ public class Part04Step04Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part04/Part04Step05Controller.java
+++ b/src/org/etools/j1939_84/controllers/part04/Part04Step05Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -34,7 +34,7 @@ public class Part04Step05Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part04Step05Controller(Executor executor,
@@ -43,14 +43,14 @@ public class Part04Step05Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part04/Part04Step06Controller.java
+++ b/src/org/etools/j1939_84/controllers/part04/Part04Step06Controller.java
@@ -14,7 +14,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -33,7 +33,7 @@ public class Part04Step06Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part04Step06Controller(Executor executor,
@@ -42,14 +42,14 @@ public class Part04Step06Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part04/Part04Step07Controller.java
+++ b/src/org/etools/j1939_84/controllers/part04/Part04Step07Controller.java
@@ -19,7 +19,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -38,7 +38,7 @@ public class Part04Step07Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part04Step07Controller(Executor executor,
@@ -47,14 +47,14 @@ public class Part04Step07Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part04/Part04Step08Controller.java
+++ b/src/org/etools/j1939_84/controllers/part04/Part04Step08Controller.java
@@ -16,7 +16,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -35,7 +35,7 @@ public class Part04Step08Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part04Step08Controller(Executor executor,
@@ -44,14 +44,14 @@ public class Part04Step08Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part04/Part04Step09Controller.java
+++ b/src/org/etools/j1939_84/controllers/part04/Part04Step09Controller.java
@@ -16,7 +16,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -35,7 +35,7 @@ public class Part04Step09Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part04Step09Controller(Executor executor,
@@ -44,14 +44,14 @@ public class Part04Step09Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part04/Part04Step10Controller.java
+++ b/src/org/etools/j1939_84/controllers/part04/Part04Step10Controller.java
@@ -16,7 +16,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -35,7 +35,7 @@ public class Part04Step10Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part04Step10Controller(Executor executor,
@@ -44,14 +44,14 @@ public class Part04Step10Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part04/Part04Step11Controller.java
+++ b/src/org/etools/j1939_84/controllers/part04/Part04Step11Controller.java
@@ -13,7 +13,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -32,7 +32,7 @@ public class Part04Step11Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part04Step11Controller(Executor executor,
@@ -41,14 +41,14 @@ public class Part04Step11Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part04/Part04Step12Controller.java
+++ b/src/org/etools/j1939_84/controllers/part04/Part04Step12Controller.java
@@ -18,7 +18,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.SpnFmi;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -37,7 +37,7 @@ public class Part04Step12Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part04Step12Controller(Executor executor,
@@ -46,14 +46,14 @@ public class Part04Step12Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part04/Part04Step13Controller.java
+++ b/src/org/etools/j1939_84/controllers/part04/Part04Step13Controller.java
@@ -20,7 +20,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -41,7 +41,7 @@ public class Part04Step13Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new SectionA5Verifier(PART_NUMBER, STEP_NUMBER));
     }
 
@@ -51,7 +51,7 @@ public class Part04Step13Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            SectionA5Verifier verifier) {
         super(executor,
               bannerModule,
@@ -59,7 +59,7 @@ public class Part04Step13Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part04/Part04Step14Controller.java
+++ b/src/org/etools/j1939_84/controllers/part04/Part04Step14Controller.java
@@ -14,7 +14,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -33,7 +33,7 @@ public class Part04Step14Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part04Step14Controller(Executor executor,
@@ -42,14 +42,14 @@ public class Part04Step14Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part04/Part04Step15Controller.java
+++ b/src/org/etools/j1939_84/controllers/part04/Part04Step15Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -34,7 +34,7 @@ public class Part04Step15Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part04Step15Controller(Executor executor,
@@ -43,14 +43,14 @@ public class Part04Step15Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part05/Part05Controller.java
+++ b/src/org/etools/j1939_84/controllers/part05/Part05Controller.java
@@ -11,7 +11,7 @@ import org.etools.j1939_84.controllers.PartController;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -27,7 +27,7 @@ public class Part05Controller extends PartController {
              dataRepository,
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new Part05Step01Controller(),
              new Part05Step02Controller(),
              new Part05Step03Controller(),
@@ -46,7 +46,7 @@ public class Part05Controller extends PartController {
                             DataRepository dataRepository,
                             EngineSpeedModule engineSpeedModule,
                             VehicleInformationModule vehicleInformationModule,
-                            DiagnosticMessageModule diagnosticMessageModule,
+                            CommunicationsModule communicationsModule,
                             StepController... stepControllers) {
         super(executor,
               bannerModule,
@@ -54,7 +54,7 @@ public class Part05Controller extends PartController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               5,
               stepControllers);
     }

--- a/src/org/etools/j1939_84/controllers/part05/Part05Step01Controller.java
+++ b/src/org/etools/j1939_84/controllers/part05/Part05Step01Controller.java
@@ -12,7 +12,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -31,7 +31,7 @@ public class Part05Step01Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part05Step01Controller(Executor executor,
@@ -40,14 +40,14 @@ public class Part05Step01Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part05/Part05Step02Controller.java
+++ b/src/org/etools/j1939_84/controllers/part05/Part05Step02Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -34,7 +34,7 @@ public class Part05Step02Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part05Step02Controller(Executor executor,
@@ -43,14 +43,14 @@ public class Part05Step02Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part05/Part05Step03Controller.java
+++ b/src/org/etools/j1939_84/controllers/part05/Part05Step03Controller.java
@@ -18,7 +18,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -37,7 +37,7 @@ public class Part05Step03Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part05Step03Controller(Executor executor,
@@ -46,14 +46,14 @@ public class Part05Step03Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part05/Part05Step04Controller.java
+++ b/src/org/etools/j1939_84/controllers/part05/Part05Step04Controller.java
@@ -18,7 +18,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -37,7 +37,7 @@ public class Part05Step04Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part05Step04Controller(Executor executor,
@@ -46,14 +46,14 @@ public class Part05Step04Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part05/Part05Step05Controller.java
+++ b/src/org/etools/j1939_84/controllers/part05/Part05Step05Controller.java
@@ -16,7 +16,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -35,7 +35,7 @@ public class Part05Step05Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part05Step05Controller(Executor executor,
@@ -44,14 +44,14 @@ public class Part05Step05Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part05/Part05Step06Controller.java
+++ b/src/org/etools/j1939_84/controllers/part05/Part05Step06Controller.java
@@ -13,7 +13,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -32,7 +32,7 @@ public class Part05Step06Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part05Step06Controller(Executor executor,
@@ -41,14 +41,14 @@ public class Part05Step06Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part05/Part05Step07Controller.java
+++ b/src/org/etools/j1939_84/controllers/part05/Part05Step07Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -31,7 +31,7 @@ public class Part05Step07Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part05Step07Controller(Executor executor,
@@ -40,14 +40,14 @@ public class Part05Step07Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part06/Part06Controller.java
+++ b/src/org/etools/j1939_84/controllers/part06/Part06Controller.java
@@ -11,7 +11,7 @@ import org.etools.j1939_84.controllers.PartController;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -27,7 +27,7 @@ public class Part06Controller extends PartController {
              dataRepository,
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new Part06Step01Controller(),
              new Part06Step02Controller(),
              new Part06Step03Controller(),
@@ -50,7 +50,7 @@ public class Part06Controller extends PartController {
                             DataRepository dataRepository,
                             EngineSpeedModule engineSpeedModule,
                             VehicleInformationModule vehicleInformationModule,
-                            DiagnosticMessageModule diagnosticMessageModule,
+                            CommunicationsModule communicationsModule,
                             StepController... stepControllers) {
         super(executor,
               bannerModule,
@@ -58,7 +58,7 @@ public class Part06Controller extends PartController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               6,
               stepControllers);
     }

--- a/src/org/etools/j1939_84/controllers/part06/Part06Step01Controller.java
+++ b/src/org/etools/j1939_84/controllers/part06/Part06Step01Controller.java
@@ -12,7 +12,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -31,7 +31,7 @@ public class Part06Step01Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part06Step01Controller(Executor executor,
@@ -40,14 +40,14 @@ public class Part06Step01Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part06/Part06Step02Controller.java
+++ b/src/org/etools/j1939_84/controllers/part06/Part06Step02Controller.java
@@ -11,7 +11,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -30,7 +30,7 @@ public class Part06Step02Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part06Step02Controller(Executor executor,
@@ -39,14 +39,14 @@ public class Part06Step02Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part06/Part06Step03Controller.java
+++ b/src/org/etools/j1939_84/controllers/part06/Part06Step03Controller.java
@@ -16,7 +16,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -35,7 +35,7 @@ public class Part06Step03Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part06Step03Controller(Executor executor,
@@ -44,14 +44,14 @@ public class Part06Step03Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part06/Part06Step04Controller.java
+++ b/src/org/etools/j1939_84/controllers/part06/Part06Step04Controller.java
@@ -20,7 +20,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -39,7 +39,7 @@ public class Part06Step04Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part06Step04Controller(Executor executor,
@@ -48,14 +48,14 @@ public class Part06Step04Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part06/Part06Step05Controller.java
+++ b/src/org/etools/j1939_84/controllers/part06/Part06Step05Controller.java
@@ -13,7 +13,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -32,7 +32,7 @@ public class Part06Step05Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part06Step05Controller(Executor executor,
@@ -41,14 +41,14 @@ public class Part06Step05Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part06/Part06Step06Controller.java
+++ b/src/org/etools/j1939_84/controllers/part06/Part06Step06Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -34,7 +34,7 @@ public class Part06Step06Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part06Step06Controller(Executor executor,
@@ -43,14 +43,14 @@ public class Part06Step06Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part06/Part06Step07Controller.java
+++ b/src/org/etools/j1939_84/controllers/part06/Part06Step07Controller.java
@@ -17,7 +17,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -36,7 +36,7 @@ public class Part06Step07Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part06Step07Controller(Executor executor,
@@ -45,14 +45,14 @@ public class Part06Step07Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part06/Part06Step08Controller.java
+++ b/src/org/etools/j1939_84/controllers/part06/Part06Step08Controller.java
@@ -18,7 +18,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -37,7 +37,7 @@ public class Part06Step08Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part06Step08Controller(Executor executor,
@@ -46,14 +46,14 @@ public class Part06Step08Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part06/Part06Step09Controller.java
+++ b/src/org/etools/j1939_84/controllers/part06/Part06Step09Controller.java
@@ -18,7 +18,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -37,7 +37,7 @@ public class Part06Step09Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part06Step09Controller(Executor executor,
@@ -46,14 +46,14 @@ public class Part06Step09Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part06/Part06Step10Controller.java
+++ b/src/org/etools/j1939_84/controllers/part06/Part06Step10Controller.java
@@ -16,7 +16,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -35,7 +35,7 @@ public class Part06Step10Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part06Step10Controller(Executor executor,
@@ -44,14 +44,14 @@ public class Part06Step10Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part06/Part06Step11Controller.java
+++ b/src/org/etools/j1939_84/controllers/part06/Part06Step11Controller.java
@@ -17,7 +17,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -36,7 +36,7 @@ public class Part06Step11Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part06Step11Controller(Executor executor,
@@ -45,14 +45,14 @@ public class Part06Step11Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part07/Part07Controller.java
+++ b/src/org/etools/j1939_84/controllers/part07/Part07Controller.java
@@ -11,7 +11,7 @@ import org.etools.j1939_84.controllers.PartController;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -27,7 +27,7 @@ public class Part07Controller extends PartController {
              dataRepository,
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new Part07Step01Controller(),
              new Part07Step02Controller(),
              new Part07Step03Controller(),
@@ -57,7 +57,7 @@ public class Part07Controller extends PartController {
                             DataRepository dataRepository,
                             EngineSpeedModule engineSpeedModule,
                             VehicleInformationModule vehicleInformationModule,
-                            DiagnosticMessageModule diagnosticMessageModule,
+                            CommunicationsModule communicationsModule,
                             StepController... stepControllers) {
         super(executor,
               bannerModule,
@@ -65,7 +65,7 @@ public class Part07Controller extends PartController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               7,
               stepControllers);
     }

--- a/src/org/etools/j1939_84/controllers/part07/Part07Step01Controller.java
+++ b/src/org/etools/j1939_84/controllers/part07/Part07Step01Controller.java
@@ -12,7 +12,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -31,7 +31,7 @@ public class Part07Step01Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part07Step01Controller(Executor executor,
@@ -40,14 +40,14 @@ public class Part07Step01Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part07/Part07Step02Controller.java
+++ b/src/org/etools/j1939_84/controllers/part07/Part07Step02Controller.java
@@ -17,7 +17,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -36,7 +36,7 @@ public class Part07Step02Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part07Step02Controller(Executor executor,
@@ -45,14 +45,14 @@ public class Part07Step02Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part07/Part07Step03Controller.java
+++ b/src/org/etools/j1939_84/controllers/part07/Part07Step03Controller.java
@@ -20,7 +20,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -39,7 +39,7 @@ public class Part07Step03Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part07Step03Controller(Executor executor,
@@ -48,14 +48,14 @@ public class Part07Step03Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part07/Part07Step04Controller.java
+++ b/src/org/etools/j1939_84/controllers/part07/Part07Step04Controller.java
@@ -14,7 +14,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -33,7 +33,7 @@ public class Part07Step04Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part07Step04Controller(Executor executor,
@@ -42,14 +42,14 @@ public class Part07Step04Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part07/Part07Step05Controller.java
+++ b/src/org/etools/j1939_84/controllers/part07/Part07Step05Controller.java
@@ -14,7 +14,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -33,7 +33,7 @@ public class Part07Step05Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part07Step05Controller(Executor executor,
@@ -42,14 +42,14 @@ public class Part07Step05Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part07/Part07Step06Controller.java
+++ b/src/org/etools/j1939_84/controllers/part07/Part07Step06Controller.java
@@ -14,7 +14,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -34,7 +34,7 @@ public class Part07Step06Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part07Step06Controller(Executor executor,
@@ -43,14 +43,14 @@ public class Part07Step06Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part07/Part07Step07Controller.java
+++ b/src/org/etools/j1939_84/controllers/part07/Part07Step07Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -34,7 +34,7 @@ public class Part07Step07Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part07Step07Controller(Executor executor,
@@ -43,14 +43,14 @@ public class Part07Step07Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part07/Part07Step08Controller.java
+++ b/src/org/etools/j1939_84/controllers/part07/Part07Step08Controller.java
@@ -14,7 +14,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -33,7 +33,7 @@ public class Part07Step08Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part07Step08Controller(Executor executor,
@@ -42,14 +42,14 @@ public class Part07Step08Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part07/Part07Step09Controller.java
+++ b/src/org/etools/j1939_84/controllers/part07/Part07Step09Controller.java
@@ -14,7 +14,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -33,7 +33,7 @@ public class Part07Step09Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part07Step09Controller(Executor executor,
@@ -42,14 +42,14 @@ public class Part07Step09Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part07/Part07Step10Controller.java
+++ b/src/org/etools/j1939_84/controllers/part07/Part07Step10Controller.java
@@ -13,7 +13,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -32,7 +32,7 @@ public class Part07Step10Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part07Step10Controller(Executor executor,
@@ -41,14 +41,14 @@ public class Part07Step10Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part07/Part07Step11Controller.java
+++ b/src/org/etools/j1939_84/controllers/part07/Part07Step11Controller.java
@@ -18,7 +18,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -37,7 +37,7 @@ public class Part07Step11Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part07Step11Controller(Executor executor,
@@ -46,14 +46,14 @@ public class Part07Step11Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part07/Part07Step12Controller.java
+++ b/src/org/etools/j1939_84/controllers/part07/Part07Step12Controller.java
@@ -17,7 +17,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -36,7 +36,7 @@ public class Part07Step12Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part07Step12Controller(Executor executor,
@@ -45,14 +45,14 @@ public class Part07Step12Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part07/Part07Step13Controller.java
+++ b/src/org/etools/j1939_84/controllers/part07/Part07Step13Controller.java
@@ -13,7 +13,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -32,7 +32,7 @@ public class Part07Step13Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part07Step13Controller(Executor executor,
@@ -41,14 +41,14 @@ public class Part07Step13Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part07/Part07Step14Controller.java
+++ b/src/org/etools/j1939_84/controllers/part07/Part07Step14Controller.java
@@ -12,7 +12,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -31,7 +31,7 @@ public class Part07Step14Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part07Step14Controller(Executor executor,
@@ -40,14 +40,14 @@ public class Part07Step14Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part07/Part07Step15Controller.java
+++ b/src/org/etools/j1939_84/controllers/part07/Part07Step15Controller.java
@@ -22,7 +22,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -41,7 +41,7 @@ public class Part07Step15Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part07Step15Controller(Executor executor,
@@ -50,14 +50,14 @@ public class Part07Step15Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part07/Part07Step16Controller.java
+++ b/src/org/etools/j1939_84/controllers/part07/Part07Step16Controller.java
@@ -14,7 +14,7 @@ import org.etools.j1939_84.controllers.SectionA5Verifier;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -35,7 +35,7 @@ public class Part07Step16Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new SectionA5Verifier(PART_NUMBER, STEP_NUMBER));
     }
 
@@ -45,7 +45,7 @@ public class Part07Step16Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            SectionA5Verifier verifier) {
         super(executor,
               bannerModule,
@@ -53,7 +53,7 @@ public class Part07Step16Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part07/Part07Step17Controller.java
+++ b/src/org/etools/j1939_84/controllers/part07/Part07Step17Controller.java
@@ -14,7 +14,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -33,7 +33,7 @@ public class Part07Step17Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part07Step17Controller(Executor executor,
@@ -42,14 +42,14 @@ public class Part07Step17Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part07/Part07Step18Controller.java
+++ b/src/org/etools/j1939_84/controllers/part07/Part07Step18Controller.java
@@ -17,7 +17,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -36,7 +36,7 @@ public class Part07Step18Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part07Step18Controller(Executor executor,
@@ -45,14 +45,14 @@ public class Part07Step18Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part08/Part08Controller.java
+++ b/src/org/etools/j1939_84/controllers/part08/Part08Controller.java
@@ -11,7 +11,7 @@ import org.etools.j1939_84.controllers.PartController;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -27,7 +27,7 @@ public class Part08Controller extends PartController {
              dataRepository,
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new Part08Step01Controller(),
              new Part08Step02Controller(),
              new Part08Step03Controller(),
@@ -55,7 +55,7 @@ public class Part08Controller extends PartController {
                             DataRepository dataRepository,
                             EngineSpeedModule engineSpeedModule,
                             VehicleInformationModule vehicleInformationModule,
-                            DiagnosticMessageModule diagnosticMessageModule,
+                            CommunicationsModule communicationsModule,
                             StepController... stepControllers) {
         super(executor,
               bannerModule,
@@ -63,7 +63,7 @@ public class Part08Controller extends PartController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               8,
               stepControllers);
     }

--- a/src/org/etools/j1939_84/controllers/part08/Part08Step01Controller.java
+++ b/src/org/etools/j1939_84/controllers/part08/Part08Step01Controller.java
@@ -12,7 +12,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -31,7 +31,7 @@ public class Part08Step01Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part08Step01Controller(Executor executor,
@@ -40,14 +40,14 @@ public class Part08Step01Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part08/Part08Step02Controller.java
+++ b/src/org/etools/j1939_84/controllers/part08/Part08Step02Controller.java
@@ -24,7 +24,7 @@ import org.etools.j1939_84.controllers.QuestionListener;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -43,7 +43,7 @@ public class Part08Step02Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part08Step02Controller(Executor executor,
@@ -52,14 +52,14 @@ public class Part08Step02Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part08/Part08Step03Controller.java
+++ b/src/org/etools/j1939_84/controllers/part08/Part08Step03Controller.java
@@ -19,7 +19,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -38,7 +38,7 @@ public class Part08Step03Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part08Step03Controller(Executor executor,
@@ -47,14 +47,14 @@ public class Part08Step03Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part08/Part08Step04Controller.java
+++ b/src/org/etools/j1939_84/controllers/part08/Part08Step04Controller.java
@@ -17,7 +17,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -36,7 +36,7 @@ public class Part08Step04Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part08Step04Controller(Executor executor,
@@ -45,14 +45,14 @@ public class Part08Step04Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part08/Part08Step05Controller.java
+++ b/src/org/etools/j1939_84/controllers/part08/Part08Step05Controller.java
@@ -17,7 +17,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -36,7 +36,7 @@ public class Part08Step05Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part08Step05Controller(Executor executor,
@@ -45,14 +45,14 @@ public class Part08Step05Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part08/Part08Step06Controller.java
+++ b/src/org/etools/j1939_84/controllers/part08/Part08Step06Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -35,7 +35,7 @@ public class Part08Step06Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part08Step06Controller(Executor executor,
@@ -44,14 +44,14 @@ public class Part08Step06Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part08/Part08Step07Controller.java
+++ b/src/org/etools/j1939_84/controllers/part08/Part08Step07Controller.java
@@ -16,7 +16,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -35,7 +35,7 @@ public class Part08Step07Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part08Step07Controller(Executor executor,
@@ -44,14 +44,14 @@ public class Part08Step07Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part08/Part08Step08Controller.java
+++ b/src/org/etools/j1939_84/controllers/part08/Part08Step08Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -34,7 +34,7 @@ public class Part08Step08Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part08Step08Controller(Executor executor,
@@ -43,14 +43,14 @@ public class Part08Step08Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part08/Part08Step09Controller.java
+++ b/src/org/etools/j1939_84/controllers/part08/Part08Step09Controller.java
@@ -19,7 +19,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -38,7 +38,7 @@ public class Part08Step09Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part08Step09Controller(Executor executor,
@@ -47,14 +47,14 @@ public class Part08Step09Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part08/Part08Step10Controller.java
+++ b/src/org/etools/j1939_84/controllers/part08/Part08Step10Controller.java
@@ -18,7 +18,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -37,7 +37,7 @@ public class Part08Step10Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part08Step10Controller(Executor executor,
@@ -46,14 +46,14 @@ public class Part08Step10Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part08/Part08Step11Controller.java
+++ b/src/org/etools/j1939_84/controllers/part08/Part08Step11Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -34,7 +34,7 @@ public class Part08Step11Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part08Step11Controller(Executor executor,
@@ -43,14 +43,14 @@ public class Part08Step11Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part08/Part08Step12Controller.java
+++ b/src/org/etools/j1939_84/controllers/part08/Part08Step12Controller.java
@@ -27,7 +27,7 @@ import org.etools.j1939_84.controllers.SectionA5Verifier;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -48,7 +48,7 @@ public class Part08Step12Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new SectionA5Verifier(PART_NUMBER, STEP_NUMBER));
     }
 
@@ -58,7 +58,7 @@ public class Part08Step12Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            SectionA5Verifier verifier) {
         super(executor,
               bannerModule,
@@ -66,7 +66,7 @@ public class Part08Step12Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part08/Part08Step13Controller.java
+++ b/src/org/etools/j1939_84/controllers/part08/Part08Step13Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -36,7 +36,7 @@ public class Part08Step13Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new SectionA5Verifier(PART_NUMBER, STEP_NUMBER));
     }
 
@@ -46,7 +46,7 @@ public class Part08Step13Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            SectionA5Verifier verifier) {
         super(executor,
               bannerModule,
@@ -54,7 +54,7 @@ public class Part08Step13Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part08/Part08Step14Controller.java
+++ b/src/org/etools/j1939_84/controllers/part08/Part08Step14Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -34,7 +34,7 @@ public class Part08Step14Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part08Step14Controller(Executor executor,
@@ -43,14 +43,14 @@ public class Part08Step14Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part08/Part08Step15Controller.java
+++ b/src/org/etools/j1939_84/controllers/part08/Part08Step15Controller.java
@@ -11,7 +11,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -30,7 +30,7 @@ public class Part08Step15Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part08Step15Controller(Executor executor,
@@ -39,14 +39,14 @@ public class Part08Step15Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part08/Part08Step16Controller.java
+++ b/src/org/etools/j1939_84/controllers/part08/Part08Step16Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -34,7 +34,7 @@ public class Part08Step16Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part08Step16Controller(Executor executor,
@@ -43,14 +43,14 @@ public class Part08Step16Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part09/Part09Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Controller.java
@@ -11,7 +11,7 @@ import org.etools.j1939_84.controllers.PartController;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -27,7 +27,7 @@ public class Part09Controller extends PartController {
              dataRepository,
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new Part09Step01Controller(),
              new Part09Step02Controller(),
              new Part09Step03Controller(),
@@ -64,7 +64,7 @@ public class Part09Controller extends PartController {
                             DataRepository dataRepository,
                             EngineSpeedModule engineSpeedModule,
                             VehicleInformationModule vehicleInformationModule,
-                            DiagnosticMessageModule diagnosticMessageModule,
+                            CommunicationsModule communicationsModule,
                             StepController... stepControllers) {
         super(executor,
               bannerModule,
@@ -72,7 +72,7 @@ public class Part09Controller extends PartController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               9,
               stepControllers);
     }

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step01Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step01Controller.java
@@ -12,7 +12,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -31,7 +31,7 @@ public class Part09Step01Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part09Step01Controller(Executor executor,
@@ -40,14 +40,14 @@ public class Part09Step01Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step02Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step02Controller.java
@@ -16,7 +16,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -35,7 +35,7 @@ public class Part09Step02Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part09Step02Controller(Executor executor,
@@ -44,14 +44,14 @@ public class Part09Step02Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step03Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step03Controller.java
@@ -27,7 +27,7 @@ import org.etools.j1939_84.controllers.SectionA5Verifier;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -48,7 +48,7 @@ public class Part09Step03Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new SectionA5Verifier(PART_NUMBER, STEP_NUMBER));
     }
 
@@ -58,7 +58,7 @@ public class Part09Step03Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            SectionA5Verifier verifier) {
         super(executor,
               bannerModule,
@@ -66,7 +66,7 @@ public class Part09Step03Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step04Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step04Controller.java
@@ -10,7 +10,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -29,7 +29,7 @@ public class Part09Step04Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part09Step04Controller(Executor executor,
@@ -38,14 +38,14 @@ public class Part09Step04Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step05Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step05Controller.java
@@ -13,7 +13,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -32,7 +32,7 @@ public class Part09Step05Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part09Step05Controller(Executor executor,
@@ -41,14 +41,14 @@ public class Part09Step05Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step06Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step06Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -34,7 +34,7 @@ public class Part09Step06Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part09Step06Controller(Executor executor,
@@ -43,14 +43,14 @@ public class Part09Step06Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step07Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step07Controller.java
@@ -12,7 +12,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -31,7 +31,7 @@ public class Part09Step07Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part09Step07Controller(Executor executor,
@@ -40,14 +40,14 @@ public class Part09Step07Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step08Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step08Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -36,7 +36,7 @@ public class Part09Step08Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new SectionA5Verifier(PART_NUMBER, STEP_NUMBER));
     }
 
@@ -46,7 +46,7 @@ public class Part09Step08Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            SectionA5Verifier verifier) {
         super(executor,
               bannerModule,
@@ -54,7 +54,7 @@ public class Part09Step08Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step09Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step09Controller.java
@@ -14,7 +14,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -33,7 +33,7 @@ public class Part09Step09Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part09Step09Controller(Executor executor,
@@ -42,14 +42,14 @@ public class Part09Step09Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step10Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step10Controller.java
@@ -17,7 +17,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.SpnFmi;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -36,7 +36,7 @@ public class Part09Step10Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part09Step10Controller(Executor executor,
@@ -45,14 +45,14 @@ public class Part09Step10Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step11Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step11Controller.java
@@ -17,7 +17,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -36,7 +36,7 @@ public class Part09Step11Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part09Step11Controller(Executor executor,
@@ -45,14 +45,14 @@ public class Part09Step11Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step12Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step12Controller.java
@@ -16,7 +16,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -35,7 +35,7 @@ public class Part09Step12Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part09Step12Controller(Executor executor,
@@ -44,14 +44,14 @@ public class Part09Step12Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step13Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step13Controller.java
@@ -17,7 +17,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -36,7 +36,7 @@ public class Part09Step13Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part09Step13Controller(Executor executor,
@@ -45,14 +45,14 @@ public class Part09Step13Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step14Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step14Controller.java
@@ -12,7 +12,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -31,7 +31,7 @@ public class Part09Step14Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part09Step14Controller(Executor executor,
@@ -40,14 +40,14 @@ public class Part09Step14Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step15Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step15Controller.java
@@ -14,7 +14,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -33,7 +33,7 @@ public class Part09Step15Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part09Step15Controller(Executor executor,
@@ -42,14 +42,14 @@ public class Part09Step15Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step16Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step16Controller.java
@@ -13,7 +13,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -32,7 +32,7 @@ public class Part09Step16Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part09Step16Controller(Executor executor,
@@ -41,14 +41,14 @@ public class Part09Step16Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step17Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step17Controller.java
@@ -13,7 +13,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -32,7 +32,7 @@ public class Part09Step17Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part09Step17Controller(Executor executor,
@@ -41,14 +41,14 @@ public class Part09Step17Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step18Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step18Controller.java
@@ -13,7 +13,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -32,7 +32,7 @@ public class Part09Step18Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part09Step18Controller(Executor executor,
@@ -41,14 +41,14 @@ public class Part09Step18Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step19Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step19Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -34,7 +34,7 @@ public class Part09Step19Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part09Step19Controller(Executor executor,
@@ -43,14 +43,14 @@ public class Part09Step19Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step20Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step20Controller.java
@@ -13,7 +13,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -32,7 +32,7 @@ public class Part09Step20Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part09Step20Controller(Executor executor,
@@ -41,14 +41,14 @@ public class Part09Step20Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step21Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step21Controller.java
@@ -12,7 +12,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -31,7 +31,7 @@ public class Part09Step21Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part09Step21Controller(Executor executor,
@@ -40,14 +40,14 @@ public class Part09Step21Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step22Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step22Controller.java
@@ -14,7 +14,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -33,7 +33,7 @@ public class Part09Step22Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part09Step22Controller(Executor executor,
@@ -42,14 +42,14 @@ public class Part09Step22Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step23Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step23Controller.java
@@ -17,7 +17,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -36,7 +36,7 @@ public class Part09Step23Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part09Step23Controller(Executor executor,
@@ -45,14 +45,14 @@ public class Part09Step23Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step24Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step24Controller.java
@@ -14,7 +14,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -33,7 +33,7 @@ public class Part09Step24Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part09Step24Controller(Executor executor,
@@ -42,14 +42,14 @@ public class Part09Step24Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step25Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step25Controller.java
@@ -13,7 +13,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -32,7 +32,7 @@ public class Part09Step25Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part09Step25Controller(Executor executor,
@@ -41,14 +41,14 @@ public class Part09Step25Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part10/Part10Controller.java
+++ b/src/org/etools/j1939_84/controllers/part10/Part10Controller.java
@@ -11,7 +11,7 @@ import org.etools.j1939_84.controllers.PartController;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -27,7 +27,7 @@ public class Part10Controller extends PartController {
              dataRepository,
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new Part10Step01Controller(),
              new Part10Step02Controller(),
              new Part10Step03Controller(),
@@ -44,7 +44,7 @@ public class Part10Controller extends PartController {
                             DataRepository dataRepository,
                             EngineSpeedModule engineSpeedModule,
                             VehicleInformationModule vehicleInformationModule,
-                            DiagnosticMessageModule diagnosticMessageModule,
+                            CommunicationsModule communicationsModule,
                             StepController... stepControllers) {
         super(executor,
               bannerModule,
@@ -52,7 +52,7 @@ public class Part10Controller extends PartController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               10,
               stepControllers);
     }

--- a/src/org/etools/j1939_84/controllers/part10/Part10Step01Controller.java
+++ b/src/org/etools/j1939_84/controllers/part10/Part10Step01Controller.java
@@ -12,7 +12,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -31,7 +31,7 @@ public class Part10Step01Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part10Step01Controller(Executor executor,
@@ -40,14 +40,14 @@ public class Part10Step01Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part10/Part10Step02Controller.java
+++ b/src/org/etools/j1939_84/controllers/part10/Part10Step02Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -34,7 +34,7 @@ public class Part10Step02Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part10Step02Controller(Executor executor,
@@ -43,14 +43,14 @@ public class Part10Step02Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part10/Part10Step03Controller.java
+++ b/src/org/etools/j1939_84/controllers/part10/Part10Step03Controller.java
@@ -12,7 +12,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -31,7 +31,7 @@ public class Part10Step03Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part10Step03Controller(Executor executor,
@@ -40,14 +40,14 @@ public class Part10Step03Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part10/Part10Step04Controller.java
+++ b/src/org/etools/j1939_84/controllers/part10/Part10Step04Controller.java
@@ -13,7 +13,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -32,7 +32,7 @@ public class Part10Step04Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part10Step04Controller(Executor executor,
@@ -41,14 +41,14 @@ public class Part10Step04Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part10/Part10Step05Controller.java
+++ b/src/org/etools/j1939_84/controllers/part10/Part10Step05Controller.java
@@ -15,7 +15,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -34,7 +34,7 @@ public class Part10Step05Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part10Step05Controller(Executor executor,
@@ -43,14 +43,14 @@ public class Part10Step05Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part11/Part11Controller.java
+++ b/src/org/etools/j1939_84/controllers/part11/Part11Controller.java
@@ -11,7 +11,7 @@ import org.etools.j1939_84.controllers.PartController;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -27,7 +27,7 @@ public class Part11Controller extends PartController {
              dataRepository,
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new Part11Step01Controller(),
              new Part11Step02Controller(),
              new Part11Step03Controller(),
@@ -52,7 +52,7 @@ public class Part11Controller extends PartController {
                             DataRepository dataRepository,
                             EngineSpeedModule engineSpeedModule,
                             VehicleInformationModule vehicleInformationModule,
-                            DiagnosticMessageModule diagnosticMessageModule,
+                            CommunicationsModule communicationsModule,
                             StepController... stepControllers) {
         super(executor,
               bannerModule,
@@ -60,7 +60,7 @@ public class Part11Controller extends PartController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               11,
               stepControllers);
     }

--- a/src/org/etools/j1939_84/controllers/part11/Part11Step01Controller.java
+++ b/src/org/etools/j1939_84/controllers/part11/Part11Step01Controller.java
@@ -12,7 +12,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -31,7 +31,7 @@ public class Part11Step01Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part11Step01Controller(Executor executor,
@@ -40,14 +40,14 @@ public class Part11Step01Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part11/Part11Step02Controller.java
+++ b/src/org/etools/j1939_84/controllers/part11/Part11Step02Controller.java
@@ -11,7 +11,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -30,7 +30,7 @@ public class Part11Step02Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part11Step02Controller(Executor executor,
@@ -39,14 +39,14 @@ public class Part11Step02Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part11/Part11Step03Controller.java
+++ b/src/org/etools/j1939_84/controllers/part11/Part11Step03Controller.java
@@ -11,7 +11,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -30,7 +30,7 @@ public class Part11Step03Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part11Step03Controller(Executor executor,
@@ -39,14 +39,14 @@ public class Part11Step03Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part11/Part11Step04Controller.java
+++ b/src/org/etools/j1939_84/controllers/part11/Part11Step04Controller.java
@@ -11,7 +11,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -30,7 +30,7 @@ public class Part11Step04Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part11Step04Controller(Executor executor,
@@ -39,14 +39,14 @@ public class Part11Step04Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part11/Part11Step05Controller.java
+++ b/src/org/etools/j1939_84/controllers/part11/Part11Step05Controller.java
@@ -10,7 +10,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -29,7 +29,7 @@ public class Part11Step05Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part11Step05Controller(Executor executor,
@@ -38,14 +38,14 @@ public class Part11Step05Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part11/Part11Step06Controller.java
+++ b/src/org/etools/j1939_84/controllers/part11/Part11Step06Controller.java
@@ -13,7 +13,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -32,7 +32,7 @@ public class Part11Step06Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part11Step06Controller(Executor executor,
@@ -41,14 +41,14 @@ public class Part11Step06Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part11/Part11Step07Controller.java
+++ b/src/org/etools/j1939_84/controllers/part11/Part11Step07Controller.java
@@ -31,7 +31,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.controllers.TableA1Validator;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -60,7 +60,7 @@ public class Part11Step07Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new TableA1Validator(DataRepository.getInstance(), PART_NUMBER, STEP_NUMBER));
     }
 
@@ -70,7 +70,7 @@ public class Part11Step07Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            TableA1Validator validator) {
         super(executor,
               bannerModule,
@@ -78,7 +78,7 @@ public class Part11Step07Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part11/Part11Step08Controller.java
+++ b/src/org/etools/j1939_84/controllers/part11/Part11Step08Controller.java
@@ -22,7 +22,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -58,7 +58,7 @@ public class Part11Step08Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part11Step08Controller(Executor executor,
@@ -67,14 +67,14 @@ public class Part11Step08Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part11/Part11Step09Controller.java
+++ b/src/org/etools/j1939_84/controllers/part11/Part11Step09Controller.java
@@ -16,7 +16,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -35,7 +35,7 @@ public class Part11Step09Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part11Step09Controller(Executor executor,
@@ -44,14 +44,14 @@ public class Part11Step09Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part11/Part11Step10Controller.java
+++ b/src/org/etools/j1939_84/controllers/part11/Part11Step10Controller.java
@@ -3,7 +3,7 @@
  */
 package org.etools.j1939_84.controllers.part11;
 
-import static org.etools.j1939_84.modules.DiagnosticMessageModule.getCompositeSystems;
+import static org.etools.j1939_84.modules.CommunicationsModule.getCompositeSystems;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -14,7 +14,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -33,7 +33,7 @@ public class Part11Step10Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part11Step10Controller(Executor executor,
@@ -42,14 +42,14 @@ public class Part11Step10Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part11/Part11Step11Controller.java
+++ b/src/org/etools/j1939_84/controllers/part11/Part11Step11Controller.java
@@ -3,7 +3,7 @@
  */
 package org.etools.j1939_84.controllers.part11;
 
-import static org.etools.j1939_84.modules.DiagnosticMessageModule.getCompositeSystems;
+import static org.etools.j1939_84.modules.CommunicationsModule.getCompositeSystems;
 
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.Executor;
@@ -18,7 +18,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -37,7 +37,7 @@ public class Part11Step11Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part11Step11Controller(Executor executor,
@@ -46,14 +46,14 @@ public class Part11Step11Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part11/Part11Step12Controller.java
+++ b/src/org/etools/j1939_84/controllers/part11/Part11Step12Controller.java
@@ -14,7 +14,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -33,7 +33,7 @@ public class Part11Step12Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part11Step12Controller(Executor executor,
@@ -42,14 +42,14 @@ public class Part11Step12Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part11/Part11Step13Controller.java
+++ b/src/org/etools/j1939_84/controllers/part11/Part11Step13Controller.java
@@ -14,7 +14,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -33,7 +33,7 @@ public class Part11Step13Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part11Step13Controller(Executor executor,
@@ -42,14 +42,14 @@ public class Part11Step13Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part12/Part12Controller.java
+++ b/src/org/etools/j1939_84/controllers/part12/Part12Controller.java
@@ -11,7 +11,7 @@ import org.etools.j1939_84.controllers.PartController;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -27,7 +27,7 @@ public class Part12Controller extends PartController {
              dataRepository,
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new Part12Step01Controller(),
              new Part12Step02Controller(),
              new Part12Step03Controller(),
@@ -49,7 +49,7 @@ public class Part12Controller extends PartController {
                             DataRepository dataRepository,
                             EngineSpeedModule engineSpeedModule,
                             VehicleInformationModule vehicleInformationModule,
-                            DiagnosticMessageModule diagnosticMessageModule,
+                            CommunicationsModule communicationsModule,
                             StepController... stepControllers) {
         super(executor,
               bannerModule,
@@ -57,7 +57,7 @@ public class Part12Controller extends PartController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               12,
               stepControllers);
     }

--- a/src/org/etools/j1939_84/controllers/part12/Part12Step01Controller.java
+++ b/src/org/etools/j1939_84/controllers/part12/Part12Step01Controller.java
@@ -12,7 +12,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -31,7 +31,7 @@ public class Part12Step01Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part12Step01Controller(Executor executor,
@@ -40,14 +40,14 @@ public class Part12Step01Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part12/Part12Step02Controller.java
+++ b/src/org/etools/j1939_84/controllers/part12/Part12Step02Controller.java
@@ -19,7 +19,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -38,7 +38,7 @@ public class Part12Step02Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part12Step02Controller(Executor executor,
@@ -47,14 +47,14 @@ public class Part12Step02Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part12/Part12Step03Controller.java
+++ b/src/org/etools/j1939_84/controllers/part12/Part12Step03Controller.java
@@ -3,7 +3,7 @@
  */
 package org.etools.j1939_84.controllers.part12;
 
-import static org.etools.j1939_84.modules.DiagnosticMessageModule.getCompositeSystems;
+import static org.etools.j1939_84.modules.CommunicationsModule.getCompositeSystems;
 
 import java.util.Collection;
 import java.util.List;
@@ -22,7 +22,7 @@ import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -41,7 +41,7 @@ public class Part12Step03Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part12Step03Controller(Executor executor,
@@ -50,14 +50,14 @@ public class Part12Step03Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part12/Part12Step04Controller.java
+++ b/src/org/etools/j1939_84/controllers/part12/Part12Step04Controller.java
@@ -13,7 +13,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -32,7 +32,7 @@ public class Part12Step04Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part12Step04Controller(Executor executor,
@@ -41,14 +41,14 @@ public class Part12Step04Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part12/Part12Step05Controller.java
+++ b/src/org/etools/j1939_84/controllers/part12/Part12Step05Controller.java
@@ -11,7 +11,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -30,7 +30,7 @@ public class Part12Step05Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part12Step05Controller(Executor executor,
@@ -39,14 +39,14 @@ public class Part12Step05Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part12/Part12Step06Controller.java
+++ b/src/org/etools/j1939_84/controllers/part12/Part12Step06Controller.java
@@ -14,7 +14,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -33,7 +33,7 @@ public class Part12Step06Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part12Step06Controller(Executor executor,
@@ -42,14 +42,14 @@ public class Part12Step06Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part12/Part12Step07Controller.java
+++ b/src/org/etools/j1939_84/controllers/part12/Part12Step07Controller.java
@@ -12,7 +12,7 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -31,7 +31,7 @@ public class Part12Step07Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part12Step07Controller(Executor executor,
@@ -40,14 +40,14 @@ public class Part12Step07Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part12/Part12Step08Controller.java
+++ b/src/org/etools/j1939_84/controllers/part12/Part12Step08Controller.java
@@ -16,7 +16,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.SpnFmi;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -35,7 +35,7 @@ public class Part12Step08Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part12Step08Controller(Executor executor,
@@ -44,14 +44,14 @@ public class Part12Step08Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part12/Part12Step09Controller.java
+++ b/src/org/etools/j1939_84/controllers/part12/Part12Step09Controller.java
@@ -18,7 +18,7 @@ import org.etools.j1939_84.controllers.SectionA5Verifier;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -38,7 +38,7 @@ public class Part12Step09Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule(),
+             new CommunicationsModule(),
              new SectionA5Verifier(PART_NUMBER, STEP_NUMBER));
     }
 
@@ -48,7 +48,7 @@ public class Part12Step09Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule,
+                           CommunicationsModule communicationsModule,
                            SectionA5Verifier verifier) {
         super(executor,
               bannerModule,
@@ -56,7 +56,7 @@ public class Part12Step09Controller extends StepController {
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/controllers/part12/Part12Step10Controller.java
+++ b/src/org/etools/j1939_84/controllers/part12/Part12Step10Controller.java
@@ -12,7 +12,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.SpnFmi;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.CommunicationsModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -31,7 +31,7 @@ public class Part12Step10Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new CommunicationsModule());
     }
 
     Part12Step10Controller(Executor executor,
@@ -40,14 +40,14 @@ public class Part12Step10Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           CommunicationsModule communicationsModule) {
         super(executor,
               bannerModule,
               dateTimeModule,
               dataRepository,
               engineSpeedModule,
               vehicleInformationModule,
-              diagnosticMessageModule,
+              communicationsModule,
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);

--- a/src/org/etools/j1939_84/modules/CommunicationsModule.java
+++ b/src/org/etools/j1939_84/modules/CommunicationsModule.java
@@ -52,9 +52,9 @@ import org.etools.j1939_84.bus.j1939.packets.ParsedPacket;
 import org.etools.j1939_84.controllers.ResultsListener;
 import org.etools.j1939_84.model.RequestResult;
 
-public class DiagnosticMessageModule extends FunctionalModule {
+public class CommunicationsModule extends FunctionalModule {
 
-    public DiagnosticMessageModule() {
+    public CommunicationsModule() {
         super();
     }
 


### PR DESCRIPTION
Fix #56 - Refactor DiagnosticMessageModule.java and DiagnosticMessageModuleTest.java to be CommunicationsModule.java and CommunicationsModuleTest.java.  No real logic was modified.  Renaming of object and classes only.