### PR TITLE
Fix #161 - Update isGreaterThanFb() logic

### DIFF
--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step10ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step10ControllerTest.java
@@ -634,7 +634,7 @@ public class Part02Step10ControllerTest extends AbstractControllerTest {
         var dm58PacketSpn2 = DM58RationalityFaultSpData.create(source,
                                                                245,
                                                                spn2.getSpn(),
-                                                               new int[] { 0xFF, 0xFF, 0xFF, 0xFF });
+                                                               new int[] { 0xF0, 0xFF, 0xFF, 0xFF });
         when(communicationsModule.requestDM58(any(CommunicationsListener.class),
                                               eq(source),
                                               eq(spn2.getSpn()))).thenReturn(new BusResult<>(false, dm58PacketSpn2));
@@ -642,7 +642,7 @@ public class Part02Step10ControllerTest extends AbstractControllerTest {
         var dm58PacketSpn3 = DM58RationalityFaultSpData.create(source,
                                                                245,
                                                                spn3.getSpn(),
-                                                               new int[] { 0xFF, 0xFA, 0xFF, 0xFF });
+                                                               new int[] { 0xFF, 0xF0, 0xFF, 0xFF });
         when(communicationsModule.requestDM58(any(CommunicationsListener.class),
                                               eq(source),
                                               eq(spn3.getSpn()))).thenReturn(new BusResult<>(false, dm58PacketSpn3));

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step10ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step10ControllerTest.java
@@ -619,7 +619,7 @@ public class Part02Step10ControllerTest extends AbstractControllerTest {
                 .thenReturn(List.of(DM30ScaledTestResultsPacket.create(source, 0, testResult4)));
 
         obdModule0.setScaledTestResults(List.of(testResult4));
-        obdModule0.set(getDm24SPNSupportPacket(0x00), 1);//DM24SPNSupportPacket.create(source, spn1, spn2, spn3), 1);
+        obdModule0.set(getDm24SPNSupportPacket(0x00), 1);
         dataRepository.putObdModule(obdModule0);
 
         var dm58PacketSpn1 = DM58RationalityFaultSpData.create(source,

--- a/src/org/etools/j1939_84/controllers/StepController.java
+++ b/src/org/etools/j1939_84/controllers/StepController.java
@@ -35,6 +35,7 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
+import org.etools.j1939_84.utils.CollectionUtils;
 import org.etools.j1939tools.bus.BusResult;
 import org.etools.j1939tools.bus.RequestResult;
 import org.etools.j1939tools.j1939.J1939DaRepository;
@@ -470,13 +471,14 @@ public abstract class StepController extends Controller {
 
     protected boolean isGreaterThanFb(DM58RationalityFaultSpData packet) {
         Spn spn = packet.getSpn();
-        long rawValue = spn.getRawValue();
+        Slot slot = J1939DaRepository.getInstance().findSLOT(DM58RationalityFaultSpData.PGN, spn.getId());
+        long rawValue = slot.toValue(packet.getSpnDataBytes());
 
         switch (spn.getSlot().getByteLength()) {
             case 1:
-                return rawValue > 0xFB;
+                return rawValue > 0xFBL;
             case 2:
-                return rawValue > 0xFBFF;
+                return rawValue > 0xFBFFL;
             case 4:
                 return rawValue > 0xFBFFFFFFL;
             default:

--- a/src/org/etools/j1939_84/engine/simulated/Engine.java
+++ b/src/org/etools/j1939_84/engine/simulated/Engine.java
@@ -53,6 +53,7 @@ import org.etools.j1939_84.model.KeyState;
 import org.etools.j1939tools.bus.Bus;
 import org.etools.j1939tools.bus.BusException;
 import org.etools.j1939tools.bus.Packet;
+import org.etools.j1939tools.j1939.J1939DaRepository;
 import org.etools.j1939tools.j1939.model.SpnFmi;
 import org.etools.j1939tools.j1939.packets.AcknowledgmentPacket;
 import org.etools.j1939tools.j1939.packets.CompositeSystem;
@@ -226,7 +227,7 @@ public class Engine implements AutoCloseable {
                              }
                              return Packet.create(EngineSpeedPacket.PGN,
                                                   ADDR,
-                                                  combine(new byte[] { NA, 0, 0 }, engineSpeed, NA3));
+                                                  combine(new byte[] { NA, (byte) 0xFF, (byte) 0xFF }, engineSpeed, NA3));
                          }
                      });
 
@@ -1190,7 +1191,7 @@ public class Engine implements AutoCloseable {
                          return DM58RationalityFaultSpData.create(ADDR,
                                                                   dm7.getTestId(),
                                                                   dm7.getSpn(),
-                                                                  new int[] { 0xDD, 0xCC, 0xBB, 0xAA })
+                                                                  new int[] { 0xF0, 0xFF, 0xFF, 0xFF })
                                                           .getPacket();
                      });
 


### PR DESCRIPTION
Fix StepController.java logic to properly translate the values in method isGreaterThanFb() of data based on their slot length.  Also, update the Engine.java to correctly return the values with SAE defined padding in the messages.  Also, updated Part02Step10ControllerTest.java to correctly return data values based on slot size.