### PR TITLE
Fix #11 - Print only data bytes not all bytes

### DIFF
--- a/src-test/org/etools/j1939tools/j1939/packets/DM58RationalityFaultSpDataTest.java
+++ b/src-test/org/etools/j1939tools/j1939/packets/DM58RationalityFaultSpDataTest.java
@@ -11,9 +11,6 @@ import static org.junit.Assert.assertEquals;
 import java.util.Arrays;
 
 import org.etools.j1939tools.bus.Packet;
-import org.etools.j1939tools.j1939.packets.DM58RationalityFaultSpData;
-import org.etools.j1939tools.j1939.packets.DM5DiagnosticReadinessPacket;
-import org.etools.j1939tools.j1939.packets.SupportedSPN;
 import org.etools.j1939tools.modules.DateTimeModule;
 import org.etools.j1939tools.modules.TestDateTimeModule;
 import org.etools.j1939tools.utils.CollectionUtils;
@@ -92,7 +89,7 @@ public class DM58RationalityFaultSpDataTest {
         String expected = "DM58 from Engine #1 (0): " + NL;
         expected += "  Test Identifier: 245" + NL;
         expected += "  Rationality Fault SPN: 190" + NL;
-        expected += "  Rationality Fault SPN Data Value: [DD CC BB AA]" + NL;
+        expected += "  Rationality Fault SPN Data Value: [DD CC]" + NL;
         expected += "  SPN   190, Engine Speed: 6555.625 rpm" + NL;
         assertEquals(expected, instance.toString());
     }


### PR DESCRIPTION
Update the printing of data to be the length specified in the SPN definition.