### PR TITLE
Fix #163 - Update to use PGN definitions instead of class name

### DIFF
--- a/src-test/org/etools/j1939_84/controllers/SectionA5MessageVerifierTest.java
+++ b/src-test/org/etools/j1939_84/controllers/SectionA5MessageVerifierTest.java
@@ -1116,13 +1116,13 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = IdleOperationPacket.create(0, 101);
-        when(communicationsModule.request(eq(IdleOperationPacket.class),
+        when(communicationsModule.request(eq(IdleOperationPacket.PGN),
                                           eq(0x00),
                                           any(CommunicationsListener.class))).thenReturn(new BusResult<>(false, packet));
 
         assertTrue(instance.checkEngineIdleTime(listener, SECTION, 0));
 
-        verify(communicationsModule).request(eq(IdleOperationPacket.class),
+        verify(communicationsModule).request(eq(IdleOperationPacket.PGN),
                                              eq(0x00),
                                              any(CommunicationsListener.class));
     }
@@ -1134,13 +1134,13 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = IdleOperationPacket.create(0, 0);
-        when(communicationsModule.request(eq(IdleOperationPacket.class),
+        when(communicationsModule.request(eq(IdleOperationPacket.PGN),
                                           eq(0x00),
                                           any(CommunicationsListener.class))).thenReturn(new BusResult<>(false, packet));
 
         assertFalse(instance.checkEngineIdleTime(listener, SECTION, 0));
 
-        verify(communicationsModule).request(eq(IdleOperationPacket.class),
+        verify(communicationsModule).request(eq(IdleOperationPacket.PGN),
                                              eq(0x00),
                                              any(CommunicationsListener.class));
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -1163,13 +1163,13 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = EngineHoursPacket.create(0, 101);
-        when(communicationsModule.request(eq(EngineHoursPacket.class), eq(0x00), any(CommunicationsListener.class)))
+        when(communicationsModule.request(eq(EngineHoursPacket.PGN), eq(0x00), any(CommunicationsListener.class)))
                                                                                                                     .thenReturn(new BusResult<>(false,
                                                                                                                                               packet));
 
         assertTrue(instance.checkEngineRunTime(listener, SECTION, 0));
 
-        verify(communicationsModule).request(eq(EngineHoursPacket.class),
+        verify(communicationsModule).request(eq(EngineHoursPacket.PGN),
                                              eq(0x00),
                                              any(CommunicationsListener.class));
     }
@@ -1181,13 +1181,13 @@ public class SectionA5MessageVerifierTest {
         dataRepository.putObdModule(moduleInfo);
 
         var packet = EngineHoursPacket.create(0, 0);
-        when(communicationsModule.request(eq(EngineHoursPacket.class), eq(0x00), any(CommunicationsListener.class)))
+        when(communicationsModule.request(eq(EngineHoursPacket.PGN), eq(0x00), any(CommunicationsListener.class)))
                                                                                                                     .thenReturn(new BusResult<>(false,
                                                                                                                                               packet));
 
         assertFalse(instance.checkEngineRunTime(listener, SECTION, 0));
 
-        verify(communicationsModule).request(eq(EngineHoursPacket.class), eq(0x00), any(CommunicationsListener.class));
+        verify(communicationsModule).request(eq(EngineHoursPacket.PGN), eq(0x00), any(CommunicationsListener.class));
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step05ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step05ControllerTest.java
@@ -27,7 +27,9 @@ import org.etools.j1939_84.modules.VehicleInformationModule;
 import org.etools.j1939_84.utils.AbstractControllerTest;
 import org.etools.j1939_84.utils.VinDecoder;
 import org.etools.j1939tools.CommunicationsListener;
+import org.etools.j1939tools.bus.RequestResult;
 import org.etools.j1939tools.j1939.J1939;
+import org.etools.j1939tools.j1939.packets.GenericPacket;
 import org.etools.j1939tools.j1939.packets.VehicleIdentificationPacket;
 import org.etools.j1939tools.modules.CommunicationsModule;
 import org.etools.j1939tools.modules.DateTimeModule;
@@ -178,8 +180,8 @@ public class Part01Step05ControllerTest extends AbstractControllerTest {
         obdModule1.set(packet, 0x01);
         dataRepository.putObdModule(obdModule1);
 
-        when(communicationsModule.request(eq(VehicleIdentificationPacket.class),
-                                          any(CommunicationsListener.class))).thenReturn(List.of(packet));
+        when(communicationsModule.request(eq(VehicleIdentificationPacket.PGN),
+                                          any(CommunicationsListener.class))).thenReturn(RequestResult.of(packet));
         VehicleInformation vehicleInformation = new VehicleInformation();
 
         vehicleInformation.setVin(vin);
@@ -189,7 +191,7 @@ public class Part01Step05ControllerTest extends AbstractControllerTest {
         runTest();
 
         verify(communicationsModule).setJ1939(eq(j1939));
-        verify(communicationsModule).request(eq(VehicleIdentificationPacket.class), any(CommunicationsListener.class));
+        verify(communicationsModule).request(eq(VehicleIdentificationPacket.PGN), any(CommunicationsListener.class));
 
         verify(engineSpeedModule).setJ1939(j1939);
     }
@@ -245,8 +247,8 @@ public class Part01Step05ControllerTest extends AbstractControllerTest {
         OBDModuleInformation obdModule2 = new OBDModuleInformation((1));
         obdModule2.set(packet2, 1);
         dataRepository.putObdModule(obdModule2);
-        when(communicationsModule.request(eq(VehicleIdentificationPacket.class),
-                                          any(CommunicationsListener.class))).thenReturn(List.of(packet1, packet2));
+        when(communicationsModule.request(eq(VehicleIdentificationPacket.PGN),
+                                          any(CommunicationsListener.class))).thenReturn(RequestResult.of(packet1, packet2));
 
         VehicleInformation vehicleInformation = new VehicleInformation();
         vehicleInformation.setVin(vin);
@@ -255,7 +257,7 @@ public class Part01Step05ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(communicationsModule).request(eq(VehicleIdentificationPacket.class), any(ResultsListener.class));
+        verify(communicationsModule).request(eq(VehicleIdentificationPacket.PGN), any(ResultsListener.class));
 
         verify(engineSpeedModule).setJ1939(j1939);
 
@@ -325,8 +327,8 @@ public class Part01Step05ControllerTest extends AbstractControllerTest {
         OBDModuleInformation obdModule2 = new OBDModuleInformation((0x00));
         obdModule2.set(packet2, 1);
 
-        when(communicationsModule.request(eq(VehicleIdentificationPacket.class),
-                                          any(ResultsListener.class))).thenReturn(List.of(packet1, packet2));
+        when(communicationsModule.request(eq(VehicleIdentificationPacket.PGN),
+                                          any(ResultsListener.class))).thenReturn(RequestResult.of(packet1, packet2));
 
         VehicleInformation vehicleInformation = new VehicleInformation();
         vehicleInformation.setVin(vin);
@@ -336,7 +338,7 @@ public class Part01Step05ControllerTest extends AbstractControllerTest {
         runTest();
 
         verify(communicationsModule).setJ1939(j1939);
-        verify(communicationsModule).request(any(), any(ResultsListener.class));
+        verify(communicationsModule).request(eq(VehicleIdentificationPacket.PGN), any(ResultsListener.class));
 
         verify(engineSpeedModule).setJ1939(j1939);
 
@@ -396,12 +398,12 @@ public class Part01Step05ControllerTest extends AbstractControllerTest {
         vehicleInformation.setVehicleModelYear(2014);
         dataRepository.setVehicleInformation(vehicleInformation);
 
-        when(communicationsModule.request(eq(VehicleIdentificationPacket.class),
-                                          any(CommunicationsListener.class))).thenReturn(List.of(packet));
+        when(communicationsModule.request(eq(VehicleIdentificationPacket.PGN),
+                                          any(CommunicationsListener.class))).thenReturn(RequestResult.of(packet));
 
         runTest();
 
-        verify(communicationsModule).request(eq(VehicleIdentificationPacket.class),
+        verify(communicationsModule).request(eq(VehicleIdentificationPacket.PGN),
                                              any(ResultsListener.class));
 
         verify(engineSpeedModule).setJ1939(j1939);
@@ -454,8 +456,8 @@ public class Part01Step05ControllerTest extends AbstractControllerTest {
         OBDModuleInformation obdModule1 = new OBDModuleInformation((0x01));
         obdModule1.set(packet, 1);
         dataRepository.putObdModule(obdModule1);
-        when(communicationsModule.request(eq(VehicleIdentificationPacket.class),
-                                          any(CommunicationsListener.class))).thenReturn((List.of(packet)));
+        when(communicationsModule.request(eq(VehicleIdentificationPacket.PGN),
+                                          any(CommunicationsListener.class))).thenReturn(RequestResult.of(packet));
         VehicleInformation vehicleInformation = new VehicleInformation();
         vehicleInformation.setVin(vin);
         vehicleInformation.setVehicleModelYear(2019);
@@ -463,7 +465,7 @@ public class Part01Step05ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(communicationsModule).request(eq(VehicleIdentificationPacket.class), any(CommunicationsListener.class));
+        verify(communicationsModule).request(eq(VehicleIdentificationPacket.PGN), any(CommunicationsListener.class));
 
         verify(engineSpeedModule).setJ1939(j1939);
 
@@ -518,8 +520,8 @@ public class Part01Step05ControllerTest extends AbstractControllerTest {
         obdModule1.set(packet, 1);
         dataRepository.putObdModule(obdModule1);
 
-        when(communicationsModule.request(eq(VehicleIdentificationPacket.class),
-                                          any(ResultsListener.class))).thenReturn((List.of(packet)));
+        when(communicationsModule.request(eq(VehicleIdentificationPacket.PGN),
+                                          any(ResultsListener.class))).thenReturn(RequestResult.of(packet));
 
         VehicleInformation vehicleInformation = new VehicleInformation();
         vehicleInformation.setVin(vin);
@@ -528,7 +530,7 @@ public class Part01Step05ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(communicationsModule).request(eq(VehicleIdentificationPacket.class), any(ResultsListener.class));
+        verify(communicationsModule).request(eq(VehicleIdentificationPacket.PGN), any(ResultsListener.class));
 
         verify(engineSpeedModule).setJ1939(j1939);
 
@@ -600,8 +602,8 @@ public class Part01Step05ControllerTest extends AbstractControllerTest {
         OBDModuleInformation obdModule2 = new OBDModuleInformation((0x00));
         obdModule2.set(packet2, 1);
         dataRepository.putObdModule(obdModule2);
-        when(communicationsModule.request(eq(VehicleIdentificationPacket.class),
-                                          any(ResultsListener.class))).thenReturn(List.of(packet1, packet2));
+        when(communicationsModule.request(eq(VehicleIdentificationPacket.PGN),
+                                          any(ResultsListener.class))).thenReturn(RequestResult.of(packet1, packet2));
 
         VehicleInformation vehicleInformation = new VehicleInformation();
         vehicleInformation.setVin(vin);
@@ -610,7 +612,7 @@ public class Part01Step05ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(communicationsModule).request(eq(VehicleIdentificationPacket.class), any(ResultsListener.class));
+        verify(communicationsModule).request(eq(VehicleIdentificationPacket.PGN), any(ResultsListener.class));
 
         verify(engineSpeedModule).setJ1939(j1939);
 
@@ -661,8 +663,8 @@ public class Part01Step05ControllerTest extends AbstractControllerTest {
         OBDModuleInformation obdModule1 = new OBDModuleInformation((0x01));
         obdModule1.set(packet, 1);
         dataRepository.putObdModule(obdModule1);
-        when(communicationsModule.request(eq(VehicleIdentificationPacket.class),
-                                          any(ResultsListener.class))).thenReturn((List.of(packet)));
+        when(communicationsModule.request(eq(VehicleIdentificationPacket.PGN),
+                                          any(ResultsListener.class))).thenReturn(RequestResult.of(packet));
 
         VehicleInformation vehicleInformation = new VehicleInformation();
         vehicleInformation.setVin("1XPBDK9X1LD708195");
@@ -672,7 +674,7 @@ public class Part01Step05ControllerTest extends AbstractControllerTest {
         runTest();
 
         verify(communicationsModule).setJ1939(j1939);
-        verify(communicationsModule).request(eq(VehicleIdentificationPacket.class), any(ResultsListener.class));
+        verify(communicationsModule).request(eq(VehicleIdentificationPacket.PGN), any(ResultsListener.class));
 
         verify(engineSpeedModule).setJ1939(j1939);
 
@@ -723,8 +725,8 @@ public class Part01Step05ControllerTest extends AbstractControllerTest {
         OBDModuleInformation obdModule1 = new OBDModuleInformation((0x01));
         obdModule1.set(packet, 1);
         dataRepository.putObdModule(obdModule1);
-        when(communicationsModule.request(eq(VehicleIdentificationPacket.class),
-                                          any(ResultsListener.class))).thenReturn((List.of(packet)));
+        when(communicationsModule.request(eq(VehicleIdentificationPacket.PGN),
+                                          any(ResultsListener.class))).thenReturn((RequestResult.of(packet)));
         VehicleInformation vehicleInformation = new VehicleInformation();
         vehicleInformation.setVin(vin);
         dataRepository.setVehicleInformation(vehicleInformation);
@@ -733,7 +735,7 @@ public class Part01Step05ControllerTest extends AbstractControllerTest {
 
         verify(engineSpeedModule).setJ1939(j1939);
 
-        verify(communicationsModule).request(eq(VehicleIdentificationPacket.class), any(ResultsListener.class));
+        verify(communicationsModule).request(eq(VehicleIdentificationPacket.PGN), any(ResultsListener.class));
 
         verify(mockListener).addOutcome(1,
                                         5,
@@ -775,12 +777,12 @@ public class Part01Step05ControllerTest extends AbstractControllerTest {
     @TestDoc(@TestItem(verifies = "6.1.5.2.a", description = "Fail if no VIN is provided by any ECU"))
     public void testPacketsEmptyFailure() {
 
-        when(communicationsModule.request(eq(VehicleIdentificationPacket.class),
-                                          any(ResultsListener.class))).thenReturn((List.of()));
+        when(communicationsModule.request(eq(VehicleIdentificationPacket.PGN),
+                                          any(ResultsListener.class))).thenReturn((RequestResult.of()));
 
         runTest();
 
-        verify(communicationsModule).request(eq(VehicleIdentificationPacket.class), any(ResultsListener.class));
+        verify(communicationsModule).request(eq(VehicleIdentificationPacket.PGN), any(ResultsListener.class));
 
         verify(mockListener).addOutcome(1, 5, FAIL, "6.1.5.2.a - No VIN was provided by any ECU");
     }

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step09ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step09ControllerTest.java
@@ -31,6 +31,7 @@ import org.etools.j1939_84.utils.AbstractControllerTest;
 import org.etools.j1939tools.CommunicationsListener;
 import org.etools.j1939tools.bus.BusResult;
 import org.etools.j1939tools.bus.Packet;
+import org.etools.j1939tools.bus.RequestResult;
 import org.etools.j1939tools.j1939.J1939;
 import org.etools.j1939tools.j1939.packets.ComponentIdentificationPacket;
 import org.etools.j1939tools.modules.CommunicationsModule;
@@ -198,17 +199,17 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(obdModule);
 
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
-                                          any(CommunicationsListener.class))).thenReturn(List.of(packet));
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
+                                          any(CommunicationsListener.class))).thenReturn(RequestResult.of(packet));
 
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x00),
                                           any(CommunicationsListener.class))).thenReturn(BusResult.empty());
 
         runTest();
 
-        verify(communicationsModule).request(any(), any(ResultsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN), any(ResultsListener.class));
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0x00),
                                              any(ResultsListener.class));
 
@@ -247,27 +248,28 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModule0);
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class), any(CommunicationsListener.class)))
-                                                                                                                      .thenReturn(List.of(packet0));
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN), any(CommunicationsListener.class)))
+                                                                                                                      .thenReturn(
+                                                                                                                              RequestResult.of(packet0));
 
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x00),
                                           any(CommunicationsListener.class)))
                                                                              .thenReturn(new BusResult<>(false,
                                                                                                        packet0));
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x01),
                                           any(CommunicationsListener.class)))
                                                                              .thenReturn(new BusResult<>(false,
                                                                                                        packet1));
         runTest();
 
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0x00),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0x01),
                                              any(CommunicationsListener.class));
 
@@ -303,20 +305,20 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(obdModule0x00);
 
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class), any(CommunicationsListener.class)))
-                                                                                                                      .thenReturn(List.of(packet2));
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN), any(CommunicationsListener.class)))
+                                                                                                                      .thenReturn(RequestResult.of(packet2));
 
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x00),
                                           any(ResultsListener.class)))
                                                                       .thenReturn(new BusResult<>(false, packet1));
 
         runTest();
 
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0x0),
                                              any(ResultsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              any(CommunicationsListener.class));
 
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, EXPECTED_FAIL_MESSAGE_5_B);
@@ -364,25 +366,25 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(2));
         dataRepository.putObdModule(new OBDModuleInformation(3));
 
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class), any()))
-                                                                                          .thenReturn(List.of(
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN), any()))
+                                                                                          .thenReturn(RequestResult.of(
                                                                                                               packet0x00,
                                                                                                               packet0x01,
                                                                                                               packet0x02,
                                                                                                               packet0x03));
 
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x00),
                                           any(CommunicationsListener.class)))
                                                                              .thenReturn(new BusResult<>(false,
                                                                                                        packet0x00));
-        when(communicationsModule.request(any(), eq(0x01), any(CommunicationsListener.class)))
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN), eq(0x01), any(CommunicationsListener.class)))
                                                                                               .thenReturn(new BusResult<>(false,
                                                                                                                         packet0x01));
-        when(communicationsModule.request(any(), eq(0x02), any(CommunicationsListener.class)))
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN), eq(0x02), any(CommunicationsListener.class)))
                                                                                               .thenReturn(new BusResult<>(false,
                                                                                                                         packet0x02));
-        when(communicationsModule.request(any(), eq(0x03), any(CommunicationsListener.class)))
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN), eq(0x03), any(CommunicationsListener.class)))
                                                                                               .thenReturn(new BusResult<>(false,
                                                                                                                         packet0x03));
 
@@ -410,18 +412,18 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
 
         assertEquals(List.of(), listener.getOutcomes());
         //
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(1),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(2),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(3),
                                              any(CommunicationsListener.class));
 
@@ -481,13 +483,11 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(0, 0));
 
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class), any(CommunicationsListener.class)))
-                                                                                                                      .thenReturn(List.of(packet));
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN), any(CommunicationsListener.class))).thenReturn(RequestResult.of(packet));
 
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0),
-                                          any(CommunicationsListener.class)))
-                                                                             .thenReturn(new BusResult<>(false, packet));
+                                          any(CommunicationsListener.class))).thenReturn(new BusResult<>(false, packet));
 
         runTest();
 
@@ -500,9 +500,9 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
         assertEquals("", listener.getMessages());
         assertEquals("Function 0 ECU is Engine #1 (0)" + NL, listener.getResults());
 
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0),
                                              any(CommunicationsListener.class));
 
@@ -540,19 +540,19 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(obdModule0x00);
 
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class), any(CommunicationsListener.class)))
-                                                                                                                      .thenReturn(List.of(packet));
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN), any(CommunicationsListener.class)))
+                                                                                                                      .thenReturn(RequestResult.of(packet));
 
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x00),
                                           any(CommunicationsListener.class)))
                                                                              .thenReturn(new BusResult<>(false, packet));
         runTest();
 
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              any(CommunicationsListener.class));
 
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, EXPECTED_FAIL_MESSAGE_2_D_MAKE);
@@ -586,20 +586,20 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(obdModule);
 
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class), any(CommunicationsListener.class)))
-                                                                                                                      .thenReturn(List.of(packet));
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN), any(CommunicationsListener.class)))
+                                                                                                                      .thenReturn(RequestResult.of(packet));
 
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0),
                                           any(CommunicationsListener.class)))
                                                                              .thenReturn(new BusResult<>(false, packet));
 
         runTest();
 
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0x00),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              any(CommunicationsListener.class));
 
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, WARN, EXPECTED_WARN_MESSAGE_3_B);
@@ -632,20 +632,20 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(obdModule);
 
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class), any(CommunicationsListener.class)))
-                                                                                                                      .thenReturn(List.of(packet));
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN), any(CommunicationsListener.class)))
+                                                                                                                      .thenReturn(RequestResult.of(packet));
 
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0),
                                           any(CommunicationsListener.class)))
                                                                              .thenReturn(new BusResult<>(false, packet));
 
         runTest();
 
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              any(CommunicationsListener.class));
 
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, WARN, EXPECTED_WARN_MESSAGE_3_C);
@@ -680,19 +680,19 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(obdModule);
 
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class), any(CommunicationsListener.class)))
-                                                                                                                      .thenReturn(List.of(packet));
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN), any(CommunicationsListener.class)))
+                                                                                                                      .thenReturn(RequestResult.of(packet));
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x00),
                                           any(CommunicationsListener.class)))
                                                                              .thenReturn(new BusResult<>(false, packet));
 
         runTest();
 
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0x00),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              any(CommunicationsListener.class));
 
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, EXPECTED_FAIL_MESSAGE_2_D_MODEL);
@@ -725,20 +725,20 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(obdModule);
 
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class), any(CommunicationsListener.class)))
-                                                                                                                      .thenReturn(List.of(packet));
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN), any(CommunicationsListener.class)))
+                                                                                                                      .thenReturn(RequestResult.of(packet));
 
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0),
                                           any(CommunicationsListener.class)))
                                                                              .thenReturn(new BusResult<>(false, packet));
 
         runTest();
 
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0x00),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              any(CommunicationsListener.class));
 
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, WARN, EXPECTED_WARN_MESSAGE_3_D);
@@ -770,20 +770,20 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
                                                                     "Land");
         dataRepository.putObdModule(obdModule);
 
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class), any(CommunicationsListener.class)))
-                                                                                                                      .thenReturn(List.of());
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN), any(CommunicationsListener.class)))
+                .thenReturn(RequestResult.of());
 
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x00),
                                           any(CommunicationsListener.class)))
                                                                              .thenReturn(new BusResult<>(false, packet));
 
         runTest();
 
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              any(CommunicationsListener.class));
 
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, EXPECTED_FAIL_MESSAGE_5_A);
@@ -860,28 +860,28 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(obdModule0x02);
         dataRepository.putObdModule(obdModule0x03);
 
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class), any(CommunicationsListener.class)))
-                                                                                                                      .thenReturn(List.of(packet0x00,
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN), any(CommunicationsListener.class)))
+                                                                                                                      .thenReturn(RequestResult.of(packet0x00,
                                                                                                                                           packet0x01,
                                                                                                                                           packet0x02,
                                                                                                                                           packet0x03));
 
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x00),
                                           any(CommunicationsListener.class)))
                                                                              .thenReturn(new BusResult<>(false,
                                                                                                        packet0x00));
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x01),
                                           any(CommunicationsListener.class)))
                                                                              .thenReturn(new BusResult<>(false,
                                                                                                        packet0x01));
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x02),
                                           any(CommunicationsListener.class)))
                                                                              .thenReturn(new BusResult<>(false,
                                                                                                        packet0x02));
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x03),
                                           any(CommunicationsListener.class)))
                                                                              .thenReturn(new BusResult<>(false,
@@ -889,18 +889,18 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0x00),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0x01),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0x02),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0x03),
                                              any(CommunicationsListener.class));
 
@@ -934,19 +934,19 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(obdModule0x00);
 
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class), any(CommunicationsListener.class)))
-                                                                                                                      .thenReturn(List.of(packet));
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN), any(CommunicationsListener.class)))
+                                                                                                                      .thenReturn(RequestResult.of(packet));
 
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x0),
                                           any(CommunicationsListener.class)))
                                                                              .thenReturn(new BusResult<>(false, packet));
 
         runTest();
 
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0x00),
                                              any(CommunicationsListener.class));
 
@@ -981,19 +981,19 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(obdModule0x00);
 
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class), any(CommunicationsListener.class)))
-                                                                                                                      .thenReturn(List.of(packet));
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN), any(CommunicationsListener.class)))
+                                                                                                                      .thenReturn(RequestResult.of(packet));
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x00),
                                           any(CommunicationsListener.class)))
                                                                              .thenReturn(new BusResult<>(false, packet));
 
         runTest();
 
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              anyInt(),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              any(CommunicationsListener.class));
 
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, EXPECTED_FAIL_MESSAGE_2_C);

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step07ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step07ControllerTest.java
@@ -28,6 +28,7 @@ import org.etools.j1939_84.modules.VehicleInformationModule;
 import org.etools.j1939_84.utils.AbstractControllerTest;
 import org.etools.j1939tools.CommunicationsListener;
 import org.etools.j1939tools.bus.BusResult;
+import org.etools.j1939tools.bus.RequestResult;
 import org.etools.j1939tools.j1939.J1939;
 import org.etools.j1939tools.j1939.packets.ComponentIdentificationPacket;
 import org.etools.j1939tools.modules.CommunicationsModule;
@@ -140,7 +141,7 @@ public class Part02Step07ControllerTest extends AbstractControllerTest {
         module0.set(ComponentIdentificationPacket.create(0, "make0", "model0", "serialNumber0", "unit0"), 1);
         dataRepository.putObdModule(module0);
         var packet0 = ComponentIdentificationPacket.create(0, "make0", "model0", "serialNumber0", "unit0");
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x00),
                                           any(CommunicationsListener.class))).thenReturn(new BusResult<>(false, packet0));
 
@@ -148,24 +149,24 @@ public class Part02Step07ControllerTest extends AbstractControllerTest {
         module1.set(ComponentIdentificationPacket.create(1, "make1", "model1", "serialNumber1", "unit1"), 1);
         dataRepository.putObdModule(module1);
         var packet1 = ComponentIdentificationPacket.create(1, "make1", "model1", "serialNumber1", "unit1");
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x01),
                                           any(CommunicationsListener.class))).thenReturn(new BusResult<>(false, packet1));
 
         var packet00 = ComponentIdentificationPacket.create(0, "make0", "model0", "serialNumber0", "unit0");
         var packet11 = ComponentIdentificationPacket.create(1, "make1", "model1", "serialNumber1", "unit1");
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
-                                          any(CommunicationsListener.class))).thenReturn(List.of(packet00,
-                                                                                                     packet11));
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
+                                          any(CommunicationsListener.class))).thenReturn(RequestResult.of(packet00,
+                                                                                                               packet11));
         runTest();
 
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0x00),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0x01),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              any(CommunicationsListener.class));
 
         assertEquals("", listener.getMessages());
@@ -179,30 +180,30 @@ public class Part02Step07ControllerTest extends AbstractControllerTest {
         module0.set(ComponentIdentificationPacket.create(0, "make0", "model0", "serialNumber0", "unit0"), 1);
         dataRepository.putObdModule(module0);
         var packet0 = ComponentIdentificationPacket.create(0, "make0", "model0", "serialNumber0", "unit0");
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x00),
                                           any(CommunicationsListener.class))).thenReturn(new BusResult<>(false, packet0));
 
         var module1 = new OBDModuleInformation(1);
         module1.set(ComponentIdentificationPacket.create(1, "make1", "model1", "serialNumber1", "unit1"), 1);
         dataRepository.putObdModule(module1);
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x01),
                                           any(CommunicationsListener.class))).thenReturn(BusResult.empty());
 
         var packet00 = ComponentIdentificationPacket.create(0, "make0", "model0", "serialNumber0", "unit0");
         var packet11 = ComponentIdentificationPacket.create(1, "make1", "model1", "serialNumber1", "unit1");
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
-                                          any(CommunicationsListener.class))).thenReturn(List.of(packet00,
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
+                                          any(CommunicationsListener.class))).thenReturn(RequestResult.of(packet00,
                                                                                                          packet11));
         runTest();
 
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0x00),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0x01),
                                              any(CommunicationsListener.class));
 
@@ -220,7 +221,7 @@ public class Part02Step07ControllerTest extends AbstractControllerTest {
         module0.set(ComponentIdentificationPacket.create(0, "make", "model", "serialNumber", "unit"), 1);
         dataRepository.putObdModule(module0);
         var packet0 = ComponentIdentificationPacket.create(0, "make0", "model0", "serialNumber0", "unit0");
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x00),
                                           any(CommunicationsListener.class))).thenReturn(new BusResult<>(false, packet0));
 
@@ -228,24 +229,24 @@ public class Part02Step07ControllerTest extends AbstractControllerTest {
         module1.set(ComponentIdentificationPacket.create(1, "make1", "model1", "serialNumber1", "unit1"), 1);
         dataRepository.putObdModule(module1);
         var packet1 = ComponentIdentificationPacket.create(1, "make1", "model1", "serialNumber1", "unit1");
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x01),
                                           any(CommunicationsListener.class))).thenReturn(new BusResult<>(false, packet1));
 
         var packet00 = ComponentIdentificationPacket.create(0, "make0", "model0", "serialNumber0", "unit0");
         var packet11 = ComponentIdentificationPacket.create(1, "make1", "model1", "serialNumber1", "unit1");
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
-                                          any(CommunicationsListener.class))).thenReturn(List.of(packet00,
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
+                                          any(CommunicationsListener.class))).thenReturn(RequestResult.of(packet00,
                                                                                                  packet11));
         runTest();
 
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0x00),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0x01),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              any(CommunicationsListener.class));
 
         assertEquals("", listener.getMessages());
@@ -262,7 +263,7 @@ public class Part02Step07ControllerTest extends AbstractControllerTest {
         module0.set(ComponentIdentificationPacket.create(0, "make0", "model0", "serialNumber0", "unit0"), 1);
         dataRepository.putObdModule(module0);
         var packet0 = ComponentIdentificationPacket.create(0, "make0", "model0", "serialNumber0", "unit0");
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x00),
                                           any(CommunicationsListener.class))).thenReturn(new BusResult<>(false, packet0));
 
@@ -270,21 +271,21 @@ public class Part02Step07ControllerTest extends AbstractControllerTest {
         module1.set(ComponentIdentificationPacket.create(1, "make1", "model1", "serialNumber1", "unit1"), 1);
         dataRepository.putObdModule(module1);
         var packet1 = ComponentIdentificationPacket.create(1, "make1", "model1", "serialNumber1", "unit1");
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(1),
                                           any(CommunicationsListener.class))).thenReturn(new BusResult<>(false, packet1));
 
         var packet11 = ComponentIdentificationPacket.create(1, "make1", "model1", "serialNumber1", "unit1");
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
-                                          any(CommunicationsListener.class))).thenReturn(List.of(packet11));
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
+                                          any(CommunicationsListener.class))).thenReturn(RequestResult.of(packet11));
         runTest();
 
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0x00),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0x01),
                                              any(CommunicationsListener.class));
 
@@ -302,7 +303,7 @@ public class Part02Step07ControllerTest extends AbstractControllerTest {
         module0.set(ComponentIdentificationPacket.create(0, "make0", "model0", "serialNumber0", "unit0"), 1);
         dataRepository.putObdModule(module0);
         var packet0 = ComponentIdentificationPacket.create(0, "make0", "model0", "serialNumber0", "unit0");
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x00),
                                           any(CommunicationsListener.class))).thenReturn(new BusResult<>(false, packet0));
 
@@ -310,23 +311,23 @@ public class Part02Step07ControllerTest extends AbstractControllerTest {
         module1.set(ComponentIdentificationPacket.create(1, "make1", "model1", "serialNumber1", "unit1"), 1);
         dataRepository.putObdModule(module1);
         var packet1 = ComponentIdentificationPacket.create(1, "make1", "model1", "serialNumber1", "unit1");
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x01),
                                           any(CommunicationsListener.class))).thenReturn(new BusResult<>(false, packet1));
 
         var packet00 = ComponentIdentificationPacket.create(0, "make0", "model0", "serialNumber0", "unit0");
         var packet11 = ComponentIdentificationPacket.create(1, "make1", "model1", "serialNumber1", "unit1");
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
-                                          any(CommunicationsListener.class))).thenReturn(List.of(packet00, packet11));
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
+                                          any(CommunicationsListener.class))).thenReturn(RequestResult.of(packet00, packet11));
 
         runTest();
 
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0x00),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0x01),
                                              any(CommunicationsListener.class));
 
@@ -344,7 +345,7 @@ public class Part02Step07ControllerTest extends AbstractControllerTest {
         module0.set(ComponentIdentificationPacket.create(0, "make0", "model0", "serialNumber0", "unit0"), 1);
         dataRepository.putObdModule(module0);
         var packet0 = ComponentIdentificationPacket.create(0, "make0", "model0", "serialNumber0", "unit0");
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x00),
                                           any(CommunicationsListener.class))).thenReturn(new BusResult<>(false, packet0));// when(communicationsModule.requestComponentIdentification(any(),
                                                                                                                         // eq(0))).thenReturn(BusResult.of(packet0));
@@ -353,22 +354,22 @@ public class Part02Step07ControllerTest extends AbstractControllerTest {
         module1.set(ComponentIdentificationPacket.create(1, "make1", "model1", "serialNumber1", "unit1"), 1);
         dataRepository.putObdModule(module1);
         var packet1 = ComponentIdentificationPacket.create(1, "make1", "model1", "serialNumber1", "unit1");
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x01),
                                           any(CommunicationsListener.class))).thenReturn(new BusResult<>(false, packet1));
 
         var packet00 = ComponentIdentificationPacket.create(0, "make", "model", "serialNumber", "unit");
         var packet11 = ComponentIdentificationPacket.create(1, "make1", "model1", "serialNumber1", "unit1");
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
-                                          any(CommunicationsListener.class))).thenReturn(List.of(packet00, packet11));
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
+                                          any(CommunicationsListener.class))).thenReturn(RequestResult.of(packet00, packet11));
         runTest();
 
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0x00),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0x01),
                                              any(CommunicationsListener.class));
 
@@ -386,7 +387,7 @@ public class Part02Step07ControllerTest extends AbstractControllerTest {
         module0.set(ComponentIdentificationPacket.create(0, "make0", "model0", "serialNumber0", "unit0"), 1);
         dataRepository.putObdModule(module0);
         var packet0 = ComponentIdentificationPacket.create(0, "make0", "model0", "serialNumber0", "unit0");
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x00),
                                           any(CommunicationsListener.class))).thenReturn(new BusResult<>(false, packet0));
 
@@ -394,22 +395,22 @@ public class Part02Step07ControllerTest extends AbstractControllerTest {
         module1.set(ComponentIdentificationPacket.create(1, "make1", "model1", "serialNumber1", "unit1"), 1);
         dataRepository.putObdModule(module1);
         var packet1 = ComponentIdentificationPacket.create(1, "make1", "model1", "serialNumber1", "unit1");
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
                                           eq(0x01),
                                           any(CommunicationsListener.class))).thenReturn(new BusResult<>(false, packet1));
 
         var packet00 = ComponentIdentificationPacket.create(0, "make0", "model0", "serialNumber0", "unit0");
-        when(communicationsModule.request(eq(ComponentIdentificationPacket.class),
-                                          any(CommunicationsListener.class))).thenReturn(List.of(packet00));
+        when(communicationsModule.request(eq(ComponentIdentificationPacket.PGN),
+                                          any(CommunicationsListener.class))).thenReturn(RequestResult.of(packet00));
 
         runTest();
 
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0x00),
                                              any(CommunicationsListener.class));
-        verify(communicationsModule).request(eq(ComponentIdentificationPacket.class),
+        verify(communicationsModule).request(eq(ComponentIdentificationPacket.PGN),
                                              eq(0x01),
                                              any(CommunicationsListener.class));
 

--- a/src-test/org/etools/j1939tools/modules/CommunicationsModuleTest.java
+++ b/src-test/org/etools/j1939tools/modules/CommunicationsModuleTest.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.etools.j1939tools.CommunicationsListener;
+import org.etools.j1939tools.bus.Bus;
 import org.etools.j1939tools.bus.BusException;
 import org.etools.j1939tools.bus.BusResult;
 import org.etools.j1939tools.bus.Packet;
@@ -430,8 +431,6 @@ public class CommunicationsModuleTest {
     public void testRequestDM11() throws BusException {
         final int pgn = DM11ClearActiveDTCsPacket.PGN;
 
-        // DataRepository.getInstance().putObdModule(new OBDModuleInformation(0));
-
         Packet requestPacket1 = Packet.create(REQUEST_PGN | GLOBAL_ADDR, BUS_ADDR, true, pgn, pgn >> 8, pgn >> 16);
         doReturn(requestPacket1).when(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
 
@@ -469,8 +468,6 @@ public class CommunicationsModuleTest {
     public void testRequestDM11DS() throws BusException {
         final int pgn = DM11ClearActiveDTCsPacket.PGN;
 
-        // DataRepository.getInstance().putObdModule(new OBDModuleInformation(0));
-
         Packet requestPacket1 = Packet.create(REQUEST_PGN, BUS_ADDR, true, pgn, pgn >> 8, pgn >> 16);
         doReturn(requestPacket1).when(j1939).createRequestPacket(pgn, 0);
 
@@ -506,7 +503,6 @@ public class CommunicationsModuleTest {
     @Test
     public void testRequestDM12DestinationSpecific() throws BusException {
         final int pgn = DM12MILOnEmissionDTCPacket.PGN;
-        // DataRepository.getInstance().putObdModule(new OBDModuleInformation(0));
 
         Packet requestPacket = Packet.create(REQUEST_PGN, BUS_ADDR, true, pgn, pgn >> 8, pgn >> 16);
         doReturn(requestPacket).when(j1939).createRequestPacket(pgn, 0);
@@ -543,7 +539,6 @@ public class CommunicationsModuleTest {
     @Test
     public void testRequestDM12DestinationSpecificWithDTCs() throws BusException {
         final int pgn = DM12MILOnEmissionDTCPacket.PGN;
-        // DataRepository.getInstance().putObdModule(new OBDModuleInformation(0));
 
         Packet requestPacket = Packet.create(REQUEST_PGN, BUS_ADDR, true, pgn, pgn >> 8, pgn >> 16);
         doReturn(requestPacket).when(j1939).createRequestPacket(pgn, 0);
@@ -612,7 +607,6 @@ public class CommunicationsModuleTest {
     @Test
     public void testRequestDM12Global() throws BusException {
         final int pgn = DM12MILOnEmissionDTCPacket.PGN;
-        // DataRepository.getInstance().putObdModule(new OBDModuleInformation(0));
 
         DM12MILOnEmissionDTCPacket packet1 = new DM12MILOnEmissionDTCPacket(
                                                                             Packet.create(pgn,
@@ -3453,9 +3447,9 @@ public class CommunicationsModuleTest {
                                                                                                              .read(anyLong(),
                                                                                                                    any());
 
-        List<? extends GenericPacket> actual = instance.requestDM57(listener, moduleAddress);
+        BusResult<? extends GenericPacket> actual = instance.requestDM57(listener, moduleAddress);
 
-        assertEquals(List.of(packet), actual);
+        assertEquals(BusResult.of(packet), actual);
 
         String expected = "";
         expected += "10:15:30.0000 Destination Specific DM57 Request to Instrument Cluster #1 (23)" + NL;

--- a/src/org/etools/j1939_84/controllers/Controller.java
+++ b/src/org/etools/j1939_84/controllers/Controller.java
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import java.util.stream.Collectors;
 import org.etools.j1939_84.J1939_84;
 import org.etools.j1939_84.controllers.ResultsListener.MessageType;
 import org.etools.j1939_84.model.Outcome;
@@ -23,6 +24,7 @@ import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 import org.etools.j1939tools.bus.BusResult;
+import org.etools.j1939tools.bus.RequestResult;
 import org.etools.j1939tools.j1939.J1939;
 import org.etools.j1939tools.j1939.packets.GenericPacket;
 import org.etools.j1939tools.modules.CommunicationsModule;
@@ -112,16 +114,12 @@ public abstract class Controller {
         return getCommunicationsModule().read(clazz, timeout, timeUnit, getListener());
     }
 
-    protected List<? extends GenericPacket> request(int pg) {
+    protected <T extends GenericPacket> RequestResult<T> request(int pg) {
         return getCommunicationsModule().request(pg, getListener());
     }
 
-    protected <T extends GenericPacket> List<T> request(Class<T> clazz) {
-        return getCommunicationsModule().request(clazz, getListener());
-    }
-
-    protected <T extends GenericPacket> BusResult<T> request(Class<T> clazz, int address) {
-        return getCommunicationsModule().request(clazz, address, getListener());
+    protected <T extends GenericPacket> BusResult<T> request(int pg, int address) {
+        return getCommunicationsModule().request(pg, address, getListener());
     }
 
     /**

--- a/src/org/etools/j1939_84/controllers/SectionA5MessageVerifier.java
+++ b/src/org/etools/j1939_84/controllers/SectionA5MessageVerifier.java
@@ -400,8 +400,10 @@ public class SectionA5MessageVerifier {
             return true;
         }
 
-        return communicationsModule.request(EngineHoursPacket.class, address, listener)
-                                   .toPacketStream()
+        return communicationsModule.request(EngineHoursPacket.PGN, address, listener)
+                .toPacketStream()
+                .map(GenericPacket::getPacket)
+                .map(EngineHoursPacket::new)
                                    .filter(p -> {
                                        return p.getEngineHours() < packet.getEngineHours();
                                    })
@@ -420,8 +422,10 @@ public class SectionA5MessageVerifier {
             return true;
         }
 
-        return communicationsModule.request(IdleOperationPacket.class, address, listener)
+        return communicationsModule.request(IdleOperationPacket.PGN, address, listener)
                                    .toPacketStream()
+                .map(GenericPacket::getPacket)
+                .map(IdleOperationPacket::new)
                                    .filter(p -> {
                                        return p.getEngineIdleHours() < packet.getEngineIdleHours();
                                    })

--- a/src/org/etools/j1939_84/controllers/StepController.java
+++ b/src/org/etools/j1939_84/controllers/StepController.java
@@ -155,7 +155,8 @@ public abstract class StepController extends Controller {
 
                 incrementProgress("Requesting " + pgnDef.getLabel() + " (" + pgnDef.getAcronym() + ") from "
                         + moduleName);
-                var response = getCommunicationsModule().request(pgn, address, getListener());
+                var response = getCommunicationsModule().request(pgn, address, getListener()).toPacketStream().collect(
+                        Collectors.toList());
                 packets.addAll(response);
             }
             return packets;

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step05Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step05Controller.java
@@ -63,8 +63,8 @@ public class Part01Step05Controller extends StepController {
     @Override
     protected void run() throws Throwable {
         // 6.1.5.1.a. Global Request (PGN 59904) for PGN 65260 Vehicle ID (SPN 237) VIN.
-        List<VehicleIdentificationPacket> packets = request(VehicleIdentificationPacket.class)
-                                                                                              .stream()
+        List<VehicleIdentificationPacket> packets = request(VehicleIdentificationPacket.PGN)
+                                                                                              .toPacketStream()
                                                                                               .map(p -> new VehicleIdentificationPacket(p.getPacket()))
                                                                                               .collect(Collectors.toList());
 

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step09Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step09Controller.java
@@ -18,6 +18,7 @@ import org.etools.j1939_84.modules.VehicleInformationModule;
 import org.etools.j1939tools.bus.BusResult;
 import org.etools.j1939tools.j1939.Lookup;
 import org.etools.j1939tools.j1939.packets.ComponentIdentificationPacket;
+import org.etools.j1939tools.j1939.packets.GenericPacket;
 import org.etools.j1939tools.j1939.packets.ParsedPacket;
 import org.etools.j1939tools.modules.CommunicationsModule;
 import org.etools.j1939tools.modules.DateTimeModule;
@@ -68,7 +69,7 @@ public class Part01Step09Controller extends StepController {
         // 6.1.9.1.b Display each positive return in the log.
         var dsPackets = getDataRepository().getObdModuleAddresses()
                                            .stream()
-                                           .map(a -> request(ComponentIdentificationPacket.class, a))
+                                           .map(a -> request(ComponentIdentificationPacket.PGN, a))
                                            .map(BusResult::requestResult)
                                            .flatMap(r -> r.getPackets().stream())
                                            .collect(Collectors.toList());
@@ -191,9 +192,7 @@ public class Part01Step09Controller extends StepController {
 
         // 6.1.9.4.a. Global Component ID request (PG 59904) for PG 65259 (SPs 586, 587, and 588).
         // 6.1.9.4.b. Display each positive return in the log.
-        var globalPackets = request(ComponentIdentificationPacket.class)
-                                                                        .stream()
-                                                                        .collect(Collectors.toList());
+        var globalPackets = request(ComponentIdentificationPacket.PGN).getPackets();
 
         // 6.1.9.5 Fail Criteria2 for function 0:
         var globalFunction0Packet = globalPackets.stream()

--- a/src/org/etools/j1939_84/controllers/part02/Part02Step07Controller.java
+++ b/src/org/etools/j1939_84/controllers/part02/Part02Step07Controller.java
@@ -139,8 +139,8 @@ public class Part02Step07Controller extends StepController {
     }
 
     private List<ComponentIdentificationPacket> requestComponentIds() {
-        return request(ComponentIdentificationPacket.class)
-                                                           .stream()
+        return request(ComponentIdentificationPacket.PGN)
+                                                           .toPacketStream()
                                                            .map(p -> new ComponentIdentificationPacket(p.getPacket()))
                                                            .collect(Collectors.toList());
     }
@@ -157,6 +157,6 @@ public class Part02Step07Controller extends StepController {
     }
 
     private BusResult<ComponentIdentificationPacket> requestComponentId(int address) {
-        return (BusResult<ComponentIdentificationPacket>) request(ComponentIdentificationPacket.class, address);
+        return request(ComponentIdentificationPacket.PGN, address);
     }
 }

--- a/src/org/etools/j1939_84/ui/VehicleInformationPresenter.java
+++ b/src/org/etools/j1939_84/ui/VehicleInformationPresenter.java
@@ -199,10 +199,9 @@ public class VehicleInformationPresenter implements VehicleInformationContract.P
             view.setEmissionUnits(obdModules.size());
 
             obdModules.stream().peek(address -> {
-                emissionUnitsFound.addAll(communicationsModule.request(ComponentIdentificationPacket.class,
+                emissionUnitsFound.addAll(communicationsModule.request(ComponentIdentificationPacket.PGN,
                                                                        address,
-                                                                       NOOP)
-                                                              .toPacketStream()
+                                                                       NOOP).toPacketStream()
                                                               .map(p -> new ComponentIdentificationPacket(p.getPacket()))
                                                               .collect(Collectors.toList()));
             });

--- a/src/org/etools/j1939tools/j1939/J1939DaRepository.java
+++ b/src/org/etools/j1939tools/j1939/J1939DaRepository.java
@@ -167,7 +167,10 @@ public class J1939DaRepository {
                                                                   PgnDefinition pgnDef = null;
                                                                   // we don't care about the PGN that have no
                                                                   // SPNs.
-                                                                  if (spnDef != null && !pgnIdStr.isBlank()) {
+                                                                  if ( !pgnIdStr.isBlank()) {
+                                                                      if(spnDef == null){
+                                                                          spnDef = new SpnDefinition(-1, "Unknown", 0, 0, -1);
+                                                                      }
                                                                       int transmissionRate = parseTransmissionRate(line[3]);
                                                                       String label = shortenLabel(line[1]).trim();
                                                                       pgnDef = new PgnDefinition(parseInt(pgnIdStr),

--- a/src/org/etools/j1939tools/modules/CommunicationsModule.java
+++ b/src/org/etools/j1939tools/modules/CommunicationsModule.java
@@ -89,11 +89,11 @@ public class CommunicationsModule extends FunctionalModule {
     }
 
     public RequestResult<DM2PreviouslyActiveDTC> requestDM2(CommunicationsListener listener) {
-        return requestDMPackets("DM2", DM2PreviouslyActiveDTC.class, GLOBAL_ADDR, listener);
+        return requestDMPackets(getPgDefinition(DM2PreviouslyActiveDTC.PGN).getAcronym(), DM2PreviouslyActiveDTC.class, GLOBAL_ADDR, listener);
     }
 
     public BusResult<DM2PreviouslyActiveDTC> requestDM2(CommunicationsListener listener, int address) {
-        return requestDMPackets("DM2", DM2PreviouslyActiveDTC.class, address, listener).busResult();
+        return requestDMPackets(getPgDefinition(DM2PreviouslyActiveDTC.PGN).getAcronym(), DM2PreviouslyActiveDTC.class, address, listener).busResult();
     }
 
     public List<AcknowledgmentPacket> requestDM3(CommunicationsListener listener) {
@@ -108,19 +108,19 @@ public class CommunicationsModule extends FunctionalModule {
     }
 
     public RequestResult<DM5DiagnosticReadinessPacket> requestDM5(CommunicationsListener listener) {
-        return requestDMPackets("DM5", DM5DiagnosticReadinessPacket.class, GLOBAL_ADDR, listener);
+        return requestDMPackets(getPgDefinition(DM5DiagnosticReadinessPacket.PGN).getAcronym(), DM5DiagnosticReadinessPacket.class, GLOBAL_ADDR, listener);
     }
 
     public BusResult<DM5DiagnosticReadinessPacket> requestDM5(CommunicationsListener listener, int address) {
-        return requestDMPackets("DM5", DM5DiagnosticReadinessPacket.class, address, listener).busResult();
+        return requestDMPackets(getPgDefinition(DM5DiagnosticReadinessPacket.PGN).getAcronym(), DM5DiagnosticReadinessPacket.class, address, listener).busResult();
     }
 
     public RequestResult<DM6PendingEmissionDTCPacket> requestDM6(CommunicationsListener listener) {
-        return requestDMPackets("DM6", DM6PendingEmissionDTCPacket.class, GLOBAL_ADDR, listener);
+        return requestDMPackets(getPgDefinition(DM6PendingEmissionDTCPacket.PGN).getAcronym(), DM6PendingEmissionDTCPacket.class, GLOBAL_ADDR, listener);
     }
 
     public RequestResult<DM6PendingEmissionDTCPacket> requestDM6(CommunicationsListener listener, int address) {
-        return requestDMPackets("DM6", DM6PendingEmissionDTCPacket.class, address, listener);
+        return requestDMPackets(getPgDefinition(DM6PendingEmissionDTCPacket.PGN).getAcronym(), DM6PendingEmissionDTCPacket.class, address, listener);
     }
 
     /*
@@ -132,40 +132,42 @@ public class CommunicationsModule extends FunctionalModule {
     }
 
     public List<AcknowledgmentPacket> requestDM11(CommunicationsListener listener, int address) {
-        String title = "Destination Specific DM11 Request to " + getAddressName(address);
+        String title = "Destination Specific " + getPgDefinition(DM11ClearActiveDTCsPacket.PGN).getAcronym() + " Request to " + getAddressName(address);
         return getJ1939().requestForAcks(listener, title, DM11ClearActiveDTCsPacket.PGN, address);
     }
 
     public List<AcknowledgmentPacket> requestDM11(CommunicationsListener listener, long timeOut, TimeUnit timeUnit) {
+
+        String title = "Global " + J1939DaRepository.getInstance().findPgnDefinition(DM11ClearActiveDTCsPacket.PGN).getAcronym() + " Request";
         return getJ1939().requestForAcks(listener,
-                                         "Global DM11 Request",
+                                         title,
                                          DM11ClearActiveDTCsPacket.PGN,
                                          timeOut,
                                          timeUnit);
     }
 
     public RequestResult<DM12MILOnEmissionDTCPacket> requestDM12(CommunicationsListener listener) {
-        return requestDMPackets("DM12", DM12MILOnEmissionDTCPacket.class, GLOBAL_ADDR, listener);
+        return requestDMPackets(getPgDefinition(DM12MILOnEmissionDTCPacket.PGN).getAcronym(), DM12MILOnEmissionDTCPacket.class, GLOBAL_ADDR, listener);
     }
 
     public BusResult<DM12MILOnEmissionDTCPacket> requestDM12(CommunicationsListener listener, int address) {
-        return requestDMPackets("DM12", DM12MILOnEmissionDTCPacket.class, address, listener).busResult();
+        return requestDMPackets(getPgDefinition(DM12MILOnEmissionDTCPacket.PGN).getAcronym(), DM12MILOnEmissionDTCPacket.class, address, listener).busResult();
     }
 
     public RequestResult<DM20MonitorPerformanceRatioPacket> requestDM20(CommunicationsListener listener) {
-        return requestDMPackets("DM20", DM20MonitorPerformanceRatioPacket.class, GLOBAL_ADDR, listener);
+        return requestDMPackets(getPgDefinition(DM20MonitorPerformanceRatioPacket.PGN).getAcronym(), DM20MonitorPerformanceRatioPacket.class, GLOBAL_ADDR, listener);
     }
 
     public BusResult<DM20MonitorPerformanceRatioPacket> requestDM20(CommunicationsListener listener, int address) {
-        return requestDMPackets("DM20", DM20MonitorPerformanceRatioPacket.class, address, listener).busResult();
+        return requestDMPackets(getPgDefinition(DM20MonitorPerformanceRatioPacket.PGN).getAcronym(), DM20MonitorPerformanceRatioPacket.class, address, listener).busResult();
     }
 
     public RequestResult<DM21DiagnosticReadinessPacket> requestDM21(CommunicationsListener listener) {
-        return requestDMPackets("DM21", DM21DiagnosticReadinessPacket.class, GLOBAL_ADDR, listener);
+        return requestDMPackets(getPgDefinition(DM21DiagnosticReadinessPacket.PGN).getAcronym(), DM21DiagnosticReadinessPacket.class, GLOBAL_ADDR, listener);
     }
 
     public BusResult<DM21DiagnosticReadinessPacket> requestDM21(CommunicationsListener listener, int address) {
-        return requestDMPackets("DM21", DM21DiagnosticReadinessPacket.class, address, listener).busResult();
+        return requestDMPackets(getPgDefinition(DM21DiagnosticReadinessPacket.PGN).getAcronym(), DM21DiagnosticReadinessPacket.class, address, listener).busResult();
     }
 
     public BusResult<DM22IndividualClearPacket> requestDM22(CommunicationsListener listener,
@@ -173,74 +175,72 @@ public class CommunicationsModule extends FunctionalModule {
                                                             ControlByte controlByte,
                                                             int spn,
                                                             int fmi) {
-        String title = "DM22";
         var requestPacket = DM22IndividualClearPacket.createRequest(getJ1939().getBus().getAddress(),
                                                                     address,
                                                                     controlByte,
                                                                     spn,
                                                                     fmi);
-        return getJ1939().requestDS(title, DM22IndividualClearPacket.PGN, requestPacket, listener);
+        return getJ1939().requestDS(getPgDefinition(DM22IndividualClearPacket.PGN).getAcronym(), DM22IndividualClearPacket.PGN, requestPacket, listener);
     }
 
     public RequestResult<DM22IndividualClearPacket> requestDM22(CommunicationsListener listener,
                                                                 ControlByte controlByte,
                                                                 int spn,
                                                                 int fmi) {
-        String title = "DM22";
         var requestPacket = DM22IndividualClearPacket.createRequest(getJ1939().getBus().getAddress(),
                                                                     GLOBAL_ADDR,
                                                                     controlByte,
                                                                     spn,
                                                                     fmi);
-        return getJ1939().requestGlobal(title, DM22IndividualClearPacket.PGN, requestPacket, listener);
+        return getJ1939().requestGlobal(getPgDefinition(DM22IndividualClearPacket.PGN).getAcronym(), DM22IndividualClearPacket.PGN, requestPacket, listener);
     }
 
     public RequestResult<DM23PreviouslyMILOnEmissionDTCPacket> requestDM23(CommunicationsListener listener) {
-        return requestDMPackets("DM23", DM23PreviouslyMILOnEmissionDTCPacket.class, GLOBAL_ADDR, listener);
+        return requestDMPackets(getPgDefinition(DM23PreviouslyMILOnEmissionDTCPacket.PGN).getAcronym(), DM23PreviouslyMILOnEmissionDTCPacket.class, GLOBAL_ADDR, listener);
     }
 
     public BusResult<DM23PreviouslyMILOnEmissionDTCPacket> requestDM23(CommunicationsListener listener, int address) {
-        return requestDMPackets("DM23", DM23PreviouslyMILOnEmissionDTCPacket.class, address, listener).busResult();
+        return requestDMPackets(getPgDefinition(DM23PreviouslyMILOnEmissionDTCPacket.PGN).getAcronym(), DM23PreviouslyMILOnEmissionDTCPacket.class, address, listener).busResult();
     }
 
     public BusResult<DM24SPNSupportPacket> requestDM24(CommunicationsListener listener, int obdModuleAddress) {
-        return requestDMPackets("DM24", DM24SPNSupportPacket.class, obdModuleAddress, listener).busResult();
+        return requestDMPackets(getPgDefinition(DM24SPNSupportPacket.PGN).getAcronym(), DM24SPNSupportPacket.class, obdModuleAddress, listener).busResult();
     }
 
     public BusResult<DM25ExpandedFreezeFrame> requestDM25(CommunicationsListener listener, int address) {
-        return requestDMPackets("DM25", DM25ExpandedFreezeFrame.class, address, listener).busResult();
+        return requestDMPackets(getPgDefinition(DM25ExpandedFreezeFrame.PGN).getAcronym(), DM25ExpandedFreezeFrame.class, address, listener).busResult();
     }
 
     public RequestResult<DM26TripDiagnosticReadinessPacket> requestDM26(CommunicationsListener listener) {
-        return requestDMPackets("DM26", DM26TripDiagnosticReadinessPacket.class, GLOBAL_ADDR, listener);
+        return requestDMPackets(getPgDefinition(DM26TripDiagnosticReadinessPacket.PGN).getAcronym(), DM26TripDiagnosticReadinessPacket.class, GLOBAL_ADDR, listener);
     }
 
     public RequestResult<DM26TripDiagnosticReadinessPacket> requestDM26(CommunicationsListener listener, int address) {
-        return requestDMPackets("DM26", DM26TripDiagnosticReadinessPacket.class, address, listener);
+        return requestDMPackets(getPgDefinition(DM26TripDiagnosticReadinessPacket.PGN).getAcronym(), DM26TripDiagnosticReadinessPacket.class, address, listener);
     }
 
     public RequestResult<DM27AllPendingDTCsPacket> requestDM27(CommunicationsListener listener) {
-        return requestDMPackets("DM27", DM27AllPendingDTCsPacket.class, GLOBAL_ADDR, listener);
+        return requestDMPackets(getPgDefinition(DM27AllPendingDTCsPacket.PGN).getAcronym(), DM27AllPendingDTCsPacket.class, GLOBAL_ADDR, listener);
     }
 
     public BusResult<DM27AllPendingDTCsPacket> requestDM27(CommunicationsListener listener, int address) {
-        return requestDMPackets("DM27", DM27AllPendingDTCsPacket.class, address, listener).busResult();
+        return requestDMPackets(getPgDefinition(DM27AllPendingDTCsPacket.PGN).getAcronym(), DM27AllPendingDTCsPacket.class, address, listener).busResult();
     }
 
     public RequestResult<DM28PermanentEmissionDTCPacket> requestDM28(CommunicationsListener listener) {
-        return requestDMPackets("DM28", DM28PermanentEmissionDTCPacket.class, GLOBAL_ADDR, listener);
+        return requestDMPackets(getPgDefinition(DM28PermanentEmissionDTCPacket.PGN).getAcronym(), DM28PermanentEmissionDTCPacket.class, GLOBAL_ADDR, listener);
     }
 
     public BusResult<DM28PermanentEmissionDTCPacket> requestDM28(CommunicationsListener listener, int address) {
-        return requestDMPackets("DM28", DM28PermanentEmissionDTCPacket.class, address, listener).busResult();
+        return requestDMPackets(getPgDefinition(DM28PermanentEmissionDTCPacket.PGN).getAcronym(), DM28PermanentEmissionDTCPacket.class, address, listener).busResult();
     }
 
     public RequestResult<DM29DtcCounts> requestDM29(CommunicationsListener listener) {
-        return requestDMPackets("DM29", DM29DtcCounts.class, GLOBAL_ADDR, listener);
+        return requestDMPackets(getPgDefinition(DM29DtcCounts.PGN).getAcronym(), DM29DtcCounts.class, GLOBAL_ADDR, listener);
     }
 
     public BusResult<DM29DtcCounts> requestDM29(CommunicationsListener listener, int address) {
-        return requestDMPackets("DM29", DM29DtcCounts.class, address, listener).busResult();
+        return requestDMPackets(getPgDefinition(DM29DtcCounts.PGN).getAcronym(), DM29DtcCounts.class, address, listener).busResult();
     }
 
     public List<DM30ScaledTestResultsPacket> requestTestResults(CommunicationsListener listener,
@@ -260,39 +260,39 @@ public class CommunicationsModule extends FunctionalModule {
     }
 
     public RequestResult<DM31DtcToLampAssociation> requestDM31(CommunicationsListener listener) {
-        return requestDMPackets("DM31", DM31DtcToLampAssociation.class, GLOBAL_ADDR, listener);
+        return requestDMPackets(getPgDefinition(DM31DtcToLampAssociation.PGN).getAcronym(), DM31DtcToLampAssociation.class, GLOBAL_ADDR, listener);
     }
 
     public RequestResult<DM31DtcToLampAssociation> requestDM31(CommunicationsListener listener, int address) {
-        return requestDMPackets("DM31", DM31DtcToLampAssociation.class, address, listener);
+        return requestDMPackets(getPgDefinition(DM31DtcToLampAssociation.PGN).getAcronym(), DM31DtcToLampAssociation.class, address, listener);
     }
 
     public RequestResult<DM33EmissionIncreasingAECDActiveTime> requestDM33(CommunicationsListener listener) {
-        return requestDMPackets("DM33", DM33EmissionIncreasingAECDActiveTime.class, GLOBAL_ADDR, listener);
+        return requestDMPackets(getPgDefinition(DM33EmissionIncreasingAECDActiveTime.PGN).getAcronym(), DM33EmissionIncreasingAECDActiveTime.class, GLOBAL_ADDR, listener);
     }
 
     public RequestResult<DM33EmissionIncreasingAECDActiveTime> requestDM33(CommunicationsListener listener,
                                                                            int address) {
-        return requestDMPackets("DM33", DM33EmissionIncreasingAECDActiveTime.class, address, listener);
+        return requestDMPackets(getPgDefinition(DM33EmissionIncreasingAECDActiveTime.PGN).getAcronym(), DM33EmissionIncreasingAECDActiveTime.class, address, listener);
     }
 
     public RequestResult<DM34NTEStatus> requestDM34(CommunicationsListener listener) {
-        return requestDMPackets("DM34", DM34NTEStatus.class, GLOBAL_ADDR, listener);
+        return requestDMPackets(getPgDefinition(DM34NTEStatus.PGN).getAcronym(), DM34NTEStatus.class, GLOBAL_ADDR, listener);
     }
 
     public RequestResult<DM34NTEStatus> requestDM34(CommunicationsListener listener, int address) {
-        return requestDMPackets("DM34", DM34NTEStatus.class, address, listener);
+        return requestDMPackets(getPgDefinition(DM34NTEStatus.PGN).getAcronym(), DM34NTEStatus.class, address, listener);
     }
 
     public List<DM56EngineFamilyPacket> requestDM56(CommunicationsListener listener, int address) {
-        return requestDMPackets("DM56", DM56EngineFamilyPacket.class, address, listener).getPackets();
+        return requestDMPackets(getPgDefinition(DM56EngineFamilyPacket.PGN).getAcronym(), DM56EngineFamilyPacket.class, address, listener).getPackets();
     }
 
     public List<DM56EngineFamilyPacket> requestDM56(CommunicationsListener listener) {
-        return requestDMPackets("DM56", DM56EngineFamilyPacket.class, GLOBAL_ADDR, listener).getPackets();
+        return requestDMPackets(getPgDefinition(DM56EngineFamilyPacket.PGN).getAcronym(), DM56EngineFamilyPacket.class, GLOBAL_ADDR, listener).getPackets();
     }
 
-    public List<? extends GenericPacket> requestDM57(CommunicationsListener listener,
+    public <T extends GenericPacket> BusResult<T> requestDM57(CommunicationsListener listener,
                                                      int address) {
         return request(64710, address, listener);
     }
@@ -374,7 +374,7 @@ public class CommunicationsModule extends FunctionalModule {
      */
     @SuppressWarnings("unchecked")
     public <T extends GenericPacket> List<T> request(Class<T> clazz, CommunicationsListener listener) {
-        return (List<T>) request(getPg(clazz, listener), listener).stream()
+        return (List<T>) request(getPg(clazz, listener), listener).getPackets().stream()
                                                                   .sorted(Comparator.comparing((o) -> o.getPacket()
                                                                                                        .getTimestamp()))
                                                                   .collect(Collectors.toList());
@@ -388,30 +388,10 @@ public class CommunicationsModule extends FunctionalModule {
      * @param listener
      *                     the {@link CommunicationsListener} that will be given the report
      */
-    public List<? extends GenericPacket> request(int pg, CommunicationsListener listener) {
+    public <T extends GenericPacket> RequestResult<T>  request(int pg, CommunicationsListener listener) {
         Packet requestPacket = getJ1939().createRequestPacket(pg, GLOBAL_ADDR);
-        return getJ1939().requestGlobal(getPgDefinition(pg).getLabel(), pg, requestPacket, listener)
-                         .getPackets()
-                         .stream()
-                         .sorted(Comparator.comparing((p) -> p.getPacket().getTimestamp()))
-                         .collect(Collectors.toList());
+        return getJ1939().requestGlobal(getPgDefinition(pg).getLabel(), pg, requestPacket, listener);
 
-    }
-
-    /**
-     * Request for List<? extends GenericPacket> and return the latest message
-     *
-     * @param clazz
-     *                     The class name of the packet to read from the bus
-     * @param listener
-     *                     the {@link CommunicationsListener} that will be given the report
-     */
-    public <T extends GenericPacket> BusResult<T> request(Class<T> clazz,
-                                                          int address,
-                                                          CommunicationsListener listener) {
-        int pg = getPg(clazz, listener);
-        Packet requestPacket = getJ1939().createRequestPacket(pg, address);
-        return getJ1939().requestDS(clazz.getName(), pg, requestPacket, listener);
     }
 
     /**
@@ -422,12 +402,10 @@ public class CommunicationsModule extends FunctionalModule {
      * @param listener
      *                     the {@link CommunicationsListener} that will be given the report
      */
-    public List<? extends GenericPacket> request(int pg, int address, CommunicationsListener listener) {
+    public <T extends GenericPacket> BusResult<T> request(int pg, int address, CommunicationsListener listener) {
         Packet requestPacket = getJ1939().createRequestPacket(pg, address);
 
-        return getJ1939().requestDS(getPgDefinition(pg).getAcronym(), pg, requestPacket, listener)
-                         .toPacketStream()
-                         .collect(Collectors.toList());
+        return getJ1939().requestDS(getPgDefinition(pg).getAcronym(), pg, requestPacket, listener);
     }
 
     /**
@@ -443,10 +421,10 @@ public class CommunicationsModule extends FunctionalModule {
     }
 
     public RequestResult<DM19CalibrationInformationPacket> requestDM19(CommunicationsListener listener) {
-        return requestDMPackets("DM19", DM19CalibrationInformationPacket.class, GLOBAL_ADDR, listener);
+        return requestDMPackets(getPgDefinition(DM19CalibrationInformationPacket.PGN).getAcronym(), DM19CalibrationInformationPacket.class, GLOBAL_ADDR, listener);
     }
 
     public BusResult<DM19CalibrationInformationPacket> requestDM19(CommunicationsListener listener, int address) {
-        return requestDMPackets("DM19", DM19CalibrationInformationPacket.class, address, listener).busResult();
+        return requestDMPackets(getPgDefinition(DM19CalibrationInformationPacket.PGN).getAcronym(), DM19CalibrationInformationPacket.class, address, listener).busResult();
     }
 }


### PR DESCRIPTION
Update the CommunicationsModule.java to remove deprecated code and update logging to use PGN definitions instead of class name.